### PR TITLE
fix(security): sanitize untrusted input/output

### DIFF
--- a/js/core/utils.js
+++ b/js/core/utils.js
@@ -15,5 +15,7 @@ export function getLogicalDeckCount(prism) {
 export function escapeHtml(text) {
   const div = document.createElement('div');
   div.textContent = text;
-  return div.innerHTML;
+  return div.innerHTML
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }

--- a/js/features/deck-import.js
+++ b/js/features/deck-import.js
@@ -78,6 +78,10 @@ export function handleJsonImport(e) {
         throw new Error('No decks found in the imported file.');
       }
 
+      // Untrusted file: clamp colors to strict hex before they reach
+      // style="background-color: ${color}" in render code. Invalid → grey fallback.
+      const validHex = (c) => (/^#[0-9A-Fa-f]{6}$/.test(c) ? c : '#888888');
+
       const newPrism = createPrism(prismData.name || 'Imported PRISM');
       newPrism.id = prismData.id || newPrism.id;
       newPrism.createdAt = prismData.createdAt || newPrism.createdAt;
@@ -92,7 +96,7 @@ export function handleJsonImport(e) {
           name: deck.name,
           commander: deck.commander,
           bracket: deck.bracket,
-          color: deck.color,
+          color: validHex(deck.color),
           stripePosition: deck.stripePosition,
           splitGroupId: deck.splitGroupId || null,
           cards: deckCards,
@@ -114,7 +118,7 @@ export function handleJsonImport(e) {
             id: group.id,
             name: group.name,
             sideAPosition: group.sideAPosition,
-            sideAColor: group.sideAColor,
+            sideAColor: validHex(group.sideAColor),
             splitStyle: group.splitStyle || 'stripes',
             childDeckIds,
             createdAt: group.createdAt,

--- a/js/modules/export.js
+++ b/js/modules/export.js
@@ -13,13 +13,19 @@ import { processCards, getColorName, formatSlotLabel } from './processor.js';
 function escapeCSV(value) {
   if (value === null || value === undefined) return '';
   
-  const str = String(value);
-  
+  let str = String(value);
+
+  // Formula injection defense: cells starting with = + - @ execute as formulas
+  // in Excel/Sheets. Leading apostrophe forces text interpretation (not displayed).
+  if (/^[=+\-@]/.test(str)) {
+    str = `'${str}`;
+  }
+
   // If the value contains comma, quote, or newline, wrap in quotes and escape internal quotes
   if (str.includes(',') || str.includes('"') || str.includes('\n')) {
     return `"${str.replace(/"/g, '""')}"`;
   }
-  
+
   return str;
 }
 

--- a/js/profile.js
+++ b/js/profile.js
@@ -6,6 +6,7 @@
 import { initAuth, setupAuthListeners, onAuthChange, getCurrentUser, signOut, updatePassword, updateEmail, updateAuthUI } from './modules/auth.js';
 import { getAllPrisms, setCurrentPrism, deletePrism, savePrism, getCurrentPrism } from './modules/storage.js';
 import { createPrism } from './modules/processor.js';
+import { escapeHtml } from './core/utils.js';
 
 // DOM Elements
 let elements = {};
@@ -342,12 +343,6 @@ async function handleChangePassword(e) {
 }
 
 // Utility functions
-function escapeHtml(text) {
-  const div = document.createElement('div');
-  div.textContent = text;
-  return div.innerHTML;
-}
-
 function formatDate(dateString) {
   if (!dateString) return 'Unknown';
   const date = new Date(dateString);


### PR DESCRIPTION
- escapeHtml: encode double-quote and apostrophe chars so names  cannot break out of quoted HTML attributes (data-card-name, title)- deck-import: validate deck.color and group.sideAColor against  /^#[0-9A-Fa-f]{6}$/ on JSON import, grey fallback for invalid —  blocks style background-color injection from untrusted files- export: prefix CSV cells starting with = + - @ with an apostrophe  char to neutralize Excel/Sheets formula injection- profile: drop local escapeHtml dup, import hardened shared oneDefensive only; no behavioral change on valid data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced HTML character escaping with improved quote handling for better security.
  * Deck colors now strictly validate hex format with automatic fallback for invalid inputs.
  * CSV exports protected against spreadsheet formula injection vulnerabilities.

* **Refactor**
  * Consolidated shared HTML escaping utility across modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->