### PR TITLE
fix(processor): return null when all 48 stripe slots fullgetNextVaria…

### DIFF
--- a/js/modules/processor.js
+++ b/js/modules/processor.js
@@ -588,7 +588,7 @@ export function getNextVariantPosition(prism) {
 	for (let i = 1; i <= 24; i++) {
 		if (!usedPositions.has(i)) return i;
 	}
-	return (prism.decks?.length || 0) + 1;
+	return null;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "globals": "^15.0.0"
   },
   "scripts": {
-    "lint": "eslint js/"
+    "lint": "eslint js/",
+    "test": "node --test \"tests/**/*.test.js\""
   }
 }

--- a/tests/processor.variant-position.test.js
+++ b/tests/processor.variant-position.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createDeck, getNextVariantPosition, splitDeck } from '../js/modules/processor.js';
+
+function fullPrism() {
+	const decks = [];
+	for (let pos = 1; pos <= 48; pos++) {
+		decks.push(
+			createDeck({
+				name: `Deck ${pos}`,
+				commander: 'Test Commander',
+				bracket: 3,
+				color: '#FF0000',
+				stripePosition: pos,
+				cards: [{ name: 'Sol Ring', quantity: 1, isCommander: false, isBasicLand: false }],
+			})
+		);
+	}
+	return { id: 'p1', name: 'Full', decks, splitGroups: [], markedCards: [], removedCards: [] };
+}
+
+test('getNextVariantPosition returns null when all 48 slots are occupied', () => {
+	assert.equal(getNextVariantPosition(fullPrism()), null);
+});
+
+test('splitDeck throws when all 48 slots are occupied instead of assigning a bad position', () => {
+	const prism = fullPrism();
+	const deckId = prism.decks[0].id;
+	assert.throws(() => splitDeck(prism, deckId, 2), /No available stripe positions/);
+});


### PR DESCRIPTION
…ntPosition fell through to (decks.length + 1), anonsense position that either collided with an occupied slot orexceeded 48 and silently failed the stripe_position DB constraint.The === null guards in splitDeck and addSplitToGroup were dead code.Returning null makes them fire and throw a clear error instead ofcorrupting data.Add regression tests: full-prism returns null, splitDeck throws.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error detection and messaging when all stripe positions are fully allocated.

* **Tests**
  * Added test coverage for variant positioning behavior and capacity constraint enforcement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/codwats/prism/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->