### PR TITLE
fix(sync): prefer local edits over cloud when ahead of baseline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,15 @@ If the Supabase CDN hasn't loaded when `initAuth()` runs, it awaits the script's
 
 `savePrismToSupabase()` replaces all cards for each deck via the `replace_deck_cards(p_deck_id, p_cards, p_created_at)` RPC defined in `supabase-schema.sql`. The RPC runs DELETE + INSERT in a single transaction, preventing a partial-failure window where a deck could be left with no cards. Pass an empty array to clear cards safely. Uses `SECURITY INVOKER` so existing RLS on `deck_cards` applies — users cannot replace cards in decks they don't own. Run `supabase-schema.sql` in the Supabase SQL editor after any schema changes.
 
+**No `updated_at` triggers on `prisms` or `decks`.** The client always supplies `updated_at` on upsert. A server-side trigger that overwrites it with `now()` (server clock) causes clock-skew bugs: `cloud.updated_at` ends up ahead of `local.updatedAt`, so `mergeEntityCollection` in `syncPrismToSupabase` silently picks the stale cloud deck and reverts user edits on the next page load. The schema includes an idempotent `BEGIN/COMMIT` migration block to drop those triggers on existing deployments.
+
+### Merge Conflict Resolution
+
+`mergeEntityCollection` handles three cases per entity ID:
+- **Both local and cloud present:** if `local.updatedAt > baseline.updatedAt` for that entity, local wins (user edited since last sync — guards against server-clock-ahead skew). Otherwise, `pickNewerEntity` compares timestamps.
+- **Local only:** kept if `local.updatedAt > baseline.updatedAt`, otherwise treated as deleted on another device.
+- **Cloud only:** kept unless locally deleted after the cloud's `updatedAt`.
+
 ### Circular Dependencies
 
 Feature modules have circular imports. This is safe because:

--- a/js/modules/storage.js
+++ b/js/modules/storage.js
@@ -199,7 +199,17 @@ function mergeEntityCollection({
     const cloudItem = cloudMap.get(id);
 
     if (localItem && cloudItem) {
-      merged.push(pickNewerEntity(localItem, cloudItem, localFallback, cloudFallback));
+      const baselineUpdatedAt = baselineUpdatedAts[id];
+      const localUpdatedAt = getEntityUpdatedAt(localItem, localFallback);
+      // Local was edited since last known-good sync → prefer local.
+      // Guards against server-clock-ahead skew where the server trigger stamps
+      // updated_at = now() (server time), making cloud.updatedAt > local.updatedAt
+      // even though local has newer user changes.
+      if (baselineUpdatedAt && getTimestampMs(localUpdatedAt) > getTimestampMs(baselineUpdatedAt)) {
+        merged.push(localItem);
+      } else {
+        merged.push(pickNewerEntity(localItem, cloudItem, localFallback, cloudFallback));
+      }
       continue;
     }
 

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -185,8 +185,16 @@ $$;
 -- on deck_cards apply — users can only replace cards in their own decks.
 GRANT EXECUTE ON FUNCTION replace_deck_cards(UUID, JSONB, TIMESTAMPTZ) TO authenticated;
 
--- NOTE: No updated_at triggers on prisms or decks.
--- The client always supplies updated_at on upsert; a server-side trigger that
--- overwrites it with now() causes clock-skew bugs where cloud.updated_at
--- (server time) beats local.updated_at (client time), silently reverting
--- user edits during the merge-before-write in syncPrismToSupabase.
+-- ============================================
+-- MIGRATION: Remove server-side updated_at triggers
+-- ============================================
+-- The client always supplies updated_at on upsert. A trigger that overwrites
+-- it with now() (server time) causes clock-skew bugs: cloud.updated_at ends up
+-- ahead of local.updated_at, so merge-before-write silently picks the stale
+-- cloud deck and reverts user edits on next page load.
+-- Safe to re-run (IF EXISTS). Wrap in transaction so partial failure rolls back.
+BEGIN;
+  DROP TRIGGER IF EXISTS update_decks_updated_at ON decks;
+  DROP TRIGGER IF EXISTS update_prisms_updated_at ON prisms;
+  DROP FUNCTION IF EXISTS update_updated_at();
+COMMIT;

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -185,22 +185,8 @@ $$;
 -- on deck_cards apply — users can only replace cards in their own decks.
 GRANT EXECUTE ON FUNCTION replace_deck_cards(UUID, JSONB, TIMESTAMPTZ) TO authenticated;
 
--- ============================================
--- HELPER FUNCTION: Update timestamp
--- ============================================
-CREATE OR REPLACE FUNCTION update_updated_at()
-RETURNS TRIGGER AS $$
-BEGIN
-  NEW.updated_at = now();
-  RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
--- Apply to tables with updated_at
-CREATE TRIGGER update_prisms_updated_at
-  BEFORE UPDATE ON prisms
-  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
-
-CREATE TRIGGER update_decks_updated_at
-  BEFORE UPDATE ON decks
-  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+-- NOTE: No updated_at triggers on prisms or decks.
+-- The client always supplies updated_at on upsert; a server-side trigger that
+-- overwrites it with now() causes clock-skew bugs where cloud.updated_at
+-- (server time) beats local.updated_at (client time), silently reverting
+-- user edits during the merge-before-write in syncPrismToSupabase.


### PR DESCRIPTION
The updated_at trigger on the decks table stamps server time on every UPDATE, overriding the client-supplied timestamp. If the server clock is ahead of the client, cloud.updatedAt > local.updatedAt even after a fresh local edit, so merge-before-write in syncPrismToSupabase silently picks the stale cloud deck and writes it back to localStorage. User edits appear saved (in-memory state is fine) but revert on refresh.

- Remove trigger definitions from schema (requires manual DROP in Supabase SQL editor — see migration note below)
- Harden mergeEntityCollection: when both local and cloud have an entity and local.updatedAt > baseline, prefer local unconditionally, bypassing the clock comparison entirely

Migration: run in Supabase SQL editor on existing deployments:
  DROP TRIGGER IF EXISTS update_decks_updated_at ON decks;
  DROP TRIGGER IF EXISTS update_prisms_updated_at ON prisms;
  DROP FUNCTION IF EXISTS update_updated_at();

Closes #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sync conflict handling so local edits are more reliably preserved and not overwritten by cloud versions.

* **Chores**
  * Adjusted timestamp management so upserts and syncs use client-provided update timestamps for consistent behavior.

* **Documentation**
  * Added guidance on merge conflict rules and the new timestamp/upsert expectations for synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->