### PR TITLE
feat(a11y): number sparse stripes and add card-preview reference ruler

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -607,6 +607,34 @@ wa-page[view='desktop'] [data-toggle-nav] {
   right: auto;
 }
 
+/* Reference ruler — faint tick + number at every 5th slot down a card edge,
+   drawn even on empty slots so any lone stripe can be located by eye. */
+.stripe-ruler-tick {
+  position: absolute;
+  right: 0px;
+  width: 10px;
+  height: 1px;
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 0 2px rgba(0, 0, 0, 0.9);
+}
+
+.stripe-ruler-tick-left {
+  right: auto;
+  left: 0px;
+}
+
+.stripe-ruler-num {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 9px;
+  font-weight: 600;
+  line-height: 1;
+  color: rgba(255, 255, 255, 0.85);
+  text-shadow: 0 0 2px #000, 0 0 3px #000;
+  pointer-events: none;
+}
+
 /* Card name hover cursor */
 .card-name-cell {
   cursor: pointer;

--- a/js/core/utils.js
+++ b/js/core/utils.js
@@ -35,6 +35,25 @@ export function debounce(fn, ms = 150) {
 const SLOTS_PER_SIDE = 24;
 // Anchor marker every Nth slot within each side.
 const STRIPE_POSITION_ANCHOR_INTERVAL = 5;
+// A card with this many or fewer visible marks is "sparse": every mark gets its
+// exact slot number (not just anchors), since a lone stripe has no neighbours to
+// count against. "Fewer than 6 marks" per the design decision.
+export const STRIPE_SPARSE_MAX = 5;
+
+function isValidPosition(position) {
+  return Number.isFinite(position) && position >= 1 && position <= SLOTS_PER_SIDE * 2;
+}
+
+/**
+ * Side-relative slot number (1-24) for any valid 1-48 position, or null.
+ * Side A is 1-24, Side B is 25-48 → both map back to 1-24 on their own edge.
+ * @param {number} position - Stripe position 1-48
+ * @returns {string|null} Exact label string (e.g. "13") or null
+ */
+export function slotNumberLabel(position) {
+  if (!isValidPosition(position)) return null;
+  return String(position > SLOTS_PER_SIDE ? position - SLOTS_PER_SIDE : position);
+}
 
 /**
  * Side-relative slot number to overlay at "anchor" positions — every 5th slot
@@ -46,9 +65,32 @@ const STRIPE_POSITION_ANCHOR_INTERVAL = 5;
  * @returns {string|null} Label string (e.g. "10") or null
  */
 export function stripePositionLabel(position) {
-  if (!Number.isFinite(position) || position < 1 || position > SLOTS_PER_SIDE * 2) return null;
+  if (!isValidPosition(position)) return null;
   const sideRelative = position > SLOTS_PER_SIDE ? position - SLOTS_PER_SIDE : position;
   return sideRelative % STRIPE_POSITION_ANCHOR_INTERVAL === 0 ? String(sideRelative) : null;
+}
+
+/**
+ * Count a card's visible marks (stripes + dots), excluding invisible
+ * 'membership' anchors which only carry deckId for deck-filter matching.
+ * @param {Array} stripes - card.stripes
+ * @returns {number}
+ */
+export function countVisibleMarks(stripes) {
+  if (!Array.isArray(stripes)) return 0;
+  return stripes.reduce((n, s) => (s.markType !== 'membership' ? n + 1 : n), 0);
+}
+
+/**
+ * Resolve the slot-number label for a stripe given whether the card is sparse.
+ * Sparse → exact number on every mark (always-on). Otherwise → anchor label
+ * (caller still gates this branch on the showStripePositionNumbers preference).
+ * @param {number} position - Stripe position 1-48
+ * @param {{ exact: boolean }} opts
+ * @returns {string|null}
+ */
+export function stripeNumberLabel(position, { exact } = {}) {
+  return exact ? slotNumberLabel(position) : stripePositionLabel(position);
 }
 
 export function escapeHtml(text) {

--- a/js/features/results.js
+++ b/js/features/results.js
@@ -3,7 +3,7 @@
  */
 
 import { state } from '../core/state.js';
-import { escapeHtml, stripePositionLabel } from '../core/utils.js';
+import { escapeHtml, stripeNumberLabel, countVisibleMarks, STRIPE_SPARSE_MAX } from '../core/utils.js';
 import { getPreferences } from '../modules/storage.js';
 import { processCards, formatSlotLabel } from '../modules/processor.js';
 import { prefetchCards } from '../modules/scryfall.js';
@@ -41,27 +41,27 @@ function stripeSignature(card) {
     .join(',');
 }
 
-// Position-number overlay for an anchor slot (every 5th slot per side), or ''.
-function positionNumHtml(position, showNums, muted = false) {
-  if (!showNums) return '';
-  const label = stripePositionLabel(position);
+// Slot-number overlay. Sparse cards (`exact`) number every mark with its exact
+// slot; otherwise only anchor slots (5/10/15/20) show, gated on `showNums`.
+function positionNumHtml(position, { showNums, exact }, muted = false) {
+  const label = (exact || showNums) ? stripeNumberLabel(position, { exact }) : null;
   if (!label) return '';
   return `<span class="stripe-pos-num${muted ? ' stripe-pos-num-muted' : ''}">${label}</span>`;
 }
 
 // Render a single stripe square (no dots).
-function renderSquare(s, showNums) {
+function renderSquare(s, opts) {
   return `<div
     class="stripe-indicator${s.side === 'b' ? ' stripe-side-b' : ''}"
     style="background-color: ${s.color};"
     title="${formatSlotLabel(s.position)}: ${escapeHtml(s.deckName)}"
-  >${positionNumHtml(s.position, showNums)}</div>`;
+  >${positionNumHtml(s.position, opts)}</div>`;
 }
 
 // Render a slot: if it has dots, use ö-style (dot row above square).
-function renderSlot(slot, showNums) {
+function renderSlot(slot, opts) {
   if (slot.dots.length === 0) {
-    return slot.square ? renderSquare(slot.square, showNums) : '';
+    return slot.square ? renderSquare(slot.square, opts) : '';
   }
   const dotsHtml = slot.dots.map(d => `<div
     class="stripe-indicator stripe-dot-indicator"
@@ -70,8 +70,8 @@ function renderSlot(slot, showNums) {
   ></div>`).join('');
   const slotPos = slot.square ? slot.square.position : slot.dots[0]?.position;
   const squareHtml = slot.square
-    ? renderSquare(slot.square, showNums)
-    : `<div class="stripe-indicator stripe-empty">${positionNumHtml(slotPos, showNums, true)}</div>`;
+    ? renderSquare(slot.square, opts)
+    : `<div class="stripe-indicator stripe-empty">${positionNumHtml(slotPos, opts, true)}</div>`;
   return `<div class="stripe-slot"><div class="slot-dot-row">${dotsHtml}</div>${squareHtml}</div>`;
 }
 
@@ -300,6 +300,11 @@ export function renderResults() {
 
     let stripeIndicators;
 
+    // Sparse cards number every mark with its exact slot (always-on); dense
+    // cards fall back to the toggle-gated anchor numbering.
+    const exact = countVisibleMarks(card.stripes) <= STRIPE_SPARSE_MAX;
+    const opts = { showNums, exact };
+
     if (showAllSlots && totalDecks > 0) {
       // Collect all used positions (deck positions + split group Side A positions)
       const allPositions = [...new Set([
@@ -312,12 +317,14 @@ export function renderResults() {
       for (const pos of allPositions) {
         const slot = slotMap.get(pos);
         if (slot) {
-          stripeIndicators += renderSlot(slot, showNums);
+          stripeIndicators += renderSlot(slot, opts);
         } else {
+          // Empty reference slots only ever show the anchor ruler number, never
+          // an "exact" number (they are not this card's marks).
           stripeIndicators += `<div
             class="stripe-indicator stripe-empty"
             title="${formatSlotLabel(pos)}: Empty"
-          >${positionNumHtml(pos, showNums, true)}</div>`;
+          >${positionNumHtml(pos, { showNums, exact: false }, true)}</div>`;
         }
       }
     } else {
@@ -325,7 +332,7 @@ export function renderResults() {
       const slotMap = buildSlotMap(card.stripes);
       stripeIndicators = '';
       for (const [, slot] of slotMap) {
-        stripeIndicators += renderSlot(slot, showNums);
+        stripeIndicators += renderSlot(slot, opts);
       }
     }
 

--- a/js/modules/card-preview.js
+++ b/js/modules/card-preview.js
@@ -2,7 +2,7 @@
 
 import { fetchCard } from './scryfall.js';
 import { getPreferences } from './storage.js';
-import { stripePositionLabel } from '../core/utils.js';
+import { stripeNumberLabel, countVisibleMarks, STRIPE_SPARSE_MAX } from '../core/utils.js';
 
 // Strip back-face name from DFCs for Scryfall lookup
 // "Bala Ged Recovery // Bala Ged Sanctuary" → "Bala Ged Recovery"
@@ -53,12 +53,44 @@ function getStripeEdge(position, sideARight) {
   return { onRight };
 }
 
+// Anchor positions (every 5th slot per side) used for the reference ruler.
+// Side A side-relative 5/10/15/20 → positions 5/10/15/20; Side B → 29/34/39/44.
+const RULER_ANCHORS = [5, 10, 15, 20, 29, 34, 39, 44];
+
+// Draw a faint tick + number at every 5th slot down both card edges, regardless
+// of which slots the card actually marks — a permanent ruler so any lone stripe
+// can be located by eye. Gated on the showStripePositionNumbers preference.
+function appendRulerGuides(container, sideARight, topDown) {
+  for (const pos of RULER_ANCHORS) {
+    const { onRight } = getStripeEdge(pos, sideARight);
+    const y = getStripeY(pos, topDown);
+
+    const tick = document.createElement('div');
+    tick.className = `stripe-ruler-tick${onRight ? '' : ' stripe-ruler-tick-left'}`;
+    tick.style.top = `${y}px`;
+
+    const num = document.createElement('span');
+    num.className = 'stripe-ruler-num';
+    num.textContent = stripeNumberLabel(pos, { exact: true });
+    if (onRight) num.style.right = '26px';
+    else num.style.left = '26px';
+    tick.appendChild(num);
+
+    container.appendChild(tick);
+  }
+}
+
 // Create stripe overlay element
 function createStripeOverlay(stripes) {
   const container = document.createElement('div');
   container.className = 'card-preview-stripes';
   const { sideARight, topDown } = getCornerConfig();
   const showNums = !!getPreferences().showStripePositionNumbers;
+  // Sparse cards number every stripe with its exact slot (always-on).
+  const exact = countVisibleMarks(stripes) <= STRIPE_SPARSE_MAX;
+
+  // Permanent reference ruler down both edges when the counting aid is on.
+  if (showNums) appendRulerGuides(container, sideARight, topDown);
 
   // Build per-group dot local indices for offset computation
   const groupDotCounters = new Map();
@@ -109,17 +141,17 @@ function createStripeOverlay(stripes) {
     const sideLabel = stripe.position > SLOTS_PER_SIDE ? 'Side B' : 'Side A';
     mark.title = `${stripe.deckName} (${sideLabel} · Slot ${stripe.position})`;
 
-    if (showNums) {
-      const label = stripePositionLabel(stripe.position);
-      if (label) {
-        const num = document.createElement('span');
-        num.className = 'stripe-mark-num';
-        num.textContent = label;
-        // Sit just inboard of the stripe's edge.
-        if (onRight) num.style.right = '26px';
-        else num.style.left = '26px';
-        mark.appendChild(num);
-      }
+    // Sparse cards label every stripe exactly (always-on); dense cards label
+    // only anchor stripes, and only when the counting aid is on.
+    const label = (exact || showNums) ? stripeNumberLabel(stripe.position, { exact }) : null;
+    if (label) {
+      const num = document.createElement('span');
+      num.className = 'stripe-mark-num';
+      num.textContent = label;
+      // Sit just inboard of the stripe's edge.
+      if (onRight) num.style.right = '26px';
+      else num.style.left = '26px';
+      mark.appendChild(num);
     }
 
     container.appendChild(mark);

--- a/js/modules/export.js
+++ b/js/modules/export.js
@@ -4,7 +4,7 @@
  */
 
 import { processCards, getColorName, formatSlotLabel } from './processor.js';
-import { stripePositionLabel } from '../core/utils.js';
+import { stripeNumberLabel, countVisibleMarks, STRIPE_SPARSE_MAX } from '../core/utils.js';
 import { getPreferences } from './storage.js';
 
 /**
@@ -233,9 +233,10 @@ export function generatePrintableGuide(prism) {
   const splitGroups = prism.splitGroups || [];
   // Read the counting-aid pref at generation time (no live re-render needed).
   const showNums = !!getPreferences().showStripePositionNumbers;
-  const posNum = (position) => {
-    if (!showNums) return '';
-    const label = stripePositionLabel(position);
+  // Sparse cards (`exact`) number every mark with its exact slot, always-on;
+  // dense cards only show the anchor numbers when the pref is on.
+  const posNum = (position, exact) => {
+    const label = (exact || showNums) ? stripeNumberLabel(position, { exact }) : null;
     return label ? `<div class="stripe-pos-num">${label}</div>` : '';
   };
 
@@ -477,6 +478,10 @@ export function generatePrintableGuide(prism) {
       dotsByPos.get(s.position).push(s);
     }
 
+    // Sparse cards number every mark with its exact slot; only the card's own
+    // marked positions get the exact treatment (empty reference slots don't).
+    const cardIsSparse = countVisibleMarks(card.stripes) <= STRIPE_SPARSE_MAX;
+
     let stripeIndicators = '';
     for (const pos of allPositions) {
       const stripe = stripeMap.get(pos);
@@ -491,7 +496,8 @@ export function generatePrintableGuide(prism) {
         squareHtml = `<div class="stripe-empty" title="${formatSlotLabel(pos)}: Empty"></div>`;
       }
 
-      stripeIndicators += `<div class="stripe-slot">${dotRow}${squareHtml}${posNum(pos)}</div>`;
+      const isCardMark = !!stripe || dots.length > 0;
+      stripeIndicators += `<div class="stripe-slot">${dotRow}${squareHtml}${posNum(pos, cardIsSparse && isCardMark)}</div>`;
     }
 
     html += `


### PR DESCRIPTION
Builds on PR #88 (`showStripePositionNumbers`) so a sparse stripe layout is locatable — a lone stripe in slot 13 was previously almost impossible to place, since PR #88's anchors only label a slot when a stripe *coincides* with 5/10/15/20, and the collapsed results table renders only filled slots (no neighbours to count against).

## What changed

**1. Sparse exact numbering — always-on**
When a card has **fewer than 6 visible marks** (`STRIPE_SPARSE_MAX = 5`), every mark is labelled with its exact side-relative slot number, regardless of the toggle. Applied to all three surfaces:
- **Results table** — even the default collapsed view (filled slots only); a lone square reads `13`.
- **Card preview** — exact number inboard of each stripe.
- **Printable guide** — exact number under each marked square.

Dense cards (6+ marks) keep PR #88's toggle-gated anchor numbers (5/10/15/20) so they don't get cluttered.

**2. Reference ruler in the card preview — toggle-gated**
When **Show stripe position numbers** is on, faint tick + number guides are drawn at every 5th slot down **both** card edges, always (even on empty slots), so any stripe is locatable against fixed marks — a stripe at 13 reads clearly between the `10` and `15` ticks.

## Implementation notes
- New shared helpers in `js/core/utils.js` (`slotNumberLabel`, `stripeNumberLabel`, `countVisibleMarks`, `STRIPE_SPARSE_MAX`) keep the three surfaces in parity, the same way PR #88 centralized `stripePositionLabel`.
- Pure render-time logic — **no** storage / schema / preferences-shape changes; reuses the existing `showStripePositionNumbers` preference.

## Verification
- `node --check` passes on all edited modules; app serves cleanly on the dev server.
- Unit-checked the label/count helpers: exact numbers, Side B mapping (e.g. slot 38 → `14`), anchor gating, and membership-anchor exclusion — all pass.

## Files
- `js/core/utils.js` — shared helpers + threshold constant
- `js/features/results.js` — per-card sparse flag threaded through slot rendering
- `js/modules/export.js` — per-card sparse flag in the printable guide
- `js/modules/card-preview.js` — sparse exact stripe numbers + reference ruler
- `css/custom.css` — ruler tick/number styles

## Not included (pending your call)
- A text-caption locator for **dense** cards (e.g. `Slots: A13, A22, B38`) — the "something else" option, left out until confirmed.
- Anchor-outline emphasis in the "show all slots" table view.

https://claude.ai/code/session_013K3QQtArHtqKT5NyvrEHDa

---
_Generated by [Claude Code](https://claude.ai/code/session_013K3QQtArHtqKT5NyvrEHDa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reference ruler overlay with tick marks and position numbers to card previews for improved stripe position identification.

* **Style**
  * Enhanced visual styling for ruler overlay elements on card and stripe preview displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->