### PR TITLE
fix(auth): replace boolean init guard with shared Promise  Boolean fl…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ PRISM helps Magic: The Gathering Commander players who share cards across multip
 - **UI Components:** [Web Awesome 3.5.0](https://www.webawesome.com/) loaded via CDN kit
 - **Styling:** `css/custom.css` + Web Awesome design tokens (`--wa-color-*`, `--wa-space-*`)
 - **Persistence:** localStorage-first (`prism_data` key), optional Supabase sync when authenticated with merge-before-write conflict handling
-- **Auth:** Supabase Auth (email/password), idempotent init pattern (`authInitialized` flag)
+- **Auth:** Supabase Auth (email/password), idempotent init via cached `authInitPromise` so concurrent callers share one awaitable sync
 - **APIs:** Scryfall (card data, no key needed), Moxfield & Archidekt (deck import via edge proxies)
 - **Hosting:** Netlify — `publish = "."` (root), edge functions in Deno/TypeScript
 - **Dev server:** `http-server` on port 3456, configured in `.claude/launch.json`
@@ -153,7 +153,7 @@ Preferences: { colorScheme, defaultColors, stripeStartCorner ('top-right'|'top-l
 
 ### Auth Double-Init
 
-`initAuth()` is idempotent via `authInitialized` flag. Both `layout.js` and page scripts can call it safely. `setupAuthListeners()` is separate and handles UI updates.
+`initAuth()` caches its async body as `authInitPromise`. Both `layout.js` and page scripts can call it safely and will await the same Promise — including the initial `syncWithSupabase()` — so cloud merge always completes before any caller proceeds. `setupAuthListeners()` is separate and handles UI updates.
 
 ### Circular Dependencies
 

--- a/js/modules/auth.js
+++ b/js/modules/auth.js
@@ -6,7 +6,7 @@ import { syncWithSupabase } from './storage.js';
 let currentUser = null;
 let authListeners = [];
 let wasLoggedOut = true; // Track if user was logged out before sign-in
-let authInitialized = false; // Guard against duplicate initialization
+let authInitPromise = null; // Cached init promise — all callers await the same one
 
 // Subscribe to auth state changes
 export function onAuthChange(callback) {
@@ -24,50 +24,59 @@ function notifyAuthChange(user) {
 }
 
 // Initialize auth state
-export async function initAuth() {
-  // Idempotent — safe to call from both layout.js and page-specific scripts
-  if (authInitialized) return currentUser;
-  authInitialized = true;
-
-  if (!isConfigured()) {
-    console.warn('Supabase not configured - auth disabled');
-    return null;
-  }
-
-  const supabase = getSupabase();
-  if (!supabase) return null;
-
-  // Get initial session
-  const { data: { session } } = await supabase.auth.getSession();
-  if (session?.user) {
-    wasLoggedOut = false; // User already logged in, don't reload on SIGNED_IN
-    notifyAuthChange(session.user);
-    // Sync on initial load if already logged in
-    await syncWithSupabase();
-  }
-
-  // Listen for auth changes
-  supabase.auth.onAuthStateChange(async (event, session) => {
-    console.log('Auth state changed:', event);
-    notifyAuthChange(session?.user || null);
-
-    // Track logout state
-    if (event === 'SIGNED_OUT') {
-      wasLoggedOut = true;
-      logToSupabase('info', 'user_signed_out');
+// Returns a shared Promise so concurrent callers (layout.js and page scripts)
+// all await the same async init — including the awaited syncWithSupabase.
+// Previously a boolean guard was flipped synchronously before the async work,
+// causing the second caller to short-circuit before cloud sync completed and
+// read stale localStorage.
+export function initAuth() {
+  if (authInitPromise) return authInitPromise;
+  authInitPromise = (async () => {
+    if (!isConfigured()) {
+      console.warn('Supabase not configured - auth disabled');
+      return null;
     }
 
-    // Sync with Supabase when user freshly logs in (not on session recovery)
-    if (event === 'SIGNED_IN' && session?.user && wasLoggedOut) {
-      wasLoggedOut = false;
-      logToSupabase('info', 'user_signed_in', { email: session.user.email });
+    const supabase = getSupabase();
+    if (!supabase) return null;
+
+    // Get initial session
+    const { data: { session } } = await supabase.auth.getSession();
+    if (session?.user) {
+      wasLoggedOut = false; // User already logged in, don't reload on SIGNED_IN
+      notifyAuthChange(session.user);
+      // Sync on initial load if already logged in
       await syncWithSupabase();
-      // Reload page to show synced data
-      window.location.reload();
     }
-  });
 
-  return currentUser;
+    // Listen for auth changes
+    supabase.auth.onAuthStateChange(async (event, session) => {
+      console.log('Auth state changed:', event);
+      notifyAuthChange(session?.user || null);
+
+      // Track logout state
+      if (event === 'SIGNED_OUT') {
+        wasLoggedOut = true;
+        logToSupabase('info', 'user_signed_out');
+      }
+
+      // Sync with Supabase when user freshly logs in (not on session recovery)
+      if (event === 'SIGNED_IN' && session?.user && wasLoggedOut) {
+        wasLoggedOut = false;
+        logToSupabase('info', 'user_signed_in', { email: session.user.email });
+        await syncWithSupabase();
+        // Reload page to show synced data
+        window.location.reload();
+      }
+    });
+
+    return currentUser;
+  })().catch(err => {
+    // Reset cache so a transient failure does not permanently wedge init
+    authInitPromise = null;
+    throw err;
+  });
+  return authInitPromise;
 }
 
 // Get current user

--- a/js/modules/storage.js
+++ b/js/modules/storage.js
@@ -817,6 +817,7 @@ async function syncPrismToSupabase(prismId) {
 // ============================================
 
 let syncTimeout = null;
+let queuedPrismId = null;
 
 // Flush a pending debounced sync on page unload so in-flight edits don't get
 // stranded in localStorage. Listen to both beforeunload and pagehide — iOS
@@ -827,10 +828,9 @@ if (typeof window !== 'undefined') {
     if (!syncTimeout) return;
     clearTimeout(syncTimeout);
     syncTimeout = null;
-    if (!shouldSyncToSupabase()) return;
-    const storage = loadStorage();
-    const prismId = storage.currentPrismId;
-    if (!prismId) return;
+    const prismId = queuedPrismId;
+    queuedPrismId = null;
+    if (!prismId || !shouldSyncToSupabase()) return;
     syncPrismToSupabase(prismId).catch(() => {});
   };
   window.addEventListener('beforeunload', flushPendingSync);
@@ -876,7 +876,10 @@ export function savePrism(prism) {
   // Sync to Supabase if logged in (debounced to avoid race conditions on rapid saves)
   if (shouldSyncToSupabase()) {
     clearTimeout(syncTimeout);
+    queuedPrismId = prism.id;
     syncTimeout = setTimeout(() => {
+      syncTimeout = null;
+      queuedPrismId = null;
       syncPrismToSupabase(prism.id).catch(err => {
         console.error('Background sync failed:', err);
       });

--- a/js/modules/storage.js
+++ b/js/modules/storage.js
@@ -818,6 +818,25 @@ async function syncPrismToSupabase(prismId) {
 
 let syncTimeout = null;
 
+// Flush a pending debounced sync on page unload so in-flight edits don't get
+// stranded in localStorage. Listen to both beforeunload and pagehide — iOS
+// Safari fires only pagehide. Fire-and-forget is acceptable because modern
+// browsers keep in-flight fetch() POSTs alive through unload briefly.
+if (typeof window !== 'undefined') {
+  const flushPendingSync = () => {
+    if (!syncTimeout) return;
+    clearTimeout(syncTimeout);
+    syncTimeout = null;
+    if (!shouldSyncToSupabase()) return;
+    const storage = loadStorage();
+    const prismId = storage.currentPrismId;
+    if (!prismId) return;
+    syncPrismToSupabase(prismId).catch(() => {});
+  };
+  window.addEventListener('beforeunload', flushPendingSync);
+  window.addEventListener('pagehide', flushPendingSync);
+}
+
 // ============================================
 // PUBLIC API (unchanged interface)
 // ============================================


### PR DESCRIPTION
…ag was flipped synchronously before async work completed,  so second caller (layout.js or page script) short-circuited before  syncWithSupabase() finished and read stale localStorage on page load.  Caching the init Promise lets all concurrent callers await the same  cloud merge before proceeding. Transient failures reset the cache so  init is retryable.  Also flush pending debounced sync on beforeunload/pagehide so edits  made just before navigation aren't stranded in localStorage.  Closes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated authentication docs to reflect the revised initialization workflow.

* **Refactor**
  * Concurrent authentication startup requests now share a single in-flight initialization to avoid redundant work.

* **New Features**
  * Storage now queues pending item IDs and flushes pending synchronizations automatically on page unload/close.

* **Bug Fixes**
  * Initialization failures no longer permanently block future startup attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->