### PR TITLE
feat: add SCRY-Mode full-screen card-marking session

### DIFF
--- a/build.html
+++ b/build.html
@@ -342,6 +342,11 @@
                 <wa-input id="results-search" placeholder="Search cards..." size="medium" style="max-width: 400px;">
                   <wa-icon slot="start" name="search"></wa-icon>
                 </wa-input>
+                <!-- SCRY-Mode launcher (hidden in Removed view) -->
+                <wa-button id="btn-scry" appearance="filled" variant="brand" size="small">
+                  <wa-icon slot="start" name="expand"></wa-icon>
+                  Scry-Mode
+                </wa-button>
               </div>
 
              
@@ -594,6 +599,16 @@
       </div>
       <div slot="footer">
         <wa-button id="stripe-reorder-cancel" variant="neutral" appearance="outlined">Cancel</wa-button>
+      </div>
+    </wa-dialog>
+
+    <!-- SCRY-Mode Dialog -->
+    <wa-dialog id="scry-dialog" label="Scry-Mode" style="--width: 100vw; --height: 100vh;">
+      <div id="scry-progress" class="wa-caption-m" style="text-align:center;padding-bottom:var(--wa-space-s);"></div>
+      <div id="scry-content" class="wa-stack wa-align-items-center" style="justify-content:center;min-height:200px;"></div>
+      <div slot="footer" class="wa-split" style="width:100%;">
+        <wa-button id="btn-scry-skip" appearance="outlined" variant="neutral">Skip</wa-button>
+        <wa-button id="btn-scry-done" appearance="filled" variant="success">Done</wa-button>
       </div>
     </wa-dialog>
 

