### PR TITLE
fix(mobile): reduce main padding and add deck action kebab menu

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -265,9 +265,40 @@ wa-page[view='desktop'] [data-toggle-nav] {
   box-shadow: var(--wa-shadow-m);
 }
 
+/* Deck action buttons: inline cluster on desktop, kebab dropdown on mobile */
+.deck-actions-kebab {
+  display: none;
+}
+
+.deck-actions-kebab-menu {
+  min-width: 12rem;
+  padding: var(--wa-space-2xs);
+}
+
+.deck-actions-kebab-menu .kebab-item::part(base) {
+  width: 100%;
+  justify-content: flex-start;
+}
+
+@media (max-width: 768px) {
+  .deck-actions-inline {
+    display: none;
+  }
+  .deck-actions-kebab {
+    display: inline-flex;
+  }
+}
+
 /* ============================================================================
    Responsive Adjustments
    ============================================================================ */
+
+@media (max-width: 768px) {
+  /* Tighten main content gutters on mobile (WA default padding is desktop-sized) */
+  wa-page > main {
+    padding-inline: var(--wa-space-s);
+  }
+}
 
 @media (max-width: 600px) {
   .results-table th,
@@ -756,20 +787,6 @@ wa-page[view='desktop'] [data-toggle-nav] {
   border-radius: var(--wa-border-radius-m);
 }
 
-/* Deck-card actions: inline row on desktop, kebab overflow menu on mobile */
-.deck-actions-menu {
-  display: none;
-}
-
-@media (max-width: 768px) {
-  .deck-actions-inline {
-    display: none;
-  }
-
-  .deck-actions-menu {
-    display: inline-flex;
-  }
-}
 
 /* Wider touch targets on mobile */
 @media (max-width: 768px) {

--- a/js/features/deck-list.js
+++ b/js/features/deck-list.js
@@ -655,42 +655,54 @@ function getMoveButtonHtml(deck, isInGroup) {
   `;
 }
 
-// Mobile overflow menu mirroring the inline action buttons. Menu items carry the
-// same btn-* classes + data-deck-id, so the existing click wiring in
-// setupDeckListeners catches them — no duplicate handler logic.
-function getDeckActionsMenuHtml(deck, isInGroup) {
-  const canWhatIf = state.currentPrism.decks.length >= 2;
-  const group = isInGroup ? state.currentPrism.splitGroups?.find(g => g.id === deck.splitGroupId) : null;
-  const isDotVariantDeck = isInGroup && (group?.splitStyle || 'stripes') === 'dots';
-
+// Mobile kebab: same actions as the inline cluster, reusing the same btn-*
+// classes + data-deck-id so existing listeners attach automatically.
+// Uses plain wa-buttons (not wa-menu) because wa-menu/wa-menu-item autoload
+// flakily from the CDN kit (see CLAUDE.md); wa-button is always registered.
+function kebabItem(deck, cls, icon, label) {
   return `
-    <wa-dropdown class="deck-actions-menu" placement="bottom-end">
-      <wa-button slot="trigger" appearance="plain" variant="neutral" size="small" title="More actions">
+    <wa-button class="kebab-item ${cls}" data-deck-id="${deck.id}"
+      appearance="plain" variant="neutral" size="small">
+      <wa-icon slot="start" name="${icon}"></wa-icon>${label}
+    </wa-button>
+  `;
+}
+
+function getMoveKebabItemHtml(deck, isInGroup) {
+  if (!isInGroup) {
+    return kebabItem(deck, "btn-move-deck", "up-down-left-right", "Move to slot");
+  }
+  const group = state.currentPrism.splitGroups?.find(g => g.id === deck.splitGroupId);
+  const splitStyle = group?.splitStyle || 'stripes';
+  const reason = splitStyle === 'stripes'
+    ? "Stripe variant decks can't be moved yet. This is coming in a future update."
+    : `Dot variants move with their parent. Move &quot;${group?.name || 'parent deck'}&quot; instead.`;
+  return `
+    <wa-button class="kebab-item" appearance="plain" variant="neutral" size="small" disabled title="${reason}">
+      <wa-icon slot="start" name="up-down-left-right"></wa-icon>Move to slot
+    </wa-button>
+  `;
+}
+
+function getDeckActionsKebabHtml(deck, isInGroup) {
+  const whatIf = state.currentPrism.decks.length >= 2
+    ? kebabItem(deck, "btn-what-if", "flask", "What if I remove this?")
+    : "";
+  const split = !isInGroup
+    ? kebabItem(deck, "btn-split-deck", "code-branch", "Split into variants")
+    : "";
+  return `
+    <wa-dropdown class="deck-actions-kebab">
+      <wa-button slot="trigger" appearance="plain" variant="neutral" size="small" title="Actions">
         <wa-icon name="ellipsis-vertical"></wa-icon>
       </wa-button>
-      <wa-menu>
-        ${canWhatIf ? `
-        <wa-menu-item class="btn-what-if" data-deck-id="${deck.id}">
-          <wa-icon slot="start" name="flask"></wa-icon>What if I remove this?
-        </wa-menu-item>` : ""}
-        ${isDotVariantDeck ? `
-        <wa-menu-item disabled>
-          <wa-icon slot="start" name="up-down-left-right"></wa-icon>Move (use parent group)
-        </wa-menu-item>` : `
-        <wa-menu-item class="btn-move-deck" data-deck-id="${deck.id}">
-          <wa-icon slot="start" name="up-down-left-right"></wa-icon>Move to slot
-        </wa-menu-item>`}
-        ${!isInGroup ? `
-        <wa-menu-item class="btn-split-deck" data-deck-id="${deck.id}">
-          <wa-icon slot="start" name="code-branch"></wa-icon>Split into variants
-        </wa-menu-item>` : ""}
-        <wa-menu-item class="btn-edit-deck" data-deck-id="${deck.id}">
-          <wa-icon slot="start" name="pen-to-square"></wa-icon>Edit deck
-        </wa-menu-item>
-        <wa-menu-item class="btn-delete-deck" data-deck-id="${deck.id}" variant="danger">
-          <wa-icon slot="start" name="trash"></wa-icon>Delete deck
-        </wa-menu-item>
-      </wa-menu>
+      <div class="wa-stack wa-gap-0 deck-actions-kebab-menu">
+        ${whatIf}
+        ${getMoveKebabItemHtml(deck, isInGroup)}
+        ${split}
+        ${kebabItem(deck, "btn-edit-deck", "pen-to-square", "Edit deck")}
+        ${kebabItem(deck, "btn-delete-deck", "trash", "Delete deck")}
+      </div>
     </wa-dropdown>
   `;
 }
@@ -752,7 +764,7 @@ export function renderDeckCard(deck, showActions = true, processedCards = null) 
             <wa-icon name="trash"></wa-icon>
           </wa-button>
         </div>
-        ${getDeckActionsMenuHtml(deck, isInGroup)}
+        ${getDeckActionsKebabHtml(deck, isInGroup)}
         `
             : ""
         }
@@ -900,5 +912,12 @@ export function renderDecksList() {
   });
   state.elements.decksList.querySelectorAll(".btn-unsplit").forEach((btn) => {
     btn.addEventListener("click", () => handleUnsplit(btn.dataset.groupId));
+  });
+  // Close the mobile kebab dropdown after picking an action (plain buttons
+  // don't auto-close the way wa-menu-items would).
+  state.elements.decksList.querySelectorAll(".kebab-item").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      btn.closest("wa-dropdown")?.removeAttribute("open");
+    });
   });
 }


### PR DESCRIPTION
Inline action buttons overflow card edge on narrow viewports. WA default main padding (60px) is desktop-sized — cramped on mobile.

- wa-page > main padding-inline: --wa-space-s at <=768px
- deck-actions-inline hidden on mobile; wa-dropdown kebab shown
- kebab uses plain wa-buttons (wa-menu/wa-menu-item CDN autoload is unreliable); same btn-* classes auto-wire existing listeners

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned mobile deck card actions: action buttons now appear in a dropdown menu on smaller devices rather than inline options, improving mobile interface usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->