### PR TITLE
feat(onboarding): surface inner-sleeve prereq at point of action

### DIFF
--- a/build.html
+++ b/build.html
@@ -62,6 +62,14 @@
           <!-- Decks Panel -->
           <wa-tab-panel name="decks">
             <div class="wa-stack wa-gap-xl">
+              <!-- First-run onboarding callout (dismissible, persisted in localStorage) -->
+              <wa-callout id="onboarding-callout" variant="brand" appearance="outlined" style="display: none;">
+                <wa-icon slot="icon" name="circle-info"></wa-icon>
+                <strong>New here? Mark the inner sleeve.</strong><br />
+                PRISM marks go on the <strong>inner Perfect Fit sleeve</strong> (card-fit), double-sleeved inside an outer sleeve (e.g. Dragon Shields) that protects the mark — never mark the outer. Add your decks below, then export a marking guide. New to it? Read the <a href="guide.html">marking guide</a> first.
+                <wa-button slot="action" id="onboarding-dismiss" appearance="plain" size="small">Dismiss</wa-button>
+              </wa-callout>
+
               <!-- Existing Decks List -->
               <section id="decks-list" class="wa-stack wa-gap-m">
                 <!-- Deck cards will be inserted here -->
@@ -335,6 +343,18 @@
           <!-- Export Panel -->
           <wa-tab-panel name="export">
             <div class="wa-stack wa-gap-xl">
+              <!-- Marking prerequisites at the point of action -->
+              <wa-callout variant="info">
+                <wa-icon slot="icon" name="circle-info"></wa-icon>
+                <strong>Mark the inner Perfect Fit sleeve, not the outer.</strong><br />
+                Marks go on the inner Perfect Fit (card-fit) sleeve, double-sleeved inside an outer sleeve (e.g. Dragon Shields) that protects the mark.
+              </wa-callout>
+              <wa-callout variant="warning">
+                <wa-icon slot="icon" name="triangle-exclamation"></wa-icon>
+                <strong>Finalize your decks before you start marking.</strong><br />
+                Adding or editing a deck only un-checks cards whose stripe markings changed — not everything. Still, mid-session edits lead to confusion, so make changes after your marking pass.
+              </wa-callout>
+
               <!-- Deck Legend -->
               <wa-card>
                 <div slot="header" class="wa-heading-m">Deck Legend</div>
@@ -554,5 +574,18 @@
       });
     </script>
     <script type="module" src="js/app.js"></script>
+    <script>
+      (function () {
+        const KEY = 'prism_onboarding_dismissed';
+        const callout = document.getElementById('onboarding-callout');
+        if (!callout) return;
+        if (localStorage.getItem(KEY) === '1') return;
+        callout.style.display = '';
+        document.getElementById('onboarding-dismiss')?.addEventListener('click', () => {
+          localStorage.setItem(KEY, '1');
+          callout.style.display = 'none';
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/guide.html
+++ b/guide.html
@@ -153,8 +153,8 @@ Share your staples across every deck. PRISM tracks what goes where so you don't 
 
           <wa-callout variant="neutral">
               <wa-icon slot="icon" name="layer-group"></wa-icon>
-              <strong>Mark the inner sleeve on the card-face side.</strong><br />
-              The marks are small (around 7mm) and won't be felt through the outer sleeve. Your cards stay tournament legal.
+              <strong>Mark the inner Perfect Fit sleeve on the card-face side.</strong><br />
+              Double-sleeve: an outer sleeve (e.g. Dragon Shields) protects the mark on the inner. The marks are small (around 7mm) and won't be felt through the outer sleeve. Your cards stay tournament legal.
           </wa-callout>
 
         </section>
@@ -246,7 +246,7 @@ Share your staples across every deck. PRISM tracks what goes where so you don't 
           </ol>
           <wa-callout variant="neutral" style="margin-top: var(--wa-space-m);">
             <wa-icon slot="icon" name="lightbulb"></wa-icon>
-            The "Done" checkbox resets when you add a new deck, so you can track progress on the new markings from scratch.
+            Adding or editing a deck only un-checks cards whose stripe markings changed — not everything. Cards whose marks are unaffected stay checked, so you only re-mark what actually changed.
           </wa-callout>
 
           <div class="wa-stack wa-gap-m">

--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
             <div class="wa-stack wa-gap-s wa-align-items-center" style="text-align: center;">
               <div style="font-size: 3rem;"><wa-icon name="3"></wa-icon></div>
               <h3 class="wa-heading-m">Mark your sleeves</h3>
-              <p>Export a printable marking guide. Use paint pens and the Spirit Guide tool to mark each sleeve edge. Fan your cards to find any deck instantly.</p>
+              <p>Export a printable marking guide. Use paint pens and the Spirit Guide tool to mark each sleeve edge. Mark the <strong>inner Perfect Fit sleeve</strong> (double-sleeved), never the outer. Fan your cards to find any deck instantly.</p>
             </div>
           </div>
         </section>


### PR DESCRIPTION
Mark-the-inner-Perfect-Fit-sleeve prerequisite only lived in tools/guide asides. First-timers could mark outer sleeves and wreck the premise.

- index: add inner-sleeve line to "Mark your sleeves" step
- build: dismissible first-run callout (prism_onboarding_dismissed)
- build: export-tab info + warning callouts at guide generation
- guide: correct overstated "Done resets" copy to actual un-check behavior; use Perfect Fit terminology