### PR TITLE
fix(security): close app_logs abuse surface

### DIFF
--- a/js/core/notifications.js
+++ b/js/core/notifications.js
@@ -2,11 +2,8 @@
  * Toast notification helpers.
  */
 
-import { logToSupabase } from '../modules/supabase-client.js';
-
 export function showError(message) {
   console.error('PRISM Error:', message);
-  logToSupabase('error', message);
   showToast(message, 'danger', 'circle-exclamation');
 }
 

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -231,3 +231,16 @@ BEGIN;
   DROP TRIGGER IF EXISTS update_prisms_updated_at ON prisms;
   DROP FUNCTION IF EXISTS update_updated_at();
 COMMIT;
+
+-- ============================================
+-- MIGRATION: Restrict app_logs INSERT to authenticated users
+-- ============================================
+-- Rejects inserts where caller is unauthenticated or supplies a mismatched
+-- user_id. Unauthenticated analytics are covered by existing GA (gtag) setup.
+-- Does not touch the SELECT policy or any other table's policies.
+BEGIN;
+  DROP POLICY IF EXISTS "Users can create logs" ON app_logs;
+  CREATE POLICY "Users can create logs"
+    ON app_logs FOR INSERT
+    WITH CHECK (auth.uid() = user_id);
+COMMIT;


### PR DESCRIPTION
 Restrict app_logs INSERT policy to auth.uid() = user_id;  unauthenticated callers and user_id spoofs now rejected- Remove auto-logging from showError; routine validation toasts  (e.g. Please enter a deck name) were flooding app_logs at  error level — intentional logToSupabase calls elsewhere unchangedMigration in supabase-schema.sql must run in Supabase SQL editorbefore this is live.