### PR TITLE
fixed export import missing variant decks

### DIFF
--- a/js/features/deck-import.js
+++ b/js/features/deck-import.js
@@ -94,11 +94,37 @@ export function handleJsonImport(e) {
           bracket: deck.bracket,
           color: deck.color,
           stripePosition: deck.stripePosition,
+          splitGroupId: deck.splitGroupId || null,
           cards: deckCards,
           createdAt: deck.createdAt,
           updatedAt: deck.updatedAt
         });
         newPrism.decks.push(newDeck);
+      }
+
+      const deckIds = new Set(newPrism.decks.map(d => d.id));
+      newPrism.splitGroups = (prismData.splitGroups || [])
+        .map(group => {
+          const childDeckIds = (group.childDeckIds || []).filter(id => deckIds.has(id));
+          if (childDeckIds.length === 0) return null;
+          return {
+            id: group.id,
+            name: group.name,
+            sideAPosition: group.sideAPosition,
+            sideAColor: group.sideAColor,
+            splitStyle: group.splitStyle || 'stripes',
+            childDeckIds,
+            createdAt: group.createdAt,
+            updatedAt: group.updatedAt
+          };
+        })
+        .filter(Boolean);
+
+      const validGroupIds = new Set(newPrism.splitGroups.map(g => g.id));
+      for (const deck of newPrism.decks) {
+        if (deck.splitGroupId && !validGroupIds.has(deck.splitGroupId)) {
+          deck.splitGroupId = null;
+        }
       }
 
       savePrism(newPrism);
@@ -108,8 +134,10 @@ export function handleJsonImport(e) {
       initColorSwatches();
       renderAll();
 
-      logToSupabase('info', 'json_import', { name: newPrism.name, deckCount: newPrism.decks.length });
-      showSuccess(`Imported "${newPrism.name}" with ${newPrism.decks.length} decks.`);
+      const groupCount = newPrism.splitGroups.length;
+      logToSupabase('info', 'json_import', { name: newPrism.name, deckCount: newPrism.decks.length, splitGroupCount: groupCount });
+      const suffix = groupCount > 0 ? ` (${groupCount} split group${groupCount === 1 ? '' : 's'})` : '';
+      showSuccess(`Imported "${newPrism.name}" with ${newPrism.decks.length} decks${suffix}.`);
     } catch (err) {
       console.error('JSON import error:', err);
       logToSupabase('error', 'json_import_failed', { error: err.message });

--- a/js/features/deck-import.js
+++ b/js/features/deck-import.js
@@ -105,7 +105,10 @@ export function handleJsonImport(e) {
       const deckIds = new Set(newPrism.decks.map(d => d.id));
       newPrism.splitGroups = (prismData.splitGroups || [])
         .map(group => {
-          const childDeckIds = (group.childDeckIds || []).filter(id => deckIds.has(id));
+          const explicit = (group.childDeckIds || []).filter(id => deckIds.has(id));
+          const childDeckIds = explicit.length > 0
+            ? explicit
+            : newPrism.decks.filter(d => d.splitGroupId === group.id).map(d => d.id);
           if (childDeckIds.length === 0) return null;
           return {
             id: group.id,

--- a/js/modules/export.js
+++ b/js/modules/export.js
@@ -123,7 +123,9 @@ export function exportToJSON(prism) {
         sideAColor: group.sideAColor,
         sideAColorName: getColorName(group.sideAColor),
         splitStyle: group.splitStyle || 'stripes',
-        childDeckIds: group.childDeckIds
+        childDeckIds: group.childDeckIds,
+        createdAt: group.createdAt,
+        updatedAt: group.updatedAt
       })),
       decks: prism.decks.map(deck => ({
         id: deck.id,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deck import now preserves split-group organization, removes empty groups, and sanitizes invalid split-group references.

* **New Features**
  * Export now includes creation and update timestamps for split groups.
  * Import success notifications and logs now show a human-readable imported split-group count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->