### PR TITLE
Cluster matching stripe-sets in Results 'Stripes' sort

### DIFF
--- a/js/features/results.js
+++ b/js/features/results.js
@@ -27,6 +27,18 @@ function buildSlotMap(stripes) {
   return slotMap;
 }
 
+// Stable signature of a card's physical stripe set: the sorted list of
+// occupied slot positions (each slot = one fixed deck color), so two cards
+// with the identical set of colored marks share a signature. The invisible
+// 'membership' anchors are excluded so only real marks count.
+function stripeSignature(card) {
+  return (card.stripes || [])
+    .filter(s => s.markType !== 'membership')
+    .map(s => s.position)
+    .sort((a, b) => a - b)
+    .join(',');
+}
+
 // Position-number overlay for an anchor slot (every 5th slot per side), or ''.
 function positionNumHtml(position, showNums, muted = false) {
   if (!showNums) return '';
@@ -378,8 +390,14 @@ function sortCards(cards, column, direction) {
         comparison = a.totalQuantity - b.totalQuantity;
         break;
       case 'deckCount':
-        // Sort by deck count (most shared first by default)
+        // 1. Sort by deck count (most shared first by default)
         comparison = a.deckCount - b.deckCount;
+        // 2. Cluster cards that carry the identical set of stripes together,
+        //    so the user marks all of them without swapping pens.
+        if (comparison === 0) {
+          comparison = stripeSignature(a).localeCompare(stripeSignature(b));
+        }
+        // 3. Alphabetical within a matching set
         if (comparison === 0) {
           comparison = a.name.localeCompare(b.name);
         }

--- a/js/features/results.js
+++ b/js/features/results.js
@@ -27,15 +27,17 @@ function buildSlotMap(stripes) {
   return slotMap;
 }
 
-// Stable signature of a card's physical stripe set: the sorted list of
-// occupied slot positions (each slot = one fixed deck color), so two cards
-// with the identical set of colored marks share a signature. The invisible
-// 'membership' anchors are excluded so only real marks count.
+// Stable signature of a card's physical stripe set: one token per visible mark
+// capturing its slot, mark type, and color, so two cards share a signature only
+// when they need the exact same pens in the exact same places. Color/markType
+// matter because dot-style split variants stack several differently-colored
+// marks at one Side A position (a position-only key would collide them). The
+// invisible 'membership' anchors are excluded so only real marks count.
 function stripeSignature(card) {
   return (card.stripes || [])
     .filter(s => s.markType !== 'membership')
-    .map(s => s.position)
-    .sort((a, b) => a - b)
+    .map(s => `${s.position}:${s.markType || 'stripe'}:${s.color}`)
+    .sort()
     .join(',');
 }
 


### PR DESCRIPTION
Tie-break the deckCount sort by an exact stripe-slot signature before falling back to card name, so cards carrying the identical set of colored marks group together. This lets users mark a run of cards without swapping paint pens between unrelated cards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced card sorting in results to better group items with matching deck counts while maintaining alphabetical order as the final tie-breaker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->