### PR TITLE
fix(analysis): render overlap matrix on wa-after-show, use deck IDs

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -418,18 +418,24 @@ wa-page[view='desktop'] [data-toggle-nav] {
 }
 
 .overlap-matrix-table thead th {
-  background: var(--wa-color-surface-2);
+  background: var(--wa-color-surface-raised);
   font-weight: var(--wa-font-weight-semibold);
   position: sticky;
   top: 0;
+  z-index: 2;
 }
 
 .overlap-matrix-table tbody th {
-  background: var(--wa-color-surface-2);
+  background: var(--wa-color-surface-raised);
   font-weight: var(--wa-font-weight-semibold);
   text-align: left;
   position: sticky;
   left: 0;
+  z-index: 1;
+}
+
+.overlap-matrix-table thead th:first-child {
+  z-index: 3;
 }
 
 .overlap-cell {

--- a/js/features/analysis.js
+++ b/js/features/analysis.js
@@ -21,13 +21,13 @@ export function renderOverlapMatrix() {
 
   state.elements.overlapMatrixContainer.style.display = '';
 
-  // Skip the expensive build when the accordion is collapsed — wa-show triggers it on open.
+  // Skip the expensive build when the accordion is collapsed — wa-after-show triggers it on open.
   if (!state.elements.overlapMatrixContainer.hasAttribute('open')) return;
 
   const overlap = calculateOverlap(state.currentPrism);
   const decks = [...state.currentPrism.decks].sort((a, b) => a.stripePosition - b.stripePosition);
 
-  // Build lookup map for pairwise overlap counts
+  // Build lookup map for pairwise overlap counts (keyed by deck ID pairs)
   const overlapMap = {};
   for (const pair of overlap.pairwiseOverlap) {
     const key1 = `${pair.deck1}|${pair.deck2}`;
@@ -73,7 +73,7 @@ export function renderOverlapMatrix() {
                   <span class="wa-caption-s" style="color: var(--wa-color-neutral-text-subtle);">${rowDeck.cards.length}</span>
                 </td>`;
               }
-              const count = overlapMap[`${rowDeck.name}|${colDeck.name}`] || 0;
+              const count = overlapMap[`${rowDeck.id}|${colDeck.id}`] || 0;
               const intensity = count / maxOverlap;
               const bg = count > 0
                 ? `rgba(var(--wa-color-brand-60-rgb, 99, 102, 241), ${0.1 + intensity * 0.5})`

--- a/js/features/events.js
+++ b/js/features/events.js
@@ -229,7 +229,7 @@ export function setupEventListeners() {
 
   // Overlap matrix — build content the first time the accordion is opened
   if (state.elements.overlapMatrixContainer) {
-    state.elements.overlapMatrixContainer.addEventListener('wa-show', renderOverlapMatrix);
+    state.elements.overlapMatrixContainer.addEventListener('wa-after-show', renderOverlapMatrix);
   }
 
   // Card preview handlers (event delegation on results table).

--- a/js/modules/processor.js
+++ b/js/modules/processor.js
@@ -331,8 +331,8 @@ export function calculateOverlap(prism) {
 			}
 
 			pairwiseOverlap.push({
-				deck1: decks[i].name,
-				deck2: decks[j].name,
+				deck1: decks[i].id,
+				deck2: decks[j].id,
 				overlapCount: overlap,
 			});
 		}


### PR DESCRIPTION
wa-show fires before Lit reflects open to the attribute; hasAttribute('open') returned false so renderOverlapMatrix bailed every time. wa-after-show fires post-animation when the attribute is guaranteed present.

pairwiseOverlap was keyed by deck name — breaks silently if any namecontains or two decks share a name. Switch to deck IDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed overlap matrix rendering timing—content now displays correctly after the accordion has fully expanded
* Corrected overlap matrix cell value lookups to eliminate retrieval errors and improve accuracy

## Refactor
* Enhanced internal consistency in overlap data identification to ensure proper alignment across analysis features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->