### PR TITLE
fix(sync): prevent phantom prisms, fix markedCards tombstoning, add sync status UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ prism/
 │   │   ├── notifications.js  showError, showSuccess, showToast
 │   │   └── utils.js        escapeHtml, getLogicalDeckCount
 │   ├── features/           Build page feature modules
-│   │   ├── init.js         getElements, init(), renderAll(), renderPrismHeader
+│   │   ├── init.js         getElements, init(), renderAll(), renderPrismHeader, setupSyncStatus
 │   │   ├── events.js       setupEventListeners, card preview handlers
 │   │   ├── deck-form.js    Add deck form, color swatches, validation
 │   │   ├── deck-import.js  Moxfield/Archidekt URL import, file upload, JSON import
@@ -93,15 +93,19 @@ Feature modules have circular imports (e.g., `deck-form ↔ deck-list`, `deck-li
 
 ### Storage
 
-localStorage key: `prism_data`. Structure: `{ version, currentPrismId, prisms: { [id]: prismData }, preferences, syncState }`. `syncState` stores per-prism sync baselines plus local deletion tombstones so multi-device merges can distinguish local edits from local deletes. Version migrations supported. Supabase sync happens optionally on auth state changes and on debounced saves while authenticated. `getPreferences()` merges with defaults so new preference keys auto-populate for existing users.
+localStorage key: `prism_data`. Structure: `{ version, currentPrismId, prisms: { [id]: prismData }, preferences, syncState }`. `syncState` stores per-prism sync baselines plus local deletion tombstones and un-mark tombstones so multi-device merges can distinguish local edits from local deletes and intentional un-marks. Version migrations supported. Supabase sync happens optionally on auth state changes and on debounced saves while authenticated. `getPreferences()` merges with defaults so new preference keys auto-populate for existing users.
 
 Sync behavior is merge-first, not whole-PRISM last-write-wins:
 
 - On login/session restore, local and cloud PRISMs are merged per prism, per deck, and per split group.
-- `markedCards` still merge by union and `removedCards` merge by `(cardName, deckId)` with latest `removedAt`.
+- `markedCards` merge by union minus any keys with an `unmarkedCards` tombstone newer than the last sync baseline — this ensures intentional un-marks (manual checkbox or auto-unmark when a new deck shares a card) are not reverted by the cloud copy.
+- `removedCards` merge by `(cardName, deckId)` with latest `removedAt`.
 - Background saves fetch the latest cloud copy, merge it with local using the stored baseline, then write the merged result back to Supabase.
 - Deck and split-group `updatedAt` timestamps are important for conflict resolution and should be preserved on mutation.
 - Split-group child ordering should be preserved from `group.childDeckIds` during merge; only orphaned child IDs should be dropped, with deck-derived order used as a fallback when the stored ordering is missing.
+- Auto-created empty PRISMs (no decks, no cards, no prior baseline) are **not** uploaded to Supabase during the login sync — they exist only as a pre-login UI placeholder and are discarded when real cloud data is available.
+- `syncWithSupabase` tracks which prisms have genuine local changes (`needsCloudWrite` set) and only writes those. Cloud-only prisms (fresh device load) have their baseline recorded without re-uploading, preventing redundant `replace_deck_cards` calls.
+- `savePrismToSupabase` continues past per-deck RPC failures so one failing deck does not leave all subsequent decks without cards. It returns `false` when any deck fails so the baseline is not recorded and the sync retries.
 
 ### PRISM Data Model
 
@@ -119,7 +123,7 @@ Preferences: { colorScheme, defaultColors, stripeStartCorner ('top-right'|'top-l
 - **Stripe starting corner** — global preference controlling which card corner stripes originate from. Affects card preview, not stored data.
 - **markedCards** tracks which cards the user has physically marked (checkbox state)
 - **removedCards** tracks cards removed from decks that still need physical marks cleared
-- **syncState** is local-only metadata used for Supabase merge reconciliation; it is not part of the PRISM domain model
+- **syncState** is local-only metadata used for Supabase merge reconciliation; it is not part of the PRISM domain model. Baseline shape per prism: `{ updatedAt, deckUpdatedAts, splitGroupUpdatedAts, deletedDecks, deletedSplitGroups, unmarkedCards: { [cardKey]: isoTimestamp } }`
 
 ### Card Processing
 
@@ -163,6 +167,8 @@ If the Supabase CDN hasn't loaded when `initAuth()` runs, it awaits the script's
 
 `savePrismToSupabase()` replaces all cards for each deck via the `replace_deck_cards(p_deck_id, p_cards, p_created_at)` RPC defined in `supabase-schema.sql`. The RPC runs DELETE + INSERT in a single transaction, preventing a partial-failure window where a deck could be left with no cards. Pass an empty array to clear cards safely. Uses `SECURITY INVOKER` so existing RLS on `deck_cards` applies — users cannot replace cards in decks they don't own. Run `supabase-schema.sql` in the Supabase SQL editor after any schema changes.
 
+The deck-card loop uses **continue-on-error**: a failing RPC for one deck is logged but does not abort the loop. All decks are attempted. If any deck failed, `savePrismToSupabase` returns `false` so `recordPrismBaseline` is not called and the next debounced save retries.
+
 **No `updated_at` triggers on `prisms` or `decks`.** The client always supplies `updated_at` on upsert. A server-side trigger that overwrites it with `now()` (server clock) causes clock-skew bugs: `cloud.updated_at` ends up ahead of `local.updatedAt`, so `mergeEntityCollection` in `syncPrismToSupabase` silently picks the stale cloud deck and reverts user edits on the next page load. The schema includes an idempotent `BEGIN/COMMIT` migration block to drop those triggers on existing deployments.
 
 ### Merge Conflict Resolution
@@ -171,6 +177,8 @@ If the Supabase CDN hasn't loaded when `initAuth()` runs, it awaits the script's
 - **Both local and cloud present:** if `local.updatedAt > baseline.updatedAt` for that entity, local wins (user edited since last sync — guards against server-clock-ahead skew). Otherwise, `pickNewerEntity` compares timestamps.
 - **Local only:** kept if `local.updatedAt > baseline.updatedAt`, otherwise treated as deleted on another device.
 - **Cloud only:** kept unless locally deleted after the cloud's `updatedAt`.
+
+**markedCards tombstones:** `mergeMarkedCards(local, cloud, unmarkedTombstones, baselineUpdatedAt)` starts from the union of local+cloud marks, then removes any key whose tombstone timestamp is strictly greater than `baselineUpdatedAt`. `recordPrismBaseline` prunes tombstones with `unmarkedAt <= newBaseline.updatedAt` after each successful sync (they've been baked in). `recordUnmarkedCards(prismId, cardKeys)` writes the tombstones; call it immediately before `savePrism()` whenever cards are removed from `markedCards` — in `handleMarkToggle` (un-check), `unmarkSharedCards` (new deck shares a card), and `unmarkCardsWithNewStripes` (deck edit adds stripes). `unmarkSharedCards` and `unmarkCardsWithNewStripes` now return the array of removed keys (was: count); callers compute `.length` for the success message.
 
 ### Circular Dependencies
 
@@ -206,9 +214,11 @@ Preview viewport should be 1280px+ wide to see the desktop layout (sidebar nav).
 - Use `state.currentPrism` instead of a local variable — it's the single source of truth
 - `renderAll()` is the safe way to re-render everything after state changes
 - `savePrism(state.currentPrism)` persists to localStorage after mutations
+- When removing cards from `markedCards`, call `recordUnmarkedCards(prismId, keys)` **before** `savePrism()` to record tombstones that survive the next cloud merge
 - Feature modules import from `../core/`, `../modules/`, and sibling `./` files
 - 22 paint pen colors in `DEFAULT_COLORS` (processor.js) — matched to real products
 - Bracket values 1–5 represent Commander power level
 - `formatSlotLabel(position, side?)` renders "Side A - Slot 1" style labels
 - Stripe Settings in the Decks tab is a `<wa-details>` accordion (collapsed by default)
 - The Stripe Positions reorder card was removed from the Decks tab — use the Move button (⊕) on each deck card to open the visual slot-picker dialog, or use the Export tab's dropdown list for bulk reordering
+- `build.html` has a sync status indicator (`#sync-status`) and a Sync Now button (`#btn-sync-now`) near the PRISM name; both are hidden until the user is logged in. `setupSyncStatus()` in `init.js` wires these to `onSyncStatusChange` / `forceSyncCurrentPrism` from `storage.js`. Storage exports: `onSyncStatusChange(cb)` (returns unsubscribe fn), `forceSyncCurrentPrism()`, `recordUnmarkedCards(prismId, keys)`

--- a/build.html
+++ b/build.html
@@ -29,7 +29,13 @@
                 style="--wa-input-border-width: 0; font-weight: 600;"
               ></wa-input>
             </div>
-            <wa-tag id="deck-count-tag" variant="neutral" size="small">0/32 decks</wa-tag>
+            <div class="wa-cluster wa-gap-s wa-align-items-center">
+              <span id="sync-status" class="sync-status-indicator" style="display: none;"></span>
+              <wa-button id="btn-sync-now" size="small" appearance="plain" variant="neutral" title="Sync now" style="display: none;">
+                <wa-icon name="arrows-rotate"></wa-icon>
+              </wa-button>
+              <wa-tag id="deck-count-tag" variant="neutral" size="small">0/32 decks</wa-tag>
+            </div>
           </div>
         </section>
 

--- a/css/custom.css
+++ b/css/custom.css
@@ -4,6 +4,25 @@
  */
 
 /* ============================================================================
+   Sync Status Indicator
+   ============================================================================ */
+
+.sync-status-indicator {
+  font-size: var(--wa-font-size-s);
+  color: var(--wa-color-neutral-text-subtle);
+  white-space: nowrap;
+}
+
+.sync-status-indicator.sync-status-ok {
+  color: var(--wa-color-success-text);
+}
+
+.sync-status-indicator.sync-status-failed {
+  color: var(--wa-color-warning-text);
+  font-weight: 600;
+}
+
+/* ============================================================================
    Mobile Navigation Toggle
    ============================================================================ */
 

--- a/js/features/deck-form.js
+++ b/js/features/deck-form.js
@@ -16,7 +16,7 @@ import {
   DEFAULT_COLORS,
   getColorName,
 } from "../modules/processor.js";
-import { savePrism } from "../modules/storage.js";
+import { savePrism, recordUnmarkedCards } from "../modules/storage.js";
 import { canonicalizeCards } from "../modules/scryfall.js";
 import {
   getStripeCountMap,
@@ -193,7 +193,11 @@ export async function handleDeckSubmit(e) {
     state.currentPrism = addDeckToPrism(state.currentPrism, deck);
 
     // Unmark marked cards that are now shared with this deck
-    const unmarkedCount = unmarkSharedCards(newCardNames);
+    const unmarkedKeys = unmarkSharedCards(newCardNames);
+    const unmarkedCount = unmarkedKeys.length;
+    if (unmarkedKeys.length > 0) {
+      recordUnmarkedCards(state.currentPrism.id, unmarkedKeys);
+    }
 
     // Auto-clear any removed cards that are now back
     const autoClearedCount = autoClearRemovedCards(parseResult.cards);

--- a/js/features/deck-list.js
+++ b/js/features/deck-list.js
@@ -22,7 +22,7 @@ import {
   createPrism,
   isDotVariant,
 } from "../modules/processor.js";
-import { savePrism, setCurrentPrism } from "../modules/storage.js";
+import { savePrism, setCurrentPrism, recordUnmarkedCards } from "../modules/storage.js";
 import { canonicalizeCards } from "../modules/scryfall.js";
 import { hideEditImportMessages } from "./deck-import.js";
 import { initColorSwatches, resetDeckForm } from "./deck-form.js";
@@ -46,10 +46,10 @@ export function getStripeCountMap() {
 }
 
 export function unmarkCardsWithNewStripes(beforeCounts) {
-  if (!state.currentPrism?.markedCards?.length) return 0;
+  if (!state.currentPrism?.markedCards?.length) return [];
 
   const afterCounts = getStripeCountMap();
-  let unmarkedCount = 0;
+  const unmarkedKeys = [];
 
   state.currentPrism.markedCards = state.currentPrism.markedCards.filter(
     (cardKey) => {
@@ -58,23 +58,23 @@ export function unmarkCardsWithNewStripes(beforeCounts) {
       const after = afterCounts.get(cardName) || 0;
 
       if (after > before) {
-        unmarkedCount++;
+        unmarkedKeys.push(cardKey);
         return false;
       }
       return true;
     },
   );
 
-  return unmarkedCount;
+  return unmarkedKeys;
 }
 
 export function unmarkSharedCards(newCardNames) {
-  if (!state.currentPrism?.markedCards?.length) return 0;
+  if (!state.currentPrism?.markedCards?.length) return [];
 
   const processed = processCards(state.currentPrism);
   const cardMap = new Map(processed.map((c) => [c.name.toLowerCase(), c]));
 
-  let unmarkedCount = 0;
+  const unmarkedKeys = [];
 
   state.currentPrism.markedCards = state.currentPrism.markedCards.filter(
     (cardKey) => {
@@ -85,7 +85,7 @@ export function unmarkSharedCards(newCardNames) {
       if (newCardNames.has(cardName)) {
         const card = cardMap.get(cardName);
         if (card && card.stripes.length > 1) {
-          unmarkedCount++;
+          unmarkedKeys.push(cardKey);
           return false;
         }
       }
@@ -93,7 +93,7 @@ export function unmarkSharedCards(newCardNames) {
     },
   );
 
-  return unmarkedCount;
+  return unmarkedKeys;
 }
 
 export function autoClearRemovedCards(newCards) {
@@ -142,6 +142,7 @@ export function handleMarkToggle(event) {
       (c) => c !== cardKey,
     );
     row.classList.remove("marked-row");
+    recordUnmarkedCards(state.currentPrism.id, [cardKey]);
   }
 
   state.currentPrism.updatedAt = new Date().toISOString();
@@ -365,7 +366,11 @@ export async function handleEditConfirm() {
   deck.cards = parseResult.cards;
   deck.updatedAt = now;
 
-  const unmarkedCount = unmarkCardsWithNewStripes(beforeCounts);
+  const unmarkedKeys = unmarkCardsWithNewStripes(beforeCounts);
+  const unmarkedCount = unmarkedKeys.length;
+  if (unmarkedKeys.length > 0) {
+    recordUnmarkedCards(state.currentPrism.id, unmarkedKeys);
+  }
 
   state.currentPrism.updatedAt = now;
   savePrism(state.currentPrism);

--- a/js/features/init.js
+++ b/js/features/init.js
@@ -265,7 +265,10 @@ function setupSyncStatus() {
 
   btnSyncNow.addEventListener('click', async () => {
     btnSyncNow.loading = true;
-    await forceSyncCurrentPrism();
-    btnSyncNow.loading = false;
+    try {
+      await forceSyncCurrentPrism();
+    } finally {
+      btnSyncNow.loading = false;
+    }
   });
 }

--- a/js/features/init.js
+++ b/js/features/init.js
@@ -5,8 +5,8 @@
 import { state } from '../core/state.js';
 import { getLogicalDeckCount } from '../core/utils.js';
 import { createPrism } from '../modules/processor.js';
-import { getCurrentPrism, savePrism, setCurrentPrism, getPreferences } from '../modules/storage.js';
-import { initAuth, setupAuthListeners } from '../modules/auth.js';
+import { getCurrentPrism, savePrism, setCurrentPrism, getPreferences, onSyncStatusChange, forceSyncCurrentPrism } from '../modules/storage.js';
+import { initAuth, setupAuthListeners, getCurrentUser } from '../modules/auth.js';
 import { logToSupabase } from '../modules/supabase-client.js';
 import { initColorSwatches } from './deck-form.js';
 import { renderDecksList } from './deck-list.js';
@@ -125,6 +125,10 @@ function getElements() {
 
     // Stripe reorder dialog
     stripeReorderDialog: document.getElementById('stripe-reorder-dialog'),
+
+    // Sync status
+    syncStatus: document.getElementById('sync-status'),
+    btnSyncNow: document.getElementById('btn-sync-now'),
   };
 }
 
@@ -174,6 +178,7 @@ export async function init() {
   // Set up event listeners
   setupEventListeners();
   setupStripeReorderDialog();
+  setupSyncStatus();
 
   console.log('PRISM: Initialization complete');
 }
@@ -207,4 +212,60 @@ function renderPrismHeader() {
       state.elements.deckCountTag.variant = 'success';
     }
   }
+}
+
+// ============================================================================
+// Sync status indicator
+// ============================================================================
+
+function setupSyncStatus() {
+  const { syncStatus, btnSyncNow } = state.elements;
+  if (!syncStatus || !btnSyncNow) return;
+
+  // Only show for logged-in users
+  if (!getCurrentUser()) return;
+
+  syncStatus.style.display = '';
+  btnSyncNow.style.display = '';
+
+  let lastSyncedAt = null;
+  let statusInterval = null;
+
+  function updateStatusText() {
+    if (!lastSyncedAt) return;
+    const mins = Math.floor((Date.now() - lastSyncedAt) / 60000);
+    if (mins < 1) {
+      syncStatus.textContent = 'Synced just now';
+    } else {
+      syncStatus.textContent = `Synced ${mins}m ago`;
+    }
+  }
+
+  onSyncStatusChange((status) => {
+    clearInterval(statusInterval);
+    if (status === 'syncing') {
+      syncStatus.textContent = 'Syncing…';
+      syncStatus.className = 'sync-status-indicator';
+    } else if (status === 'synced') {
+      lastSyncedAt = Date.now();
+      updateStatusText();
+      syncStatus.className = 'sync-status-indicator sync-status-ok';
+      statusInterval = setInterval(updateStatusText, 60000);
+    } else if (status === 'failed') {
+      syncStatus.textContent = 'Sync failed — Retry';
+      syncStatus.className = 'sync-status-indicator sync-status-failed';
+    }
+  });
+
+  syncStatus.addEventListener('click', () => {
+    if (syncStatus.classList.contains('sync-status-failed')) {
+      forceSyncCurrentPrism();
+    }
+  });
+
+  btnSyncNow.addEventListener('click', async () => {
+    btnSyncNow.loading = true;
+    await forceSyncCurrentPrism();
+    btnSyncNow.loading = false;
+  });
 }

--- a/js/modules/storage.js
+++ b/js/modules/storage.js
@@ -110,7 +110,8 @@ function getPrismBaseline(storage, prismId) {
       deckUpdatedAts: {},
       splitGroupUpdatedAts: {},
       deletedDecks: {},
-      deletedSplitGroups: {}
+      deletedSplitGroups: {},
+      unmarkedCards: {}
     };
   }
 
@@ -119,6 +120,7 @@ function getPrismBaseline(storage, prismId) {
   baseline.splitGroupUpdatedAts = baseline.splitGroupUpdatedAts || {};
   baseline.deletedDecks = baseline.deletedDecks || {};
   baseline.deletedSplitGroups = baseline.deletedSplitGroups || {};
+  baseline.unmarkedCards = baseline.unmarkedCards || {};
 
   return baseline;
 }
@@ -291,6 +293,18 @@ function recordPrismBaseline(storage, prism) {
       delete baseline.deletedSplitGroups[groupId];
     }
   }
+
+  // Prune un-mark tombstones that were already reflected in this sync baseline.
+  // Tombstones older than or equal to the new baseline were baked into the saved
+  // prism and no longer need to be applied on the next merge.
+  const newBaselineMs = getTimestampMs(baseline.updatedAt);
+  if (newBaselineMs > 0) {
+    for (const [key, unmarkedAt] of Object.entries(baseline.unmarkedCards || {})) {
+      if (getTimestampMs(unmarkedAt) <= newBaselineMs) {
+        delete baseline.unmarkedCards[key];
+      }
+    }
+  }
 }
 
 function pruneSyncState(storage) {
@@ -341,7 +355,8 @@ function mergePrismVersions(localPrism, cloudPrism, prismBaseline) {
     deckUpdatedAts: {},
     splitGroupUpdatedAts: {},
     deletedDecks: {},
-    deletedSplitGroups: {}
+    deletedSplitGroups: {},
+    unmarkedCards: {}
   };
   const localUpdatedAt = localPrism.updatedAt || localPrism.createdAt || null;
   const cloudUpdatedAt = cloudPrism.updatedAt || cloudPrism.createdAt || null;
@@ -375,7 +390,9 @@ function mergePrismVersions(localPrism, cloudPrism, prismBaseline) {
     ...basePrism,
     markedCards: mergeMarkedCards(
       localPrism.markedCards || [],
-      cloudPrism.markedCards || []
+      cloudPrism.markedCards || [],
+      baseline.unmarkedCards,
+      baseline.updatedAt
     ),
     removedCards: mergeRemovedCards(
       localPrism.removedCards || [],
@@ -416,6 +433,23 @@ const PRISM_SELECT = `
     )
   )
 `;
+
+// ============================================
+// SYNC STATUS EVENTS
+// ============================================
+
+let syncStatusListeners = [];
+
+export function onSyncStatusChange(cb) {
+  syncStatusListeners.push(cb);
+  return () => { syncStatusListeners = syncStatusListeners.filter(l => l !== cb); };
+}
+
+function emitSyncStatus(status, detail) {
+  syncStatusListeners.forEach(cb => {
+    try { cb(status, detail); } catch (_) {}
+  });
+}
 
 // ============================================
 // SUPABASE SYNC FUNCTIONS
@@ -503,8 +537,9 @@ async function savePrismToSupabase(prism) {
       }
     }
 
-    // Replace all cards per deck atomically via RPC (single transaction:
-    // DELETE + INSERT). Accepts empty array to clear cards safely.
+    // Replace all cards per deck atomically via RPC. Continue on per-deck failure
+    // so a single failing deck doesn't leave all subsequent decks without cards.
+    let anyCardFailed = false;
     for (const deck of prism.decks || []) {
       const deckUpdatedAt = deck.updatedAt || prismUpdatedAt;
       const localCards = deck.cards || [];
@@ -520,8 +555,9 @@ async function savePrismToSupabase(prism) {
       });
 
       if (replaceCardsError) {
-        console.error('Error replacing deck cards:', replaceCardsError);
-        return false;
+        console.error('Error replacing cards for deck', deck.name, ':', replaceCardsError);
+        anyCardFailed = true;
+        // Continue rather than bailing — other decks should still be saved.
       }
     }
 
@@ -539,6 +575,11 @@ async function savePrismToSupabase(prism) {
         console.error('Error deleting removed decks from Supabase:', deleteDecksError);
         return false;
       }
+    }
+
+    if (anyCardFailed) {
+      console.warn('PRISM saved with some card sync failures:', prism.name);
+      return false;
     }
 
     console.log('PRISM saved to Supabase:', prism.name);
@@ -638,11 +679,20 @@ export async function loadPrismsFromSupabase() {
 }
 
 /**
- * Merge markedCards arrays via set-union (deduplicated).
- * If either device says a card is marked, keep it marked.
+ * Merge markedCards arrays via set-union (deduplicated), then remove any cards
+ * that were intentionally un-marked after the last sync (tombstone > baseline).
  */
-function mergeMarkedCards(localArr, cloudArr) {
+function mergeMarkedCards(localArr, cloudArr, unmarkedTombstones, baselineUpdatedAt) {
+  const tombstones = unmarkedTombstones || {};
+  const baselineMs = getTimestampMs(baselineUpdatedAt);
   const set = new Set([...localArr, ...cloudArr]);
+
+  for (const [key, unmarkedAt] of Object.entries(tombstones)) {
+    if (getTimestampMs(unmarkedAt) > baselineMs) {
+      set.delete(key);
+    }
+  }
+
   return [...set];
 }
 
@@ -681,6 +731,7 @@ export async function syncWithSupabase() {
   const storage = loadStorage();
   const syncState = ensureSyncState(storage);
   const merged = {};
+  const needsCloudWrite = new Set();
   const prismIds = new Set([
     ...Object.keys(storage.prisms),
     ...Object.keys(cloudPrisms)
@@ -693,12 +744,23 @@ export async function syncWithSupabase() {
 
     if (localPrism && cloudPrism) {
       merged[prismId] = mergePrismVersions(localPrism, cloudPrism, baseline);
+      needsCloudWrite.add(prismId);
       continue;
     }
 
     if (localPrism) {
+      // Skip auto-created default prisms: no decks, no cards, no prior sync history.
+      // These were created as a UI placeholder before the user's cloud data loaded,
+      // and should not be uploaded as phantom empty PRISMs.
+      const hasContent = (localPrism.decks?.length > 0) ||
+                         (localPrism.markedCards?.length > 0) ||
+                         (localPrism.removedCards?.length > 0);
+      const hasBaseline = !!(baseline?.updatedAt);
+      if (!hasContent && !hasBaseline) continue;
+
       if (!baseline?.updatedAt || getTimestampMs(localPrism.updatedAt) > getTimestampMs(baseline.updatedAt)) {
         merged[prismId] = localPrism;
+        needsCloudWrite.add(prismId);
       }
       continue;
     }
@@ -706,6 +768,7 @@ export async function syncWithSupabase() {
     const deletedAt = syncState.deletedPrisms[prismId];
     if (!deletedAt || getTimestampMs(cloudPrism.updatedAt || cloudPrism.createdAt) > getTimestampMs(deletedAt)) {
       merged[prismId] = cloudPrism;
+      // cloud-only: no local write needed, just record baseline
     }
   }
 
@@ -732,8 +795,15 @@ export async function syncWithSupabase() {
   saveStorage(storage);
 
   for (const [prismId, prism] of Object.entries(storage.prisms)) {
-    const saved = await savePrismToSupabase(prism);
-    if (saved) {
+    if (needsCloudWrite.has(prismId)) {
+      // This prism has local changes — push merged result to cloud.
+      const saved = await savePrismToSupabase(prism);
+      if (saved) {
+        recordPrismBaseline(storage, prism);
+      }
+    } else {
+      // Cloud-only prism: no write needed, just record the baseline so future
+      // debounced syncs have correct reference timestamps.
       recordPrismBaseline(storage, prism);
     }
   }
@@ -751,9 +821,14 @@ export async function syncWithSupabase() {
 async function syncPrismToSupabase(prismId) {
   if (!shouldSyncToSupabase()) return;
 
+  emitSyncStatus('syncing');
+
   const storage = loadStorage();
   const localPrism = storage.prisms[prismId];
-  if (!localPrism) return;
+  if (!localPrism) {
+    emitSyncStatus('failed');
+    return;
+  }
 
   const cloudPrism = await loadPrismFromSupabase(prismId);
   const baseline = getPrismBaseline(storage, prismId);
@@ -768,6 +843,9 @@ async function syncPrismToSupabase(prismId) {
   if (saved) {
     recordPrismBaseline(storage, mergedPrism);
     saveStorage(storage);
+    emitSyncStatus('synced');
+  } else {
+    emitSyncStatus('failed');
   }
 }
 
@@ -844,6 +922,40 @@ export function savePrism(prism) {
       });
     }, 2000);
   }
+}
+
+/**
+ * Record that cards were intentionally un-marked (tombstone for merge).
+ * Call this BEFORE savePrism() when removing entries from markedCards so
+ * the next sync does not re-apply cloud marks that were intentionally cleared.
+ * @param {string} prismId
+ * @param {string[]} cardKeys - The markedCards keys that were removed
+ */
+export function recordUnmarkedCards(prismId, cardKeys) {
+  if (!cardKeys || cardKeys.length === 0) return;
+  const storage = loadStorage();
+  const baseline = getPrismBaseline(storage, prismId);
+  const now = new Date().toISOString();
+  for (const key of cardKeys) {
+    baseline.unmarkedCards[key] = now;
+  }
+  saveStorage(storage);
+}
+
+/**
+ * Force an immediate sync of the current PRISM, bypassing the debounce.
+ */
+export async function forceSyncCurrentPrism() {
+  if (!shouldSyncToSupabase()) return;
+  const storage = loadStorage();
+  const prismId = storage.currentPrismId;
+  if (!prismId) return;
+  clearTimeout(syncTimeout);
+  syncTimeout = null;
+  queuedPrismId = null;
+  await syncPrismToSupabase(prismId).catch(err => {
+    console.error('Force sync failed:', err);
+  });
 }
 
 /**

--- a/js/modules/storage.js
+++ b/js/modules/storage.js
@@ -6,6 +6,7 @@
 import { DEFAULT_COLORS } from './processor.js';
 import { getSupabase, isConfigured } from './supabase-client.js';
 import { getCurrentUser } from './auth.js';
+import { showToast } from '../core/notifications.js';
 
 const STORAGE_KEY = 'prism_data';
 const CURRENT_VERSION = 2;
@@ -435,6 +436,64 @@ const PRISM_SELECT = `
 `;
 
 // ============================================
+// RPC MIGRATION FALLBACK
+// ============================================
+
+// When the Supabase project is missing the `replace_deck_cards` RPC (schema
+// migration never run), we fall back to a non-atomic DELETE + INSERT so the
+// app keeps syncing. Per-session flags avoid retrying the missing RPC and
+// spamming the user with toasts.
+let rpcUnavailable = false;
+let migrationToastShown = false;
+
+function isFunctionNotFoundError(error) {
+  if (!error) return false;
+  if (error.code === 'PGRST202') return true;
+  const msg = (error.message || '').toLowerCase();
+  return msg.includes('could not find the function')
+    || msg.includes('function') && msg.includes('does not exist');
+}
+
+function notifyMigrationMissing() {
+  if (migrationToastShown) return;
+  migrationToastShown = true;
+  console.warn(
+    'replace_deck_cards RPC not found in Supabase project. ' +
+    'Falling back to manual DELETE + INSERT on deck_cards. ' +
+    'Run supabase-schema.sql in the Supabase SQL Editor to restore atomic card sync.'
+  );
+  showToast(
+    'Sync is using a fallback. Run supabase-schema.sql in your Supabase SQL Editor to enable atomic card sync.',
+    'warning',
+    'triangle-exclamation'
+  );
+}
+
+async function replaceDeckCardsFallback(supabase, deckId, localCards, deckUpdatedAt) {
+  const { error: delError } = await supabase
+    .from('deck_cards')
+    .delete()
+    .eq('deck_id', deckId);
+
+  if (delError) return delError;
+
+  if (localCards.length === 0) return null;
+
+  const { error: insError } = await supabase
+    .from('deck_cards')
+    .insert(localCards.map(card => ({
+      deck_id: deckId,
+      card_name: card.name,
+      quantity: card.quantity || 1,
+      is_commander: !!card.isCommander,
+      is_basic_land: !!card.isBasicLand,
+      created_at: deckUpdatedAt
+    })));
+
+  return insError || null;
+}
+
+// ============================================
 // SYNC STATUS EVENTS
 // ============================================
 
@@ -539,23 +598,43 @@ async function savePrismToSupabase(prism) {
 
     // Replace all cards per deck atomically via RPC. Continue on per-deck failure
     // so a single failing deck doesn't leave all subsequent decks without cards.
+    // If the RPC is missing from the project (schema migration not yet run),
+    // fall back to a non-atomic DELETE + INSERT for the rest of this session.
     let anyCardFailed = false;
     for (const deck of prism.decks || []) {
       const deckUpdatedAt = deck.updatedAt || prismUpdatedAt;
       const localCards = deck.cards || [];
-      const { error: replaceCardsError } = await supabase.rpc('replace_deck_cards', {
-        p_deck_id: deck.id,
-        p_cards: localCards.map(card => ({
-          card_name: card.name,
-          quantity: card.quantity || 1,
-          is_commander: card.isCommander || false,
-          is_basic_land: card.isBasicLand || false
-        })),
-        p_created_at: deckUpdatedAt
-      });
 
-      if (replaceCardsError) {
-        console.error('Error replacing cards for deck', deck.name, ':', replaceCardsError);
+      let cardError = null;
+
+      if (!rpcUnavailable) {
+        const { error: replaceCardsError } = await supabase.rpc('replace_deck_cards', {
+          p_deck_id: deck.id,
+          p_cards: localCards.map(card => ({
+            card_name: card.name,
+            quantity: card.quantity || 1,
+            is_commander: card.isCommander || false,
+            is_basic_land: card.isBasicLand || false
+          })),
+          p_created_at: deckUpdatedAt
+        });
+
+        if (replaceCardsError) {
+          if (isFunctionNotFoundError(replaceCardsError)) {
+            rpcUnavailable = true;
+            notifyMigrationMissing();
+          } else {
+            cardError = replaceCardsError;
+          }
+        }
+      }
+
+      if (rpcUnavailable && !cardError) {
+        cardError = await replaceDeckCardsFallback(supabase, deck.id, localCards, deckUpdatedAt);
+      }
+
+      if (cardError) {
+        console.error('Error replacing cards for deck', deck.name, ':', cardError);
         anyCardFailed = true;
         // Continue rather than bailing — other decks should still be saved.
       }

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -25,7 +25,7 @@ CREATE TABLE IF NOT EXISTS decks (
   name TEXT NOT NULL,
   color TEXT NOT NULL DEFAULT '#888888',
   bracket INTEGER CHECK (bracket >= 1 AND bracket <= 5),
-  stripe_position INTEGER CHECK (stripe_position >= 1 AND stripe_position <= 32),
+  stripe_position INTEGER CHECK (stripe_position >= 1 AND stripe_position <= 48),
   sort_order INTEGER DEFAULT 0,
   split_group_id UUID,
   created_at TIMESTAMPTZ DEFAULT now(),
@@ -194,6 +194,19 @@ $$;
 -- SECURITY INVOKER: function runs as the calling user so existing RLS policies
 -- on deck_cards apply — users can only replace cards in their own decks.
 GRANT EXECUTE ON FUNCTION replace_deck_cards(UUID, JSONB, TIMESTAMPTZ) TO authenticated;
+
+-- ============================================
+-- MIGRATION: Widen decks.stripe_position from 1..32 to 1..48
+-- ============================================
+-- Stripe positions span 1..48 (Side A: 1..24, Side B: 25..48). An older
+-- version of this schema constrained positions to 1..32, which rejects any
+-- Side-B deck (typically split-group variants) with a 23514 error on upsert.
+-- This block drops the old constraint and re-adds the correct one. Idempotent.
+BEGIN;
+  ALTER TABLE decks DROP CONSTRAINT IF EXISTS decks_stripe_position_check;
+  ALTER TABLE decks ADD CONSTRAINT decks_stripe_position_check
+    CHECK (stripe_position >= 1 AND stripe_position <= 48);
+COMMIT;
 
 -- ============================================
 -- MIGRATION: Remove server-side updated_at triggers

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -1,10 +1,11 @@
 -- Prism MTG Database Schema
 -- Run this in Supabase SQL Editor (SQL Editor > New Query)
+-- This script is fully idempotent — safe to re-run on an existing database.
 
 -- ============================================
--- PRISMS TABLE - saved prism configurations
+-- PRISMS TABLE
 -- ============================================
-CREATE TABLE prisms (
+CREATE TABLE IF NOT EXISTS prisms (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
   name TEXT NOT NULL,
@@ -16,9 +17,9 @@ CREATE TABLE prisms (
 );
 
 -- ============================================
--- DECKS TABLE - deck metadata within a prism
+-- DECKS TABLE
 -- ============================================
-CREATE TABLE decks (
+CREATE TABLE IF NOT EXISTS decks (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   prism_id UUID REFERENCES prisms(id) ON DELETE CASCADE NOT NULL,
   name TEXT NOT NULL,
@@ -32,9 +33,9 @@ CREATE TABLE decks (
 );
 
 -- ============================================
--- DECK_CARDS TABLE - cards in each deck
+-- DECK_CARDS TABLE
 -- ============================================
-CREATE TABLE deck_cards (
+CREATE TABLE IF NOT EXISTS deck_cards (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   deck_id UUID REFERENCES decks(id) ON DELETE CASCADE NOT NULL,
   card_name TEXT NOT NULL,
@@ -44,71 +45,77 @@ CREATE TABLE deck_cards (
   created_at TIMESTAMPTZ DEFAULT now()
 );
 
--- Index for fast card lookups
-CREATE INDEX idx_deck_cards_name ON deck_cards(card_name);
-CREATE INDEX idx_deck_cards_deck ON deck_cards(deck_id);
+CREATE INDEX IF NOT EXISTS idx_deck_cards_name ON deck_cards(card_name);
+CREATE INDEX IF NOT EXISTS idx_deck_cards_deck ON deck_cards(deck_id);
 
 -- ============================================
--- APP_LOGS TABLE - for debugging
+-- APP_LOGS TABLE
 -- ============================================
-CREATE TABLE app_logs (
+CREATE TABLE IF NOT EXISTS app_logs (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
-  level TEXT NOT NULL DEFAULT 'info', -- 'debug', 'info', 'warn', 'error'
+  level TEXT NOT NULL DEFAULT 'info',
   message TEXT NOT NULL,
   metadata JSONB,
   created_at TIMESTAMPTZ DEFAULT now()
 );
 
--- Index for querying logs
-CREATE INDEX idx_app_logs_level ON app_logs(level);
-CREATE INDEX idx_app_logs_created ON app_logs(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_app_logs_level ON app_logs(level);
+CREATE INDEX IF NOT EXISTS idx_app_logs_created ON app_logs(created_at DESC);
 
 -- ============================================
--- ROW LEVEL SECURITY POLICIES
+-- ROW LEVEL SECURITY
 -- ============================================
 
--- PRISMS: Users can only see/modify their own prisms
 ALTER TABLE prisms ENABLE ROW LEVEL SECURITY;
+ALTER TABLE decks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE deck_cards ENABLE ROW LEVEL SECURITY;
+ALTER TABLE app_logs ENABLE ROW LEVEL SECURITY;
 
+-- PRISMS
+DROP POLICY IF EXISTS "Users can view own prisms" ON prisms;
 CREATE POLICY "Users can view own prisms"
   ON prisms FOR SELECT
   USING (auth.uid() = user_id);
 
+DROP POLICY IF EXISTS "Users can create own prisms" ON prisms;
 CREATE POLICY "Users can create own prisms"
   ON prisms FOR INSERT
   WITH CHECK (auth.uid() = user_id);
 
+DROP POLICY IF EXISTS "Users can update own prisms" ON prisms;
 CREATE POLICY "Users can update own prisms"
   ON prisms FOR UPDATE
   USING (auth.uid() = user_id);
 
+DROP POLICY IF EXISTS "Users can delete own prisms" ON prisms;
 CREATE POLICY "Users can delete own prisms"
   ON prisms FOR DELETE
   USING (auth.uid() = user_id);
 
--- DECKS: Access through prism ownership
-ALTER TABLE decks ENABLE ROW LEVEL SECURITY;
-
+-- DECKS
+DROP POLICY IF EXISTS "Users can view decks in own prisms" ON decks;
 CREATE POLICY "Users can view decks in own prisms"
   ON decks FOR SELECT
   USING (prism_id IN (SELECT id FROM prisms WHERE user_id = auth.uid()));
 
+DROP POLICY IF EXISTS "Users can create decks in own prisms" ON decks;
 CREATE POLICY "Users can create decks in own prisms"
   ON decks FOR INSERT
   WITH CHECK (prism_id IN (SELECT id FROM prisms WHERE user_id = auth.uid()));
 
+DROP POLICY IF EXISTS "Users can update decks in own prisms" ON decks;
 CREATE POLICY "Users can update decks in own prisms"
   ON decks FOR UPDATE
   USING (prism_id IN (SELECT id FROM prisms WHERE user_id = auth.uid()));
 
+DROP POLICY IF EXISTS "Users can delete decks in own prisms" ON decks;
 CREATE POLICY "Users can delete decks in own prisms"
   ON decks FOR DELETE
   USING (prism_id IN (SELECT id FROM prisms WHERE user_id = auth.uid()));
 
--- DECK_CARDS: Access through deck -> prism ownership
-ALTER TABLE deck_cards ENABLE ROW LEVEL SECURITY;
-
+-- DECK_CARDS
+DROP POLICY IF EXISTS "Users can view cards in own decks" ON deck_cards;
 CREATE POLICY "Users can view cards in own decks"
   ON deck_cards FOR SELECT
   USING (deck_id IN (
@@ -117,6 +124,7 @@ CREATE POLICY "Users can view cards in own decks"
     WHERE p.user_id = auth.uid()
   ));
 
+DROP POLICY IF EXISTS "Users can create cards in own decks" ON deck_cards;
 CREATE POLICY "Users can create cards in own decks"
   ON deck_cards FOR INSERT
   WITH CHECK (deck_id IN (
@@ -125,6 +133,7 @@ CREATE POLICY "Users can create cards in own decks"
     WHERE p.user_id = auth.uid()
   ));
 
+DROP POLICY IF EXISTS "Users can update cards in own decks" ON deck_cards;
 CREATE POLICY "Users can update cards in own decks"
   ON deck_cards FOR UPDATE
   USING (deck_id IN (
@@ -133,6 +142,7 @@ CREATE POLICY "Users can update cards in own decks"
     WHERE p.user_id = auth.uid()
   ));
 
+DROP POLICY IF EXISTS "Users can delete cards in own decks" ON deck_cards;
 CREATE POLICY "Users can delete cards in own decks"
   ON deck_cards FOR DELETE
   USING (deck_id IN (
@@ -141,13 +151,13 @@ CREATE POLICY "Users can delete cards in own decks"
     WHERE p.user_id = auth.uid()
   ));
 
--- APP_LOGS: Users can view/create their own logs
-ALTER TABLE app_logs ENABLE ROW LEVEL SECURITY;
-
+-- APP_LOGS
+DROP POLICY IF EXISTS "Users can view own logs" ON app_logs;
 CREATE POLICY "Users can view own logs"
   ON app_logs FOR SELECT
   USING (auth.uid() = user_id);
 
+DROP POLICY IF EXISTS "Users can create logs" ON app_logs;
 CREATE POLICY "Users can create logs"
   ON app_logs FOR INSERT
   WITH CHECK (user_id IS NULL OR auth.uid() = user_id);
@@ -192,7 +202,7 @@ GRANT EXECUTE ON FUNCTION replace_deck_cards(UUID, JSONB, TIMESTAMPTZ) TO authen
 -- it with now() (server time) causes clock-skew bugs: cloud.updated_at ends up
 -- ahead of local.updated_at, so merge-before-write silently picks the stale
 -- cloud deck and reverts user edits on next page load.
--- Safe to re-run (IF EXISTS). Wrap in transaction so partial failure rolls back.
+-- Safe to re-run (IF EXISTS). Wrapped in a transaction so partial failure rolls back.
 BEGIN;
   DROP TRIGGER IF EXISTS update_decks_updated_at ON decks;
   DROP TRIGGER IF EXISTS update_prisms_updated_at ON prisms;


### PR DESCRIPTION
- storage.js: Skip uploading auto-created empty prisms during login sync.
  A default PRISM is created pre-login as a UI placeholder; it now gets
  dropped from the merge if it has no decks/cards and no prior baseline,
  preventing phantom empty PRISMs from appearing in the cloud.

- storage.js: Track which prisms have local changes during syncWithSupabase
  and only write those back to Supabase. Cloud-only prisms (fresh device
  load) no longer trigger redundant replace_deck_cards calls that could
  race with concurrent reads and produce empty-deck rows.

- storage.js: Continue-on-error in savePrismToSupabase card loop. A single
  failing deck RPC no longer bails the entire save — all decks are attempted
  and partial failures are logged. Returns false so the baseline is not
  recorded and the sync retries on next save.

- storage.js: markedCards tombstone merge. Add unmarkedCards: {} to
  prism baselines. mergeMarkedCards now filters out keys whose tombstone
  timestamp is newer than the last sync baseline, so intentional un-marks
  survive the cloud union-merge instead of getting reverted on next login.
  recordPrismBaseline prunes stale tombstones after each successful sync.

- storage.js: Export recordUnmarkedCards, forceSyncCurrentPrism,
  onSyncStatusChange. syncPrismToSupabase emits syncing/synced/failed.

- deck-list.js, deck-form.js: unmarkSharedCards and unmarkCardsWithNewStripes
  now return the removed card keys (was: count). Callers record tombstones
  via recordUnmarkedCards before savePrism. handleMarkToggle also records
  a tombstone on manual un-check.

- build.html + css/custom.css: Add sync status indicator and Sync Now button
  near the PRISM name header. Hidden until user is logged in.

- init.js: Wire setupSyncStatus — shows Syncing/Synced Xm ago/Sync failed
  based on sync events. Sync Now button calls forceSyncCurrentPrism.

https://claude.ai/code/session_01WD3wQ1NHbV4yg7HNfRLfgw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sync status indicator (syncing/synced/failed with “synced X ago”) and a “Sync now” button visible when signed in; click to retry.

* **Bug Fixes**
  * Unmarked card removals are persisted so mark/unmark actions are reliably remembered and merged.
  * Deck syncs continue per-deck on errors, log failures, and ensure failed decks are retried.

* **Style**
  * Added styling for the sync status indicator with state-specific colors.

* **Documentation**
  * Expanded sync and merge behavior, conflict-resolution, and recommended save ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/codwats/prism/pull/80?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->