### PR TITLE
feat(a11y): add stripe position-number overlay toggle

### DIFF
--- a/build.html
+++ b/build.html
@@ -88,6 +88,14 @@
                   <p class="wa-caption-s" style="color: var(--wa-color-neutral-text-subtle);">
                     Applying remaps every deck's slot number so Slot 1 sits at the chosen corner.
                   </p>
+                  <wa-switch
+                    id="show-stripe-position-numbers"
+                    size="small"
+                    aria-label="Show stripe position numbers as a counting aid so you can identify a slot without relying on color"
+                  >Show stripe position numbers</wa-switch>
+                  <p class="wa-caption-s" style="color: var(--wa-color-neutral-text-subtle);">
+                    Counting aid — overlays the slot number (5 / 10 / 15 / 20 per side) on stripes so you can find a slot without relying on color.
+                  </p>
                 </div>
               </wa-details>
 

--- a/css/custom.css
+++ b/css/custom.css
@@ -147,10 +147,32 @@ wa-page[view='desktop'] [data-toggle-nav] {
 }
 
 .stripe-indicator {
+  position: relative;
   width: 18px;
   height: 18px;
   border-radius: var(--wa-border-radius-s);
   border: 1px solid var(--wa-color-neutral-stroke);
+}
+
+/* Counting-aid slot number overlaid on an anchor stripe (every 5th slot/side) */
+.stripe-pos-num {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+  color: #fff;
+  text-shadow: 0 0 2px #000, 0 0 2px #000;
+  pointer-events: none;
+}
+
+/* On empty/unfilled anchor slots there is no colored fill — use neutral text */
+.stripe-pos-num.stripe-pos-num-muted {
+  color: var(--wa-color-neutral-text);
+  text-shadow: none;
 }
 
 .stripe-empty {
@@ -521,6 +543,19 @@ wa-page[view='desktop'] [data-toggle-nav] {
 .stripe-mark-left {
   right: auto;
   left: 0px;
+}
+
+/* Counting-aid slot number beside a card-preview stripe */
+.stripe-mark-num {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
+  color: #fff;
+  text-shadow: 0 0 2px #000, 0 0 3px #000;
+  pointer-events: none;
 }
 
 .stripe-dot-mark {

--- a/js/core/utils.js
+++ b/js/core/utils.js
@@ -32,7 +32,7 @@ const STRIPE_POSITION_ANCHOR_INTERVAL = 5;
  * @returns {string|null} Label string (e.g. "10") or null
  */
 export function stripePositionLabel(position) {
-  if (!Number.isFinite(position) || position < 1) return null;
+  if (!Number.isFinite(position) || position < 1 || position > SLOTS_PER_SIDE * 2) return null;
   const sideRelative = position > SLOTS_PER_SIDE ? position - SLOTS_PER_SIDE : position;
   return sideRelative % STRIPE_POSITION_ANCHOR_INTERVAL === 0 ? String(sideRelative) : null;
 }

--- a/js/core/utils.js
+++ b/js/core/utils.js
@@ -17,6 +17,26 @@ export function debounce(fn, ms = 150) {
   return function(...args) { const ctx = this; clearTimeout(t); t = setTimeout(() => fn.apply(ctx, args), ms); };
 }
 
+// Slots per side (Side A = 1-24, Side B = 25-48).
+const SLOTS_PER_SIDE = 24;
+// Anchor marker every Nth slot within each side.
+const STRIPE_POSITION_ANCHOR_INTERVAL = 5;
+
+/**
+ * Side-relative slot number to overlay at "anchor" positions — every 5th slot
+ * within each side (5/10/15/20 on Side A and Side B). Returns null for
+ * non-anchor positions. Pure label logic; callers gate on the
+ * showStripePositionNumbers preference. Shared by the results table, card
+ * preview, and printable guide so all three surfaces stay in parity.
+ * @param {number} position - Stripe position 1-48
+ * @returns {string|null} Label string (e.g. "10") or null
+ */
+export function stripePositionLabel(position) {
+  if (!Number.isFinite(position) || position < 1) return null;
+  const sideRelative = position > SLOTS_PER_SIDE ? position - SLOTS_PER_SIDE : position;
+  return sideRelative % STRIPE_POSITION_ANCHOR_INTERVAL === 0 ? String(sideRelative) : null;
+}
+
 export function escapeHtml(text) {
   const div = document.createElement('div');
   div.textContent = text;

--- a/js/features/events.js
+++ b/js/features/events.js
@@ -4,7 +4,7 @@
 
 import { state } from '../core/state.js';
 import { downloadCSV, downloadJSON, openPrintableGuide, downloadUndoneTxt, copyUndoneToClipboard } from '../modules/export.js';
-import { showPreview, hidePreview, updatePosition } from '../modules/card-preview.js';
+import { showPreview, hidePreview, updatePosition, refreshOpenPreview } from '../modules/card-preview.js';
 import { handleDeckSubmit, resetDeckForm, updateColorSwatchSelection, checkColorWarning, handlePrismNameChange } from './deck-form.js';
 import { handleFileUpload, handleJsonImport, handleMoxfieldImport, handleEditFileUpload, handleEditUrlImport } from './deck-import.js';
 import { handleDeleteConfirm, handleEditConfirm, handleNewPrism, handleSplitConfirm } from './deck-list.js';
@@ -194,6 +194,16 @@ export function setupEventListeners() {
       updatePreferences({ stripeStartCorner: newCorner });
       state.elements.stripeStartCornerApply.setAttribute('disabled', '');
       renderAll();
+    });
+  }
+
+  // Show stripe position numbers preference (counting aid overlay).
+  // Read at render time + re-render the visible surfaces immediately on change.
+  if (state.elements.showStripePositionNumbers) {
+    state.elements.showStripePositionNumbers.addEventListener('change', (e) => {
+      updatePreferences({ showStripePositionNumbers: e.target.checked });
+      renderResults();
+      refreshOpenPreview();
     });
   }
 

--- a/js/features/init.js
+++ b/js/features/init.js
@@ -122,6 +122,7 @@ function getElements() {
     // Stripe settings
     stripeStartCorner: document.getElementById('stripe-start-corner'),
     stripeStartCornerApply: document.getElementById('stripe-start-corner-apply'),
+    showStripePositionNumbers: document.getElementById('show-stripe-position-numbers'),
 
     // Stripe reorder dialog
     stripeReorderDialog: document.getElementById('stripe-reorder-dialog'),
@@ -169,6 +170,9 @@ export async function init() {
   if (state.elements.stripeStartCorner) {
     const prefs = getPreferences();
     state.elements.stripeStartCorner.value = prefs.stripeStartCorner || 'top-right';
+  }
+  if (state.elements.showStripePositionNumbers) {
+    state.elements.showStripePositionNumbers.checked = !!getPreferences().showStripePositionNumbers;
   }
 
   // Initialize UI

--- a/js/features/results.js
+++ b/js/features/results.js
@@ -3,7 +3,8 @@
  */
 
 import { state } from '../core/state.js';
-import { escapeHtml } from '../core/utils.js';
+import { escapeHtml, stripePositionLabel } from '../core/utils.js';
+import { getPreferences } from '../modules/storage.js';
 import { processCards, formatSlotLabel } from '../modules/processor.js';
 import { prefetchCards } from '../modules/scryfall.js';
 import { handleMarkToggle, handleClearRemoved, handleClearAllRemoved } from './deck-list.js';
@@ -26,28 +27,37 @@ function buildSlotMap(stripes) {
   return slotMap;
 }
 
+// Position-number overlay for an anchor slot (every 5th slot per side), or ''.
+function positionNumHtml(position, showNums, muted = false) {
+  if (!showNums) return '';
+  const label = stripePositionLabel(position);
+  if (!label) return '';
+  return `<span class="stripe-pos-num${muted ? ' stripe-pos-num-muted' : ''}">${label}</span>`;
+}
+
 // Render a single stripe square (no dots).
-function renderSquare(s) {
+function renderSquare(s, showNums) {
   return `<div
     class="stripe-indicator${s.side === 'b' ? ' stripe-side-b' : ''}"
     style="background-color: ${s.color};"
     title="${formatSlotLabel(s.position)}: ${escapeHtml(s.deckName)}"
-  ></div>`;
+  >${positionNumHtml(s.position, showNums)}</div>`;
 }
 
 // Render a slot: if it has dots, use ö-style (dot row above square).
-function renderSlot(slot) {
+function renderSlot(slot, showNums) {
   if (slot.dots.length === 0) {
-    return slot.square ? renderSquare(slot.square) : '';
+    return slot.square ? renderSquare(slot.square, showNums) : '';
   }
   const dotsHtml = slot.dots.map(d => `<div
     class="stripe-indicator stripe-dot-indicator"
     style="background-color: ${d.color};"
     title="Dot: ${escapeHtml(d.deckName)}"
   ></div>`).join('');
+  const slotPos = slot.square ? slot.square.position : slot.dots[0]?.position;
   const squareHtml = slot.square
-    ? renderSquare(slot.square)
-    : `<div class="stripe-indicator stripe-empty"></div>`;
+    ? renderSquare(slot.square, showNums)
+    : `<div class="stripe-indicator stripe-empty">${positionNumHtml(slotPos, showNums, true)}</div>`;
   return `<div class="stripe-slot"><div class="slot-dot-row">${dotsHtml}</div>${squareHtml}</div>`;
 }
 
@@ -209,6 +219,7 @@ export function renderResults() {
   if (!state.elements.resultsTbody) return;
 
   const showAllSlots = state.elements.showAllSlots?.checked || false;
+  const showNums = !!getPreferences().showStripePositionNumbers;
   const totalDecks = state.currentPrism?.decks?.length || 0;
 
   state.elements.resultsTbody.innerHTML = displayCards.map(card => {
@@ -259,12 +270,12 @@ export function renderResults() {
       for (const pos of allPositions) {
         const slot = slotMap.get(pos);
         if (slot) {
-          stripeIndicators += renderSlot(slot);
+          stripeIndicators += renderSlot(slot, showNums);
         } else {
           stripeIndicators += `<div
             class="stripe-indicator stripe-empty"
             title="${formatSlotLabel(pos)}: Empty"
-          ></div>`;
+          >${positionNumHtml(pos, showNums, true)}</div>`;
         }
       }
     } else {
@@ -272,7 +283,7 @@ export function renderResults() {
       const slotMap = buildSlotMap(card.stripes);
       stripeIndicators = '';
       for (const [, slot] of slotMap) {
-        stripeIndicators += renderSlot(slot);
+        stripeIndicators += renderSlot(slot, showNums);
       }
     }
 

--- a/js/modules/card-preview.js
+++ b/js/modules/card-preview.js
@@ -2,6 +2,7 @@
 
 import { fetchCard } from './scryfall.js';
 import { getPreferences } from './storage.js';
+import { stripePositionLabel } from '../core/utils.js';
 
 // Strip back-face name from DFCs for Scryfall lookup
 // "Bala Ged Recovery // Bala Ged Sanctuary" → "Bala Ged Recovery"
@@ -57,6 +58,7 @@ function createStripeOverlay(stripes) {
   const container = document.createElement('div');
   container.className = 'card-preview-stripes';
   const { sideARight, topDown } = getCornerConfig();
+  const showNums = !!getPreferences().showStripePositionNumbers;
 
   // Build per-group dot local indices for offset computation
   const groupDotCounters = new Map();
@@ -106,6 +108,19 @@ function createStripeOverlay(stripes) {
 
     const sideLabel = stripe.position > SLOTS_PER_SIDE ? 'Side B' : 'Side A';
     mark.title = `${stripe.deckName} (${sideLabel} · Slot ${stripe.position})`;
+
+    if (showNums) {
+      const label = stripePositionLabel(stripe.position);
+      if (label) {
+        const num = document.createElement('span');
+        num.className = 'stripe-mark-num';
+        num.textContent = label;
+        // Sit just inboard of the stripe's edge.
+        if (onRight) num.style.right = '26px';
+        else num.style.left = '26px';
+        mark.appendChild(num);
+      }
+    }
 
     container.appendChild(mark);
   }
@@ -198,6 +213,8 @@ function positionTooltip(tooltip, event) {
 // Tooltip element reference
 let tooltipElement = null;
 let currentCardName = null;
+let currentStripes = null;
+let currentImageUri = null;
 
 // Get or create tooltip element
 function getTooltip() {
@@ -248,6 +265,8 @@ export async function showPreview(cardName, stripes, event) {
     if (currentCardName !== cardName) return;
 
     // Show preview with stripes
+    currentImageUri = cardData.image_uri;
+    currentStripes = stripes;
     tooltip.innerHTML = '';
     tooltip.appendChild(createPreviewElement(cardData.image_uri, stripes));
     positionTooltip(tooltip, event);
@@ -270,6 +289,15 @@ export function hidePreview() {
     tooltip.hidden = true;
     currentCardName = null;
   }
+}
+
+// Re-render the open preview in place (e.g. after the position-numbers pref
+// toggles) using the cached image + stripes — no refetch.
+export function refreshOpenPreview() {
+  const tooltip = getTooltip();
+  if (!tooltip || tooltip.hidden || !currentImageUri || !currentStripes) return;
+  tooltip.innerHTML = '';
+  tooltip.appendChild(createPreviewElement(currentImageUri, currentStripes));
 }
 
 // Update tooltip position (for mousemove)

--- a/js/modules/export.js
+++ b/js/modules/export.js
@@ -4,6 +4,8 @@
  */
 
 import { processCards, getColorName, formatSlotLabel } from './processor.js';
+import { stripePositionLabel } from '../core/utils.js';
+import { getPreferences } from './storage.js';
 
 /**
  * Escape a value for CSV (handle commas, quotes, newlines)
@@ -229,6 +231,13 @@ export function downloadJSON(prism) {
 export function generatePrintableGuide(prism) {
   const processedCards = processCards(prism);
   const splitGroups = prism.splitGroups || [];
+  // Read the counting-aid pref at generation time (no live re-render needed).
+  const showNums = !!getPreferences().showStripePositionNumbers;
+  const posNum = (position) => {
+    if (!showNums) return '';
+    const label = stripePositionLabel(position);
+    return label ? `<div class="stripe-pos-num">${label}</div>` : '';
+  };
 
   let html = `
 <!DOCTYPE html>
@@ -286,6 +295,14 @@ export function generatePrintableGuide(prism) {
       color-adjust: exact !important;
     }
     .stripe-square.side-b { border-style: dashed; }
+    /* Counting-aid slot number — black text, legible at print size, no color reliance */
+    .stripe-pos-num {
+      font-size: 9px;
+      font-weight: 700;
+      line-height: 1;
+      color: #000;
+      text-align: center;
+    }
     .stripe-empty {
       width: 16px;
       height: 16px;
@@ -474,7 +491,7 @@ export function generatePrintableGuide(prism) {
         squareHtml = `<div class="stripe-empty" title="${formatSlotLabel(pos)}: Empty"></div>`;
       }
 
-      stripeIndicators += `<div class="stripe-slot">${dotRow}${squareHtml}</div>`;
+      stripeIndicators += `<div class="stripe-slot">${dotRow}${squareHtml}${posNum(pos)}</div>`;
     }
 
     html += `

--- a/js/modules/storage.js
+++ b/js/modules/storage.js
@@ -23,7 +23,8 @@ function getDefaultStorage() {
     preferences: {
       colorScheme: 'auto',
       defaultColors: [...DEFAULT_COLORS],
-      stripeStartCorner: 'top-right'
+      stripeStartCorner: 'top-right',
+      showStripePositionNumbers: false
     },
     syncState: {
       prismBaselines: {},


### PR DESCRIPTION
New showStripePositionNumbers preference (default off) overlays the side-relative slot number on every 5th stripe (5/10/15/20 per side) in the results table, card preview, and printable guide. Counting aid so colorblind players can identify a slot without relying on color.

One shared helper (stripePositionLabel in core/utils.js) drives all three surfaces to keep them in parity. Preference is localStorage-only, read at render time and re-rendered live on toggle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Show Stripe Position Numbers" toggle in Stripe Settings that overlays counting-aid numbers (every 5th slot per side — e.g., 5/10/15/20) on card stripes.
  * Number overlays appear in results, card previews, and printable marking guides, persist as a preference, and update immediately when toggled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->