### PR TITLE
fix(auth): wait for Supabase CDN and fix dialog/nav before WA upgrade…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ PRISM helps Magic: The Gathering Commander players who share cards across multip
 - **UI Components:** [Web Awesome 3.5.0](https://www.webawesome.com/) loaded via CDN kit
 - **Styling:** `css/custom.css` + Web Awesome design tokens (`--wa-color-*`, `--wa-space-*`)
 - **Persistence:** localStorage-first (`prism_data` key), optional Supabase sync when authenticated with merge-before-write conflict handling
-- **Auth:** Supabase Auth (email/password), idempotent init via cached `authInitPromise` so concurrent callers share one awaitable sync
+- **Auth:** Supabase Auth (email/password), idempotent init via cached `authInitPromise` so concurrent callers share one awaitable sync; `initAuth()` waits for the Supabase CDN script `load` event before proceeding so slow CDN loads don't break auth
 - **APIs:** Scryfall (card data, no key needed), Moxfield & Archidekt (deck import via edge proxies)
 - **Hosting:** Netlify — `publish = "."` (root), edge functions in Deno/TypeScript
 - **Dev server:** `http-server` on port 3456, configured in `.claude/launch.json`
@@ -150,10 +150,12 @@ Preferences: { colorScheme, defaultColors, stripeStartCorner ('top-right'|'top-l
 - Web Awesome inputs store values in shadow DOM. Use `element.shadowRoot?.querySelector('input')?.value` as fallback when `.value` is empty.
 - `<wa-page mobile-breakpoint="768">` controls layout. Desktop shows sidebar nav; mobile shows hamburger.
 - FOUC prevention: all HTML pages include `<style>wa-page:not(:defined){visibility:hidden}</style>`.
+- **Dialog open/close:** Use `dialog.setAttribute('open', '')` / `dialog.removeAttribute('open')` — NOT `dialog.open = true/false`. The property setter only works after WA upgrades the element; the attribute is observed via `attributeChangedCallback` and works before upgrade too.
+- **`<wa-button href>` navigation:** WA button href-navigation only works after the element is upgraded. Add a `click` listener fallback (`window.location.href = ...`) for any nav `<wa-button href>` that must work immediately on page load.
 
 ### Auth Double-Init
 
-`initAuth()` caches its async body as `authInitPromise`. Both `layout.js` and page scripts can call it safely and will await the same Promise — including the initial `syncWithSupabase()` — so cloud merge always completes before any caller proceeds. `setupAuthListeners()` is separate and handles UI updates.
+`initAuth()` caches its async body as `authInitPromise`. Both `layout.js` and page scripts can call it safely and will await the same Promise — including the initial `syncWithSupabase()` — so cloud merge always completes before any caller proceeds. `setupAuthListeners()` is separate and handles UI updates. It calls `updateAuthUI(currentUser)` at the end so the nav reflects auth state immediately, since `INITIAL_SESSION` from Supabase can fire before listeners are registered when the session is already in memory.
 
 ### Circular Dependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ prism/
 │       ├── moxfield-edge.ts   POST proxy → api2.moxfield.com
 │       └── archidekt-edge.ts  POST proxy → archidekt.com/api
 ├── netlify.toml            Deployment config (publish ".", edge function routes)
-├── supabase-schema.sql     Database schema (prisms, decks, deck_cards, app_logs)
+├── supabase-schema.sql     Database schema (prisms, decks, deck_cards, app_logs, replace_deck_cards RPC)
 └── package.json            Minimal (no deps, node >=18)
 ```
 
@@ -156,6 +156,12 @@ Preferences: { colorScheme, defaultColors, stripeStartCorner ('top-right'|'top-l
 ### Auth Double-Init
 
 `initAuth()` caches its async body as `authInitPromise`. Both `layout.js` and page scripts can call it safely and will await the same Promise — including the initial `syncWithSupabase()` — so cloud merge always completes before any caller proceeds. `setupAuthListeners()` is separate and handles UI updates. It calls `updateAuthUI(currentUser)` at the end so the nav reflects auth state immediately, since `INITIAL_SESSION` from Supabase can fire before listeners are registered when the session is already in memory.
+
+If the Supabase CDN hasn't loaded when `initAuth()` runs, it awaits the script's `load` event (5s timeout fallback). If `getSupabase()` still returns null after the wait (CDN error/timeout), `authInitPromise` is reset to `null` so callers can retry — without this reset, a resolved-null promise would permanently block re-initialization.
+
+### Supabase Card Sync
+
+`savePrismToSupabase()` replaces all cards for each deck via the `replace_deck_cards(p_deck_id, p_cards, p_created_at)` RPC defined in `supabase-schema.sql`. The RPC runs DELETE + INSERT in a single transaction, preventing a partial-failure window where a deck could be left with no cards. Pass an empty array to clear cards safely. Uses `SECURITY INVOKER` so existing RLS on `deck_cards` applies — users cannot replace cards in decks they don't own. Run `supabase-schema.sql` in the Supabase SQL editor after any schema changes.
 
 ### Circular Dependencies
 

--- a/js/layout.js
+++ b/js/layout.js
@@ -247,6 +247,15 @@ function injectNav(activePage) {
 
   // Insert nav as first child of wa-page (before header and main)
   waPage.insertBefore(nav, waPage.firstChild);
+
+  // Fallback: <wa-button href> only navigates after WA upgrades the element.
+  // Add a click listener so navigation works even before WA loads.
+  const profileNavBtn = nav.querySelector('wa-button[href="profile.html"]');
+  if (profileNavBtn) {
+    profileNavBtn.addEventListener('click', () => {
+      window.location.href = 'profile.html';
+    });
+  }
 }
 
 // ============================================================

--- a/js/modules/auth.js
+++ b/js/modules/auth.js
@@ -37,12 +37,21 @@ export function initAuth() {
       return null;
     }
 
-    const supabase = getSupabase();
-    if (!supabase) {
-      // CDN not loaded yet — don't cache so callers can retry
-      authInitPromise = null;
-      return null;
+    // Wait for Supabase CDN if the script hasn't executed yet
+    if (!window.supabase) {
+      const sbScript = document.querySelector('script[src*="supabase"]');
+      if (sbScript) {
+        await new Promise(resolve => {
+          if (window.supabase) { resolve(); return; }
+          sbScript.addEventListener('load', resolve, { once: true });
+          sbScript.addEventListener('error', resolve, { once: true });
+          setTimeout(resolve, 5000);
+        });
+      }
     }
+
+    const supabase = getSupabase();
+    if (!supabase) return null;
 
     // Get initial session
     const { data: { session } } = await supabase.auth.getSession();
@@ -237,7 +246,7 @@ export function setupAuthListeners() {
       const dialog = document.getElementById('auth-dialog');
       if (dialog) {
         showAuthView('login');
-        dialog.open = true;
+        dialog.setAttribute('open', '');
       }
     });
   }
@@ -296,7 +305,7 @@ export function setupAuthListeners() {
 
         // Close dialog on successful login
         const dialog = document.getElementById('auth-dialog');
-        if (dialog) dialog.open = false;
+        if (dialog) dialog.removeAttribute('open');
       } catch (err) {
         console.error('Login error:', err);
         if (errorEl) {

--- a/js/modules/auth.js
+++ b/js/modules/auth.js
@@ -51,7 +51,10 @@ export function initAuth() {
     }
 
     const supabase = getSupabase();
-    if (!supabase) return null;
+    if (!supabase) {
+      authInitPromise = null;
+      return null;
+    }
 
     // Get initial session
     const { data: { session } } = await supabase.auth.getSession();

--- a/js/modules/storage.js
+++ b/js/modules/storage.js
@@ -493,37 +493,25 @@ async function savePrismToSupabase(prism) {
       }
     }
 
-    // Replace all cards per deck in two calls (delete + bulk insert) instead of
-    // one call per card, which was O(cards) serial round-trips and took minutes.
+    // Replace all cards per deck atomically via RPC (single transaction:
+    // DELETE + INSERT). Accepts empty array to clear cards safely.
     for (const deck of prism.decks || []) {
-      const { error: deleteCardsError } = await supabase
-        .from('deck_cards')
-        .delete()
-        .eq('deck_id', deck.id);
-
-      if (deleteCardsError) {
-        console.error('Error deleting deck cards before re-insert:', deleteCardsError);
-        return false;
-      }
-
+      const deckUpdatedAt = deck.updatedAt || prismUpdatedAt;
       const localCards = deck.cards || [];
-      if (localCards.length > 0) {
-        const deckUpdatedAt = deck.updatedAt || prismUpdatedAt;
-        const { error: insertCardsError } = await supabase
-          .from('deck_cards')
-          .insert(localCards.map(card => ({
-            deck_id: deck.id,
-            card_name: card.name,
-            quantity: card.quantity || 1,
-            is_commander: card.isCommander || false,
-            is_basic_land: card.isBasicLand || false,
-            created_at: deckUpdatedAt
-          })));
+      const { error: replaceCardsError } = await supabase.rpc('replace_deck_cards', {
+        p_deck_id: deck.id,
+        p_cards: localCards.map(card => ({
+          card_name: card.name,
+          quantity: card.quantity || 1,
+          is_commander: card.isCommander || false,
+          is_basic_land: card.isBasicLand || false
+        })),
+        p_created_at: deckUpdatedAt
+      });
 
-        if (insertCardsError) {
-          console.error('Error bulk inserting deck cards:', insertCardsError);
-          return false;
-        }
+      if (replaceCardsError) {
+        console.error('Error replacing deck cards:', replaceCardsError);
+        return false;
       }
     }
 

--- a/js/modules/storage.js
+++ b/js/modules/storage.js
@@ -493,74 +493,35 @@ async function savePrismToSupabase(prism) {
       }
     }
 
-    // Sync cards in place for each deck so a later failure doesn't wipe the whole prism.
+    // Replace all cards per deck in two calls (delete + bulk insert) instead of
+    // one call per card, which was O(cards) serial round-trips and took minutes.
     for (const deck of prism.decks || []) {
-      const deckUpdatedAt = deck.updatedAt || prismUpdatedAt;
-      const { data: existingCardRows, error: existingCardsError } = await supabase
+      const { error: deleteCardsError } = await supabase
         .from('deck_cards')
-        .select('id, card_name, created_at')
+        .delete()
         .eq('deck_id', deck.id);
 
-      if (existingCardsError) {
-        console.error('Error loading existing deck cards before sync:', existingCardsError);
+      if (deleteCardsError) {
+        console.error('Error deleting deck cards before re-insert:', deleteCardsError);
         return false;
       }
 
-      const existingCardsByName = new Map(
-        (existingCardRows || []).map(card => [card.card_name.toLowerCase(), card])
-      );
       const localCards = deck.cards || [];
-      const localCardNameSet = new Set(localCards.map(card => card.name.toLowerCase()));
-
-      for (const card of localCards) {
-        const existingCard = existingCardsByName.get(card.name.toLowerCase());
-
-        if (existingCard) {
-          const { error: updateCardError } = await supabase
-            .from('deck_cards')
-            .update({
-              card_name: card.name,
-              quantity: card.quantity || 1,
-              is_commander: card.isCommander || false,
-              is_basic_land: card.isBasicLand || false
-            })
-            .eq('id', existingCard.id);
-
-          if (updateCardError) {
-            console.error('Error updating deck card in Supabase:', updateCardError);
-            return false;
-          }
-        } else {
-          const { error: insertCardError } = await supabase
-            .from('deck_cards')
-            .insert({
-              deck_id: deck.id,
-              card_name: card.name,
-              quantity: card.quantity || 1,
-              is_commander: card.isCommander || false,
-              is_basic_land: card.isBasicLand || false,
-              created_at: deckUpdatedAt
-            });
-
-          if (insertCardError) {
-            console.error('Error inserting deck card in Supabase:', insertCardError);
-            return false;
-          }
-        }
-      }
-
-      const staleCardIds = (existingCardRows || [])
-        .filter(card => !localCardNameSet.has(card.card_name.toLowerCase()))
-        .map(card => card.id);
-
-      if (staleCardIds.length > 0) {
-        const { error: deleteCardsError } = await supabase
+      if (localCards.length > 0) {
+        const deckUpdatedAt = deck.updatedAt || prismUpdatedAt;
+        const { error: insertCardsError } = await supabase
           .from('deck_cards')
-          .delete()
-          .in('id', staleCardIds);
+          .insert(localCards.map(card => ({
+            deck_id: deck.id,
+            card_name: card.name,
+            quantity: card.quantity || 1,
+            is_commander: card.isCommander || false,
+            is_basic_land: card.isBasicLand || false,
+            created_at: deckUpdatedAt
+          })));
 
-        if (deleteCardsError) {
-          console.error('Error deleting removed deck cards from Supabase:', deleteCardsError);
+        if (insertCardsError) {
+          console.error('Error bulk inserting deck cards:', insertCardsError);
           return false;
         }
       }

--- a/js/profile.js
+++ b/js/profile.js
@@ -69,7 +69,7 @@ function setupEventListeners() {
   if (elements.btnProfileLogin) {
     elements.btnProfileLogin.addEventListener('click', () => {
       if (elements.authDialog) {
-        elements.authDialog.open = true;
+        elements.authDialog.setAttribute('open', '');
       }
     });
   }

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -153,6 +153,39 @@ CREATE POLICY "Users can create logs"
   WITH CHECK (user_id IS NULL OR auth.uid() = user_id);
 
 -- ============================================
+-- RPC: Atomically replace all cards for a deck
+-- Accepts an empty array to clear cards safely.
+-- ============================================
+CREATE OR REPLACE FUNCTION replace_deck_cards(
+  p_deck_id UUID,
+  p_cards JSONB,
+  p_created_at TIMESTAMPTZ DEFAULT now()
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+BEGIN
+  DELETE FROM deck_cards WHERE deck_id = p_deck_id;
+
+  INSERT INTO deck_cards (deck_id, card_name, quantity, is_commander, is_basic_land, created_at)
+  SELECT
+    p_deck_id,
+    (c->>'card_name')::TEXT,
+    COALESCE((c->>'quantity')::INTEGER, 1),
+    COALESCE((c->>'is_commander')::BOOLEAN, false),
+    COALESCE((c->>'is_basic_land')::BOOLEAN, false),
+    p_created_at
+  FROM jsonb_array_elements(p_cards) AS c
+  WHERE jsonb_array_length(p_cards) > 0;
+END;
+$$;
+
+-- SECURITY INVOKER: function runs as the calling user so existing RLS policies
+-- on deck_cards apply — users can only replace cards in their own decks.
+GRANT EXECUTE ON FUNCTION replace_deck_cards(UUID, JSONB, TIMESTAMPTZ) TO authenticated;
+
+-- ============================================
 -- HELPER FUNCTION: Update timestamp
 -- ============================================
 CREATE OR REPLACE FUNCTION update_updated_at()


### PR DESCRIPTION
…  - initAuth() now awaits script load event instead of relying on a    hardcoded 100ms delay; prevents onAuthStateChange going unregistered    when CDN is slow, which was silently swallowing SIGNED_IN and    blocking sync+reload after fresh login  - dialog.open = true/false → setAttribute/removeAttribute so the    auth dialog opens before <wa-dialog> is upgraded by WA  - profile.html nav button gets a click listener fallback so navigation    works before <wa-button href> is upgraded by WA  Closes #68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Auth now reliably waits for the Supabase CDN before initializing and can retry if unavailable.
  * Auth dialog open/close uses the HTML open attribute so login state updates the UI immediately.
  * Profile button navigation works immediately on page load.
  * Deck sync now replaces decks atomically to ensure consistent server state.

* **Documentation**
  * Expanded guidance on auth sequencing, dialog control, Web Awesome behavior, and deck sync behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->