### PR TITLE
72 cards in decks of both shared variations should not show child stripe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,8 +118,12 @@ Preferences: { colorScheme, defaultColors, stripeStartCorner ('top-right'|'top-l
 ```
 
 - **Stripe positions** 1–24 (Side A) and 25–48 (Side B), max 32 logical decks per PRISM
-- **Split groups** let one deck slot have 2–8 variants sharing a Side A position
-- **Split styles** — `'stripes'` (Side B marks on opposite edge) or `'dots'` (colored dots above the Side A stripe square). Cards in **all** variants of a group get no dot (shared = no dot). Cards in a **subset** of variants get one dot per variant they belong to, colored with that variant's deck color.
+- **Split groups** let one deck slot have 2–8 (stripes) or exactly 2 (dots) variants sharing a Side A position. The group itself holds `name`, `sideAColor`, and `sideAPosition` — editable via the ✎ button on the group card header (`handleEditGroupClick`/`handleEditGroupConfirm` in `deck-list.js`, `updateSplitGroupInPrism` in `processor.js`).
+- **Split styles** — `'stripes'` (Side B marks on opposite edge) or `'dots'` (one colored dot next to the Side A stripe square). Dots groups are capped at 2 variants (physical 1-hole limit). Child variant marks are determined in a **post-loop pass** using shared-vs-subset analysis:
+  - Card in **all** children → parent Side A stripe only; membership anchors emitted per variant for deck-filter (not rendered)
+  - Card in **subset**, stripes-style → child Side B stripe per matching variant
+  - Card in **subset**, dots-style, exactly 1 variant → dot in that variant's color
+  - Card in **subset**, dots-style, 2+ variants → dot conflict; membership anchors only, parent stripe only
 - **Stripe starting corner** — global preference controlling which card corner stripes originate from. Affects card preview, not stored data.
 - **markedCards** tracks which cards the user has physically marked (checkbox state)
 - **removedCards** tracks cards removed from decks that still need physical marks cleared
@@ -127,7 +131,7 @@ Preferences: { colorScheme, defaultColors, stripeStartCorner ('top-right'|'top-l
 
 ### Card Processing
 
-`processCards(prism)` deduplicates cards across all decks and assigns stripe indicators. Basic lands use **max quantity** across decks (not sum). Card names are canonicalized via Scryfall API before storage. For dot-style split groups, dot entries are emitted in a **post-loop pass** (not the main loop): if a card appears in all variants of a group, no dots are emitted; if it appears in a strict subset, one `{ markType: 'dot', side: 'b' }` entry is emitted per variant the card is in, colored with that variant's deck color. `dotIndex` is not stored — renderers compute local dot order from the stripes array at render time. Results table and printable guide both use ö-style rendering (dot row above the stripe square).
+`processCards(prism)` deduplicates cards across all decks and assigns stripe indicators. Basic lands use **max quantity** across decks (not sum). Card names are canonicalized via Scryfall API before storage. Child variant marks for split groups are emitted in a **post-loop pass** — the main loop only emits the group's Side A stripe. The post-loop determines shared vs subset membership for the full group before emitting any child marks (see split styles above). `markType` values: `'stripe'` (rendered Side B stripe), `'dot'` (rendered dot), `'membership'` (not rendered; carries `deckId` for deck-filter matching). `dotIndex` is not stored — renderers compute local dot order from the stripes array at render time. Results table and printable guide both use ö-style rendering (dot row above the stripe square).
 
 ### Display Counts
 

--- a/build.html
+++ b/build.html
@@ -578,7 +578,7 @@
         <wa-input id="edit-group-name" label="Group Name" required></wa-input>
         <div class="wa-stack wa-gap-xs">
           <label class="wa-caption-m">Shared Stripe Color</label>
-          <input type="color" id="edit-group-color" style="width: 60px; height: 40px; border: none; border-radius: var(--wa-border-radius-m); cursor: pointer;" />
+          <wa-color-picker id="edit-group-color" format="hex" no-format-toggle></wa-color-picker>
         </div>
       </div>
       <div slot="footer" class="wa-cluster wa-gap-s">

--- a/build.html
+++ b/build.html
@@ -545,8 +545,8 @@
       <div class="wa-stack wa-gap-m">
         <p class="wa-body-m">Split "<strong id="split-deck-name"></strong>" into multiple variants?</p>
         <p class="wa-caption-m" style="color: var(--wa-color-neutral-text-subtle);">
-          Each variant gets its own Side B mark. Cards shared across variants keep the original Side A mark
-          plus each variant's Side B mark.
+          Cards in all variants keep only the shared Side A mark. Cards in a subset of variants
+          get the variant's child mark (stripe or dot) in addition to the Side A mark.
         </p>
         <input type="hidden" id="split-deck-id" />
         <wa-radio-group id="split-style" label="Variant marking style" value="stripes">

--- a/build.html
+++ b/build.html
@@ -571,6 +571,22 @@
       </div>
     </wa-dialog>
 
+    <!-- Edit Group Dialog -->
+    <wa-dialog id="edit-group-dialog" label="Edit Group" style="--width: min(420px, 92vw);">
+      <div class="wa-stack wa-gap-l">
+        <input type="hidden" id="edit-group-id" />
+        <wa-input id="edit-group-name" label="Group Name" required></wa-input>
+        <div class="wa-stack wa-gap-xs">
+          <label class="wa-caption-m">Shared Stripe Color</label>
+          <input type="color" id="edit-group-color" style="width: 60px; height: 40px; border: none; border-radius: var(--wa-border-radius-m); cursor: pointer;" />
+        </div>
+      </div>
+      <div slot="footer" class="wa-cluster wa-gap-s">
+        <wa-button id="btn-cancel-edit-group" variant="neutral" appearance="outlined">Cancel</wa-button>
+        <wa-button id="btn-confirm-edit-group" variant="brand">Save Changes</wa-button>
+      </div>
+    </wa-dialog>
+
     <!-- Stripe Reorder Dialog -->
     <wa-dialog id="stripe-reorder-dialog" label="Move Stripe Position" style="--width: min(580px, 92vw);">
       <div id="stripe-reorder-content" class="wa-stack wa-gap-l">

--- a/js/features/deck-list.js
+++ b/js/features/deck-list.js
@@ -490,6 +490,9 @@ export function handleSplitClick(deckId) {
   if (state.elements.splitStyle) {
     state.elements.splitStyle.value = "stripes";
   }
+  if (state.elements.splitCount) {
+    state.elements.splitCount.setAttribute('max', '8');
+  }
   state.elements.splitDialog.setAttribute('open', '');
 }
 

--- a/js/features/deck-list.js
+++ b/js/features/deck-list.js
@@ -496,12 +496,15 @@ export function handleSplitConfirm() {
   const deckId = state.elements.splitDeckId.value;
   const count = parseInt(state.elements.splitCount.value) || 2;
 
-  if (count < 2 || count > 8) {
-    showError("Split count must be between 2 and 8.");
+  const splitStyle = state.elements.splitStyle?.value || 'stripes';
+  const maxCount = splitStyle === 'dots' ? 2 : 8;
+
+  if (count < 2 || count > maxCount) {
+    showError(splitStyle === 'dots'
+      ? "Dot groups support a maximum of 2 variants (one dot hole per card)."
+      : "Split count must be between 2 and 8.");
     return;
   }
-
-  const splitStyle = state.elements.splitStyle?.value || 'stripes';
   let updatedPrism;
   try {
     updatedPrism = splitDeck(state.currentPrism, deckId, count, splitStyle);
@@ -869,7 +872,8 @@ export function renderDecksList() {
                 <wa-icon name="up-down-left-right"></wa-icon>
               </wa-button>
               <wa-button appearance="plain" variant="neutral" size="small"
-                class="btn-add-split" data-group-id="${group.id}" title="Add another variant">
+                class="btn-add-split" data-group-id="${group.id}" title="Add another variant"
+                ${(group.splitStyle || 'stripes') === 'dots' && group.childDeckIds.length >= 2 ? 'disabled' : ''}>
                 <wa-icon name="plus"></wa-icon>
               </wa-button>
               <wa-button appearance="plain" variant="neutral" size="small"

--- a/js/features/deck-list.js
+++ b/js/features/deck-list.js
@@ -20,6 +20,7 @@ import {
   formatSlotLabel,
   createPrism,
   isDotVariant,
+  updateSplitGroupInPrism,
 } from "../modules/processor.js";
 import { savePrism, setCurrentPrism, recordUnmarkedCards } from "../modules/storage.js";
 import { canonicalizeCards } from "../modules/scryfall.js";
@@ -550,6 +551,35 @@ export function handleUnsplit(groupId) {
   showSuccess(`Merged "${groupName}" back into a single deck.`);
 }
 
+export function handleEditGroupClick(groupId) {
+  const group = state.currentPrism.splitGroups?.find((g) => g.id === groupId);
+  if (!group) return;
+  state.elements.editGroupId.value = groupId;
+  state.elements.editGroupName.value = group.name;
+  state.elements.editGroupColor.value = group.sideAColor;
+  state.elements.editGroupDialog.setAttribute('open', '');
+}
+
+export function handleEditGroupConfirm() {
+  const groupId = state.elements.editGroupId.value;
+  const name = (state.elements.editGroupName?.value || '').trim();
+  const color = state.elements.editGroupColor?.value || '';
+
+  if (!name) {
+    showError('Group name is required.');
+    return;
+  }
+
+  state.currentPrism = updateSplitGroupInPrism(state.currentPrism, groupId, {
+    name,
+    sideAColor: color.toUpperCase(),
+  });
+  savePrism(state.currentPrism);
+  state.elements.editGroupDialog.removeAttribute('open');
+  renderAll();
+  showSuccess(`Updated group "${name}".`);
+}
+
 export function handleNewPrism() {
   savePrism(state.currentPrism);
   state.currentPrism = createPrism();
@@ -872,6 +902,10 @@ export function renderDecksList() {
                 <wa-icon name="up-down-left-right"></wa-icon>
               </wa-button>
               <wa-button appearance="plain" variant="neutral" size="small"
+                class="btn-edit-group" data-group-id="${group.id}" title="Edit group name and color">
+                <wa-icon name="pen-to-square"></wa-icon>
+              </wa-button>
+              <wa-button appearance="plain" variant="neutral" size="small"
                 class="btn-add-split" data-group-id="${group.id}" title="Add another variant"
                 ${(group.splitStyle || 'stripes') === 'dots' && group.childDeckIds.length >= 2 ? 'disabled' : ''}>
                 <wa-icon name="plus"></wa-icon>
@@ -898,6 +932,9 @@ export function renderDecksList() {
   });
   state.elements.decksList.querySelectorAll(".btn-move-group").forEach((btn) => {
     btn.addEventListener("click", () => openGroupReorderDialog(btn.dataset.groupId));
+  });
+  state.elements.decksList.querySelectorAll(".btn-edit-group").forEach((btn) => {
+    btn.addEventListener("click", () => handleEditGroupClick(btn.dataset.groupId));
   });
   state.elements.decksList.querySelectorAll(".btn-edit-deck").forEach((btn) => {
     btn.addEventListener("click", () => handleEditClick(btn.dataset.deckId));

--- a/js/features/events.js
+++ b/js/features/events.js
@@ -180,6 +180,19 @@ export function setupEventListeners() {
   if (state.elements.btnConfirmSplit) {
     state.elements.btnConfirmSplit.addEventListener('click', handleSplitConfirm);
   }
+  // When style switches to dots, cap count at 2
+  if (state.elements.splitStyle) {
+    state.elements.splitStyle.addEventListener('change', () => {
+      const isDots = state.elements.splitStyle.value === 'dots';
+      if (state.elements.splitCount) {
+        state.elements.splitCount.setAttribute('max', isDots ? '2' : '8');
+        if (isDots) {
+          const current = parseInt(state.elements.splitCount.value) || 2;
+          if (current > 2) state.elements.splitCount.value = '2';
+        }
+      }
+    });
+  }
 
   // Stripe starting corner preference
   if (state.elements.stripeStartCorner) {

--- a/js/features/events.js
+++ b/js/features/events.js
@@ -7,7 +7,7 @@ import { downloadCSV, downloadJSON, openPrintableGuide, downloadUndoneTxt, copyU
 import { showPreview, hidePreview, updatePosition, refreshOpenPreview } from '../modules/card-preview.js';
 import { handleDeckSubmit, resetDeckForm, updateColorSwatchSelection, checkColorWarning, handlePrismNameChange } from './deck-form.js';
 import { handleFileUpload, handleJsonImport, handleMoxfieldImport, handleEditFileUpload, handleEditUrlImport } from './deck-import.js';
-import { handleDeleteConfirm, handleEditConfirm, handleNewPrism, handleSplitConfirm } from './deck-list.js';
+import { handleDeleteConfirm, handleEditConfirm, handleNewPrism, handleSplitConfirm, handleEditGroupConfirm } from './deck-list.js';
 import { renderResults } from './results.js';
 import { renderOverlapMatrix } from './analysis.js';
 import { debounce } from '../core/utils.js';
@@ -169,6 +169,16 @@ export function setupEventListeners() {
         handleEditUrlImport();
       }
     });
+  }
+
+  // Edit group dialog
+  if (state.elements.btnCancelEditGroup) {
+    state.elements.btnCancelEditGroup.addEventListener('click', () => {
+      state.elements.editGroupDialog.removeAttribute('open');
+    });
+  }
+  if (state.elements.btnConfirmEditGroup) {
+    state.elements.btnConfirmEditGroup.addEventListener('click', handleEditGroupConfirm);
   }
 
   // Split dialog

--- a/js/features/init.js
+++ b/js/features/init.js
@@ -113,6 +113,14 @@ function getElements() {
     editImportError: document.getElementById('edit-import-error'),
     editImportSuccess: document.getElementById('edit-import-success'),
 
+    // Edit group dialog
+    editGroupDialog: document.getElementById('edit-group-dialog'),
+    editGroupId: document.getElementById('edit-group-id'),
+    editGroupName: document.getElementById('edit-group-name'),
+    editGroupColor: document.getElementById('edit-group-color'),
+    btnCancelEditGroup: document.getElementById('btn-cancel-edit-group'),
+    btnConfirmEditGroup: document.getElementById('btn-confirm-edit-group'),
+
     // Split dialog
     splitDialog: document.getElementById('split-dialog'),
     splitDeckId: document.getElementById('split-deck-id'),

--- a/js/modules/processor.js
+++ b/js/modules/processor.js
@@ -798,6 +798,25 @@ export function calculateRemovedCards(oldCards, newCards) {
 }
 
 /**
+ * Update a split group's name and/or sideAColor in a PRISM
+ * @param {Object} prism - The PRISM object
+ * @param {string} groupId - The split group ID
+ * @param {Object} updates - Fields to update (name, sideAColor)
+ * @returns {Object} Updated PRISM
+ */
+export function updateSplitGroupInPrism(prism, groupId, updates) {
+	const now = new Date().toISOString();
+	return {
+		...prism,
+		splitGroups: (prism.splitGroups || []).map((g) => {
+			if (g.id !== groupId) return g;
+			return { ...g, ...updates, updatedAt: now };
+		}),
+		updatedAt: now,
+	};
+}
+
+/**
  * Check if a card is still used in any other deck besides the specified one
  * @param {Object} prism - The PRISM object
  * @param {string} cardName - The card name to check

--- a/js/modules/processor.js
+++ b/js/modules/processor.js
@@ -187,22 +187,8 @@ export function processCards(prism) {
 						quantity: null,
 					});
 				}
-				// For stripes-style: emit Side B stripe immediately.
-				// For dots-style: deferred — emitted after the main loop based on partial membership.
-				const isDotStyle = (group.splitStyle || 'stripes') === 'dots';
-				if (!isDotStyle) {
-					cardData.stripes.push({
-						position: deck.stripePosition,
-						color: deck.color,
-						side: "b",
-						deckName: deck.name,
-						deckId: deck.id,
-						groupId: group.id,
-						bracket: deck.bracket,
-						quantity: card.quantity,
-						markType: 'stripe',
-					});
-				}
+				// Child variant marks are deferred to the post-loop pass below,
+				// where shared-vs-subset membership is known for the whole group.
 			} else {
 				// Standalone deck: single Side A stripe
 				cardData.stripes.push({
@@ -219,32 +205,86 @@ export function processCards(prism) {
 		}
 	}
 
-	// Dots-style split groups: emit dot entries for cards in a strict subset of variants.
-	// Cards in ALL variants of a group → no dot (Side A stripe is enough).
-	// Cards in a subset → one dot per variant the card is in, colored with that variant's color.
+	// Post-loop: emit child variant marks with full shared-vs-subset analysis.
+	// Both stripes-style and dots-style handled here (main loop only set Side A).
+	//
+	// Rules:
+	//   card in ALL children (isShared)   → parent stripe only; membership anchor per variant for deck-filter
+	//   subset, stripes-style             → child stripe (Side B, variant's own slot) per variant with card
+	//   subset, dots-style, 1 variant     → 1 dot (Side B at group's sideAPosition, variant color)
+	//   subset, dots-style, 2+ variants   → dot conflict (1-hole physical limit); membership per variant, parent only
 	for (const group of splitGroups) {
-		if ((group.splitStyle || 'stripes') !== 'dots') continue;
 		const variantDecks = group.childDeckIds
 			.map(id => decks.find(d => d.id === id))
 			.filter(Boolean);
+		const isDotStyle = (group.splitStyle || 'stripes') === 'dots';
+
 		for (const [, cardData] of cardMap) {
 			if (!cardData.sideAGroups.has(group.id)) continue; // Card not in this group at all
 			const variantsWithCard = variantDecks.filter(d => cardData.quantities.has(d.id));
 			const isShared = variantsWithCard.length === variantDecks.length;
-			for (const variantDeck of variantsWithCard) {
-				cardData.stripes.push({
-					position: group.sideAPosition,
-					color: variantDeck.color,
-					side: 'b',
-					deckName: variantDeck.name,
-					deckId: variantDeck.id,
-					groupId: group.id,
-					bracket: variantDeck.bracket,
-					quantity: cardData.quantities.get(variantDeck.id),
-					// Shared cards: membership entry only (carries deckId for filtering, not rendered visually)
-					// Subset cards: dot entry (rendered as colored dot above the Side A square)
-					markType: isShared ? 'membership' : 'dot',
-				});
+
+			if (isShared) {
+				// All children have this card — parent stripe only; membership anchors carry deckId for filtering
+				for (const variantDeck of variantsWithCard) {
+					cardData.stripes.push({
+						position: group.sideAPosition,
+						color: variantDeck.color,
+						side: 'b',
+						deckName: variantDeck.name,
+						deckId: variantDeck.id,
+						groupId: group.id,
+						bracket: variantDeck.bracket,
+						quantity: cardData.quantities.get(variantDeck.id),
+						markType: 'membership',
+					});
+				}
+			} else if (isDotStyle) {
+				if (variantsWithCard.length === 1) {
+					// Exactly one variant — emit dot
+					const variantDeck = variantsWithCard[0];
+					cardData.stripes.push({
+						position: group.sideAPosition,
+						color: variantDeck.color,
+						side: 'b',
+						deckName: variantDeck.name,
+						deckId: variantDeck.id,
+						groupId: group.id,
+						bracket: variantDeck.bracket,
+						quantity: cardData.quantities.get(variantDeck.id),
+						markType: 'dot',
+					});
+				} else {
+					// 2+ variants have this card — dot conflict; fall back to parent stripe only
+					for (const variantDeck of variantsWithCard) {
+						cardData.stripes.push({
+							position: group.sideAPosition,
+							color: variantDeck.color,
+							side: 'b',
+							deckName: variantDeck.name,
+							deckId: variantDeck.id,
+							groupId: group.id,
+							bracket: variantDeck.bracket,
+							quantity: cardData.quantities.get(variantDeck.id),
+							markType: 'membership',
+						});
+					}
+				}
+			} else {
+				// Stripes-style subset — child stripe per variant that has this card
+				for (const variantDeck of variantsWithCard) {
+					cardData.stripes.push({
+						position: variantDeck.stripePosition,
+						color: variantDeck.color,
+						side: 'b',
+						deckName: variantDeck.name,
+						deckId: variantDeck.id,
+						groupId: group.id,
+						bracket: variantDeck.bracket,
+						quantity: cardData.quantities.get(variantDeck.id),
+						markType: 'stripe',
+					});
+				}
 			}
 		}
 	}
@@ -824,6 +864,10 @@ export function splitDeck(prism, deckId, splitCount, splitStyle = 'stripes') {
 	const deck = prism.decks.find((d) => d.id === deckId);
 	if (!deck || deck.splitGroupId) return prism; // Can't split a deck that's already in a group
 
+	if (splitStyle === 'dots' && splitCount > 2) {
+		throw new Error('Dot groups support a maximum of 2 variants (one dot hole per card).');
+	}
+
 	// The original deck's position becomes the split group's Side A position
 	const group = createSplitGroup({
 		name: deck.name,
@@ -911,6 +955,10 @@ export function splitDeck(prism, deckId, splitCount, splitStyle = 'stripes') {
 export function addSplitToGroup(prism, groupId) {
 	const group = (prism.splitGroups || []).find((g) => g.id === groupId);
 	if (!group) return prism;
+
+	if ((group.splitStyle || 'stripes') === 'dots' && group.childDeckIds.length >= 2) {
+		throw new Error('Dot groups support a maximum of 2 variants (one dot hole per card).');
+	}
 
 	// Find an existing child to copy from (use the first one)
 	const templateDeck = prism.decks.find((d) => d.id === group.childDeckIds[0]);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Edit Group dialog to rename groups and pick a shared stripe color.
  * Split dialog now shows updated helper text and enforces style-aware variant limits (dots limited to 2).

* **Bug Fixes**
  * Prevent adding more variants than allowed for dot-style groups and clamp split counts when style changes.

* **Documentation**
  * Clarified split-group model and card-mark emission behavior (stripes, dots, membership) in docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->