### PR TITLE
fix(sync): use last-write-wins for markedCards to prevent un-marks fr…

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,15 @@
+import js from "@eslint/js";
+import globals from "globals";
+
+export default [
+  js.configs.recommended,
+  {
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "module",
+      globals: {
+        ...globals.browser,
+      },
+    },
+  },
+];

--- a/js/features/deck-list.js
+++ b/js/features/deck-list.js
@@ -51,6 +51,7 @@ export function unmarkCardsWithNewStripes(beforeCounts) {
   const afterCounts = getStripeCountMap();
   let unmarkedCount = 0;
 
+  const prevLength = state.currentPrism.markedCards.length;
   state.currentPrism.markedCards = state.currentPrism.markedCards.filter(
     (cardKey) => {
       const cardName = cardKey.includes("|") ? cardKey.split("|")[0] : cardKey;
@@ -65,6 +66,10 @@ export function unmarkCardsWithNewStripes(beforeCounts) {
     },
   );
 
+  if (state.currentPrism.markedCards.length < prevLength) {
+    state.currentPrism.markedCardsUpdatedAt = new Date().toISOString();
+  }
+
   return unmarkedCount;
 }
 
@@ -75,6 +80,7 @@ export function unmarkSharedCards(newCardNames) {
   const cardMap = new Map(processed.map((c) => [c.name.toLowerCase(), c]));
 
   let unmarkedCount = 0;
+  const prevCount = state.currentPrism.markedCards.length;
 
   state.currentPrism.markedCards = state.currentPrism.markedCards.filter(
     (cardKey) => {
@@ -92,6 +98,10 @@ export function unmarkSharedCards(newCardNames) {
       return true;
     },
   );
+
+  if (state.currentPrism.markedCards.length < prevCount) {
+    state.currentPrism.markedCardsUpdatedAt = new Date().toISOString();
+  }
 
   return unmarkedCount;
 }
@@ -144,7 +154,9 @@ export function handleMarkToggle(event) {
     row.classList.remove("marked-row");
   }
 
-  state.currentPrism.updatedAt = new Date().toISOString();
+  const now = new Date().toISOString();
+  state.currentPrism.updatedAt = now;
+  state.currentPrism.markedCardsUpdatedAt = now;
   savePrism(state.currentPrism);
 
   console.log(

--- a/js/modules/processor.js
+++ b/js/modules/processor.js
@@ -124,6 +124,7 @@ export function createPrism(name = "") {
 		decks: [],
 		splitGroups: [], // Split group definitions for deck variants
 		markedCards: [], // Track which cards have been physically marked
+		markedCardsUpdatedAt: now,
 		removedCards: [], // Track cards removed from decks that need marks removed
 		createdAt: now,
 		updatedAt: now,

--- a/js/modules/storage.js
+++ b/js/modules/storage.js
@@ -310,6 +310,7 @@ function buildPrismFromRow(prism) {
     createdAt: prism.created_at,
     updatedAt: prism.updated_at,
     markedCards: prism.marked_cards || [],
+    markedCardsUpdatedAt: prism.marked_cards_updated_at || null,
     removedCards: prism.removed_cards || [],
     splitGroups: (prism.split_groups || []).map(group => ({
       ...group,
@@ -371,12 +372,20 @@ function mergePrismVersions(localPrism, cloudPrism, prismBaseline) {
     mergedDecks
   );
 
+  const localMCTime = getTimestampMs(localPrism.markedCardsUpdatedAt);
+  const cloudMCTime = getTimestampMs(cloudPrism.markedCardsUpdatedAt);
+
   return {
     ...basePrism,
     markedCards: mergeMarkedCards(
       localPrism.markedCards || [],
-      cloudPrism.markedCards || []
+      localPrism.markedCardsUpdatedAt,
+      cloudPrism.markedCards || [],
+      cloudPrism.markedCardsUpdatedAt
     ),
+    markedCardsUpdatedAt: localMCTime >= cloudMCTime
+      ? localPrism.markedCardsUpdatedAt
+      : cloudPrism.markedCardsUpdatedAt,
     removedCards: mergeRemovedCards(
       localPrism.removedCards || [],
       cloudPrism.removedCards || []
@@ -394,6 +403,7 @@ const PRISM_SELECT = `
   name,
   split_groups,
   marked_cards,
+  marked_cards_updated_at,
   removed_cards,
   created_at,
   updated_at,
@@ -450,6 +460,7 @@ async function savePrismToSupabase(prism) {
         name: prism.name,
         split_groups: prism.splitGroups || [],
         marked_cards: prism.markedCards || [],
+        marked_cards_updated_at: prism.markedCardsUpdatedAt || null,
         removed_cards: prism.removedCards || [],
         created_at: prism.createdAt || prismUpdatedAt,
         updated_at: prismUpdatedAt
@@ -638,12 +649,20 @@ export async function loadPrismsFromSupabase() {
 }
 
 /**
- * Merge markedCards arrays via set-union (deduplicated).
- * If either device says a card is marked, keep it marked.
+ * Merge markedCards using last-write-wins on markedCardsUpdatedAt.
+ * Union semantics cannot represent intentional un-marks (e.g. when a new deck
+ * is added and shared cards are cleared so they can be re-marked on new sleeves).
+ * The side with the newer timestamp is authoritative for the whole array.
  */
-function mergeMarkedCards(localArr, cloudArr) {
-  const set = new Set([...localArr, ...cloudArr]);
-  return [...set];
+function mergeMarkedCards(localArr, localUpdatedAt, cloudArr, cloudUpdatedAt) {
+  const localMs = getTimestampMs(localUpdatedAt);
+  const cloudMs = getTimestampMs(cloudUpdatedAt);
+  // When neither side has a timestamp (legacy data), fall back to union so we
+  // don't silently lose marks on first sync after the upgrade.
+  if (!localMs && !cloudMs) {
+    return [...new Set([...localArr, ...cloudArr])];
+  }
+  return localMs >= cloudMs ? [...localArr] : [...cloudArr];
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -2,7 +2,16 @@
   "name": "prism",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "engines": {
     "node": ">=18.0.0"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.0.0",
+    "eslint": "^9.0.0",
+    "globals": "^15.0.0"
+  },
+  "scripts": {
+    "lint": "eslint js/"
   }
 }

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -186,6 +186,18 @@ $$;
 GRANT EXECUTE ON FUNCTION replace_deck_cards(UUID, JSONB, TIMESTAMPTZ) TO authenticated;
 
 -- ============================================
+-- MIGRATION: Add marked_cards_updated_at column
+-- ============================================
+-- Tracks when markedCards was last modified so merge-before-write can use
+-- last-write-wins instead of set-union. Union semantics cannot represent
+-- intentional un-marks (e.g. new deck added → shared cards cleared for re-marking).
+-- Safe to re-run (IF NOT EXISTS).
+BEGIN;
+  ALTER TABLE prisms
+    ADD COLUMN IF NOT EXISTS marked_cards_updated_at TIMESTAMPTZ DEFAULT NULL;
+COMMIT;
+
+-- ============================================
 -- MIGRATION: Remove server-side updated_at triggers
 -- ============================================
 -- The client always supplies updated_at on upsert. A trigger that overwrites


### PR DESCRIPTION
…om being restored on next sync

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced marked card synchronization across devices with improved conflict resolution. Marked card changes now apply a last-write-wins strategy when updates occur simultaneously from multiple devices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/codwats/prism/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->