### PR TITLE
feat(a11y): label mark-done checkboxes for screen readers

### DIFF
--- a/js/features/results.js
+++ b/js/features/results.js
@@ -311,7 +311,7 @@ export function renderResults() {
     return `
       <tr class="${rowClass} ${markedClass}" data-card-key="${escapeHtml(cardKey)}">
         <td style="text-align: center;">
-          <input type="checkbox" class="mark-checkbox" ${isMarked ? 'checked' : ''}>
+          <input type="checkbox" class="mark-checkbox" aria-label="Mark ${escapeHtml(card.name)} done" ${isMarked ? 'checked' : ''}>
         </td>
         <td class="${nameClass} card-name-cell" data-card-name="${escapeHtml(card.name)}" data-stripes='${stripesJson}'>${escapeHtml(card.name)}${basicTag}</td>${copiesCell}
         <td><div class="stripe-indicators">${stripeIndicators}</div></td>


### PR DESCRIPTION
Mark checkboxes rendered as raw inputs with no accessible name; screen reader announced only "checkbox." Add aria-label reusing the row's escaped card name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen reader support for result checkboxes by adding descriptive labels for each marked item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->