--- a/js/features/deck-list.js
+++ b/js/features/deck-list.js
@@ -123,6 +123,27 @@ export function autoClearRemovedCards(newCards) {
 // Mark toggle
 // ============================================================================
 
+export function setCardMarked(cardKey, marked) {
+  if (!cardKey || !state.currentPrism) return;
+  if (!state.currentPrism.markedCards) state.currentPrism.markedCards = [];
+
+  if (marked) {
+    if (!state.currentPrism.markedCards.includes(cardKey)) {
+      state.currentPrism.markedCards.push(cardKey);
+    }
+  } else {
+    state.currentPrism.markedCards = state.currentPrism.markedCards.filter(
+      (c) => c !== cardKey,
+    );
+    recordUnmarkedCards(state.currentPrism.id, [cardKey]);
+  }
+
+  const now = new Date().toISOString();
+  state.currentPrism.updatedAt = now;
+  state.currentPrism.markedCardsUpdatedAt = now;
+  savePrism(state.currentPrism);
+}
+
 export function handleMarkToggle(event) {
   const checkbox = event.currentTarget;
   const row = checkbox.closest("tr");
@@ -136,27 +157,15 @@ export function handleMarkToggle(event) {
     return;
   }
 
-  if (!state.currentPrism.markedCards) state.currentPrism.markedCards = [];
-
   const isChecked = checkbox.checked;
 
   if (isChecked) {
-    if (!state.currentPrism.markedCards.includes(cardKey)) {
-      state.currentPrism.markedCards.push(cardKey);
-    }
     row.classList.add("marked-row");
   } else {
-    state.currentPrism.markedCards = state.currentPrism.markedCards.filter(
-      (c) => c !== cardKey,
-    );
     row.classList.remove("marked-row");
-    recordUnmarkedCards(state.currentPrism.id, [cardKey]);
   }
 
-  const now = new Date().toISOString();
-  state.currentPrism.updatedAt = now;
-  state.currentPrism.markedCardsUpdatedAt = now;
-  savePrism(state.currentPrism);
+  setCardMarked(cardKey, isChecked);
 
   // Full re-render when: undone filter active (marked row must disappear) OR
   // sort is by "marked" column (row order needs to update).

--- a/js/features/events.js
+++ b/js/features/events.js
@@ -9,6 +9,7 @@ import { handleDeckSubmit, resetDeckForm, updateColorSwatchSelection, checkColor
 import { handleFileUpload, handleJsonImport, handleMoxfieldImport, handleEditFileUpload, handleEditUrlImport } from './deck-import.js';
 import { handleDeleteConfirm, handleEditConfirm, handleNewPrism, handleSplitConfirm, handleEditGroupConfirm } from './deck-list.js';
 import { renderResults } from './results.js';
+import { openScryMode } from './scry-mode.js';
 import { renderOverlapMatrix } from './analysis.js';
 import { debounce } from '../core/utils.js';
 import { updatePreferences, getPreferences, savePrism, setColorScheme } from '../modules/storage.js';
@@ -68,9 +69,21 @@ export function setupEventListeners() {
     });
   }
 
+  // SCRY-Mode launch
+  if (state.elements.btnScry) {
+    state.elements.btnScry.addEventListener('click', openScryMode);
+  }
+
   // Results filter - use 'change' event for wa-radio-group
   if (state.elements.resultsFilter) {
-    state.elements.resultsFilter.addEventListener('change', renderResults);
+    state.elements.resultsFilter.addEventListener('change', () => {
+      // Hide SCRY button in Removed view (removed rows have no Done semantics)
+      if (state.elements.btnScry) {
+        const filter = state.elements.resultsFilter.value;
+        state.elements.btnScry.style.display = filter === 'removed' ? 'none' : '';
+      }
+      renderResults();
+    });
   }
   if (state.elements.resultsSearch) {
     state.elements.resultsSearch.addEventListener('input', debounce(renderResults, 150));

--- a/js/features/init.js
+++ b/js/features/init.js
@@ -11,6 +11,7 @@ import { logToSupabase } from '../modules/supabase-client.js';
 import { initColorSwatches } from './deck-form.js';
 import { renderDecksList } from './deck-list.js';
 import { setupStripeReorderDialog } from './stripe-reorder-dialog.js';
+import { setupScryMode } from './scry-mode.js';
 import { renderResults, updateRemovedFilterBadge } from './results.js';
 import { renderExport } from './export-view.js';
 import { setupEventListeners } from './events.js';
@@ -139,6 +140,14 @@ function getElements() {
     // Stripe reorder dialog
     stripeReorderDialog: document.getElementById('stripe-reorder-dialog'),
 
+    // SCRY-Mode
+    btnScry: document.getElementById('btn-scry'),
+    scryDialog: document.getElementById('scry-dialog'),
+    scryContent: document.getElementById('scry-content'),
+    scryProgress: document.getElementById('scry-progress'),
+    btnScrySkip: document.getElementById('btn-scry-skip'),
+    btnScryDone: document.getElementById('btn-scry-done'),
+
     // Sync status
     syncStatus: document.getElementById('sync-status'),
     btnSyncNow: document.getElementById('btn-sync-now'),
@@ -200,6 +209,7 @@ export async function init() {
   // Set up event listeners
   setupEventListeners();
   setupStripeReorderDialog();
+  setupScryMode();
   setupSyncStatus();
 
   debugLog('PRISM: Initialization complete');

--- a/js/features/results.js
+++ b/js/features/results.js
@@ -251,6 +251,9 @@ export function renderResults() {
   // Apply sorting
   displayCards = sortCards(displayCards, state.sortState.column, state.sortState.direction);
 
+  // Snapshot for SCRY-Mode — reflects exact list visible to user (all filters/sort applied)
+  state.resultsView = displayCards;
+
   // Render table header with sort indicators
   renderResultsHeader();
 

--- a/js/features/scry-mode.js
+++ b/js/features/scry-mode.js
@@ -1,0 +1,192 @@
+/**
+ * SCRY-Mode: full-screen one-card-at-a-time marking session.
+ */
+
+import { state } from '../core/state.js';
+import { showError } from '../core/notifications.js';
+import { buildCardWithStripes, createLoadingElement, createErrorElement } from '../modules/card-preview.js';
+import { prefetchCards } from '../modules/scryfall.js';
+import { setCardMarked } from './deck-list.js';
+import { renderResults, updateMarkedProgress } from './results.js';
+
+let scrySnapshot = [];
+let scryIndex = 0;
+
+function getScryCardKey(card) {
+  return card.isBasicByDeck ? `${card.displayName}|${card.deckName}` : card.name;
+}
+
+function computeScale() {
+  // Reserve ~160px for progress line + footer buttons + dialog chrome
+  const availH = window.innerHeight - 160;
+  const availW = window.innerWidth - 48;
+  const scaleH = availH / 340;
+  const scaleW = availW / 244;
+  return Math.min(2.0, Math.max(0.8, Math.min(scaleH, scaleW)));
+}
+
+function makeScaledWrapper(scale) {
+  const scaledW = Math.round(244 * scale);
+  const scaledH = Math.round(340 * scale);
+  const outer = document.createElement('div');
+  outer.style.cssText = `width:${scaledW}px;height:${scaledH}px;display:flex;align-items:center;justify-content:center;flex-shrink:0;`;
+  const inner = document.createElement('div');
+  inner.style.cssText = `transform:scale(${scale});transform-origin:center;flex-shrink:0;`;
+  outer.appendChild(inner);
+  return { outer, inner };
+}
+
+async function renderCurrentScryCard() {
+  const { scryProgress, scryContent, btnScryDone, btnScrySkip } = state.elements;
+  if (!scryProgress || !scryContent) return;
+
+  if (scrySnapshot.length === 0) return;
+
+  // Re-enable buttons (may have been disabled on completion)
+  if (btnScryDone) btnScryDone.removeAttribute('disabled');
+  if (btnScrySkip) btnScrySkip.removeAttribute('disabled');
+
+  if (scryIndex >= scrySnapshot.length) {
+    showCompletionState();
+    return;
+  }
+
+  const card = scrySnapshot[scryIndex];
+  const displayName = card.isBasicByDeck ? card.displayName : card.name;
+  scryProgress.textContent = `${scryIndex + 1} / ${scrySnapshot.length} — ${displayName}`;
+
+  const scale = computeScale();
+  scryContent.innerHTML = '';
+
+  // Show loading state
+  const { outer: loadOuter, inner: loadInner } = makeScaledWrapper(scale);
+  loadInner.appendChild(createLoadingElement());
+  scryContent.appendChild(loadOuter);
+
+  // Stale-check token
+  const capturedIndex = scryIndex;
+
+  try {
+    const cardName = card.isBasicByDeck ? card.displayName : card.name;
+    const stripes = card.stripes || [];
+    const el = await buildCardWithStripes(cardName, stripes);
+
+    if (scryIndex !== capturedIndex) return;
+
+    scryContent.innerHTML = '';
+    const { outer, inner } = makeScaledWrapper(scale);
+    inner.appendChild(el);
+    scryContent.appendChild(outer);
+  } catch (_err) {
+    if (scryIndex !== capturedIndex) return;
+
+    scryContent.innerHTML = '';
+    const { outer, inner } = makeScaledWrapper(scale);
+    inner.appendChild(createErrorElement('Image not available'));
+    scryContent.appendChild(outer);
+  }
+
+  // Prefetch next few cards so advance is snappy
+  const nextNames = scrySnapshot
+    .slice(scryIndex + 1, scryIndex + 4)
+    .map(c => c.isBasicByDeck ? c.displayName : c.name)
+    .filter(Boolean);
+  if (nextNames.length > 0) prefetchCards(nextNames).catch(() => {});
+}
+
+function showCompletionState() {
+  const { scryProgress, scryContent, btnScryDone, btnScrySkip } = state.elements;
+  if (scryProgress) scryProgress.textContent = 'All cards reviewed!';
+  if (scryContent) {
+    scryContent.innerHTML = '';
+    const wrap = document.createElement('div');
+    wrap.className = 'wa-stack wa-gap-m wa-align-items-center';
+    wrap.style.padding = 'var(--wa-space-2xl)';
+
+    const icon = document.createElement('wa-icon');
+    icon.setAttribute('name', 'check-circle');
+    icon.style.cssText = 'font-size:4rem;color:var(--wa-color-success-fill);';
+
+    const msg = document.createElement('p');
+    msg.className = 'wa-heading-m';
+    msg.textContent = 'All cards reviewed';
+
+    wrap.appendChild(icon);
+    wrap.appendChild(msg);
+    scryContent.appendChild(wrap);
+  }
+  if (btnScryDone) btnScryDone.setAttribute('disabled', '');
+  if (btnScrySkip) btnScrySkip.setAttribute('disabled', '');
+}
+
+function advance() {
+  scryIndex++;
+  renderCurrentScryCard();
+}
+
+function handleScryDone() {
+  if (scryIndex >= scrySnapshot.length) return;
+  const card = scrySnapshot[scryIndex];
+  const cardKey = getScryCardKey(card);
+  setCardMarked(cardKey, true);
+  updateMarkedProgress();
+  advance();
+}
+
+function handleScrySkip() {
+  if (scryIndex >= scrySnapshot.length) return;
+  advance();
+}
+
+function handleScryKeydown(e) {
+  const dialog = state.elements.scryDialog;
+  if (!dialog || !dialog.hasAttribute('open')) return;
+
+  switch (e.key) {
+    case 'ArrowRight':
+    case 's':
+      e.preventDefault();
+      handleScrySkip();
+      break;
+    case 'Enter':
+    case 'd':
+      e.preventDefault();
+      handleScryDone();
+      break;
+  }
+}
+
+export function openScryMode() {
+  const view = state.resultsView || [];
+  const filtered = view.filter(c => !c.isRemoved);
+
+  if (filtered.length === 0) {
+    showError('No cards to scry in the current view.');
+    return;
+  }
+
+  scrySnapshot = [...filtered];
+  scryIndex = 0;
+
+  if (state.elements.scryDialog) {
+    state.elements.scryDialog.setAttribute('open', '');
+  }
+
+  renderCurrentScryCard();
+}
+
+export function setupScryMode() {
+  const { btnScryDone, btnScrySkip, scryDialog } = state.elements;
+
+  if (btnScryDone) btnScryDone.addEventListener('click', handleScryDone);
+  if (btnScrySkip) btnScrySkip.addEventListener('click', handleScrySkip);
+
+  if (scryDialog) {
+    // Re-render results once when dialog closes to sync marked rows
+    scryDialog.addEventListener('wa-hide', () => {
+      renderResults();
+    });
+  }
+
+  document.addEventListener('keydown', handleScryKeydown);
+}

--- a/js/features/scry-mode.js
+++ b/js/features/scry-mode.js
@@ -17,12 +17,13 @@ function getScryCardKey(card) {
 }
 
 function computeScale() {
-  // Reserve ~160px for progress line + footer buttons + dialog chrome
+  // Reserve ~160px for progress line + footer buttons + dialog chrome.
+  // 0.85 factor prevents overflow inside WA dialog's own padding on mobile.
   const availH = window.innerHeight - 160;
   const availW = window.innerWidth - 48;
   const scaleH = availH / 340;
   const scaleW = availW / 244;
-  return Math.min(2.0, Math.max(0.8, Math.min(scaleH, scaleW)));
+  return Math.min(2.0, Math.max(0.8, Math.min(scaleH, scaleW))) * 0.85;
 }
 
 function makeScaledWrapper(scale) {

--- a/js/features/scry-mode.js
+++ b/js/features/scry-mode.js
@@ -77,7 +77,8 @@ async function renderCurrentScryCard() {
     const { outer, inner } = makeScaledWrapper(scale);
     inner.appendChild(el);
     scryContent.appendChild(outer);
-  } catch (_err) {
+  } catch (err) {
+    console.warn(`SCRY: failed to load card image for "${card.isBasicByDeck ? card.displayName : card.name}":`, err);
     if (scryIndex !== capturedIndex) return;
 
     scryContent.innerHTML = '';

--- a/js/modules/card-preview.js
+++ b/js/modules/card-preview.js
@@ -128,8 +128,16 @@ function createStripeOverlay(stripes) {
   return container;
 }
 
+// Build a card preview element (image + stripe overlay) by fetching from Scryfall.
+// Returns a 244×340 .card-preview-container — caller is responsible for scaling.
+export async function buildCardWithStripes(cardName, stripes) {
+  const data = await fetchCard(frontFaceName(cardName));
+  if (!data.image_uri) throw new Error('No image available');
+  return createPreviewElement(data.image_uri, stripes);
+}
+
 // Create loading placeholder
-function createLoadingElement() {
+export function createLoadingElement() {
   const container = document.createElement('div');
   container.className = 'card-preview-container card-preview-loading';
 
@@ -141,7 +149,7 @@ function createLoadingElement() {
 }
 
 // Create error placeholder
-function createErrorElement(message) {
+export function createErrorElement(message) {
   const container = document.createElement('div');
   container.className = 'card-preview-container card-preview-error';
 


### PR DESCRIPTION
Opens a wa-dialog showing one card at a time from the current results view (respecting all active filters, search, sort). Done marks the card via the shared setCardMarked helper and auto-advances; Skip advances without marking. Keyboard shortcuts: d/Enter=Done, s/ArrowRight=Skip.

- extract setCardMarked() from handleMarkToggle so the mark write path is shared (tombstone + save stay byte-identical to the checkbox path)
- store state.resultsView after sort in renderResults() so SCRY always reflects the exact ordered/filtered list the user sees
- export buildCardWithStripes, createLoadingElement, createErrorElement from card-preview.js for use in the SCRY renderer
- new js/features/scry-mode.js: snapshot iteration, stale-async guard, responsive CSS scale (fits viewport with margin for header/footer), prefetch of next few cards, completion state, wa-hide re-render
- btn-scry hidden in Removed view; scry-dialog is 100vw x 100vh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Scry-Mode: a full-screen, one-card-at-a-time review interface for efficient deck examination
  * Added keyboard shortcuts while reviewing: Enter/d to mark as reviewed, s/Arrow Right to skip
  * Implemented auto-prefetching of upcoming card images for seamless navigation
  * Progress tracking shows completion status during card review sessions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->