### PR TITLE
fix: copy and markup corrections from beta review

### DIFF
--- a/build.html
+++ b/build.html
@@ -154,11 +154,12 @@
                   </wa-radio-group>
 
                   <div class="wa-flank wa-align-items-start">
-                    <div class="wa-stack wa-gap-xs style="--flank-size:175px;">
+                    <div class="wa-stack wa-gap-xs" style="--flank-size:175px;">
                       <label class="wa-caption-m">Current Marker</label>
                         <input type="color" id="deck-color" value="#ecc933" title="Pick a custom color" style="width: 40px; height: 32px; border: 2px dashed var(--wa-color-neutral-stroke); border-radius: var(--wa-border-radius-m); cursor: pointer;" />
                         <div id="color-warning" class="wa-caption-s" style="color: var(--wa-color-warning-text); display: none;">
                           <wa-icon name="triangle-exclamation" style="font-size: 0.9em;"></wa-icon>
+                          <span></span>
                         </div>
                     </div>
                     <div class="wa-stack wa-gap-xs">
@@ -234,12 +235,12 @@
           <wa-tab-panel name="results">
             <div class="wa-stack wa-gap-l">
               <!-- Marking prerequisites at the point of action -->
-              <wa-card id="marking-prereq-callout" >
+              <wa-card id="marking-prereq-callout" style="display: none;">
               <div class="wa-flank:end"   >
                   <div class="wa-stack wa-gap-xs">
-                <strong>Finalize your decks before you start marking.</strong>Mid-session edits lead to confusion, so make changes after your marking pass.
+                <strong>Finalize your decks before you start marking.</strong> Mid-session edits lead to confusion, so make changes after your marking pass.
                 <br />
-                <strong>Remember:</strong>Marks go on the inner Perfect Fit sleeve, double-sleeved inside an outer sleeve which protects the mark.<br />
+                <strong>Remember:</strong> Marks go on the inner Perfect Fit sleeve, double-sleeved inside an outer sleeve which protects the mark.<br />
                     <span>Read the <a href="guide.html">marking guide</a> first.</span>
                     </div>
                 <wa-button slot="action" id="marking-prereq-dismiss" appearance="filled-outlined" size="small">
@@ -332,11 +333,11 @@
                   </div>
                 </wa-dropdown>
                 <!--Results-->
-                <wa-radio-group id="results-filter" orientation="horizontal" value="all" size="s">
-                  <wa-radio appearance="button" value="all" size="s">All Cards</wa-radio>
-                  <wa-radio appearance="button" value="shared" size="s">POOL</wa-radio>
-                  <wa-radio appearance="button" value="basics-by-deck" size="s">Basics by Deck</wa-radio>
-                  <wa-radio appearance="button" value="removed" id="removed-filter-btn" size="s">Removed</wa-radio>
+                <wa-radio-group id="results-filter" orientation="horizontal" value="all" size="small">
+                  <wa-radio appearance="button" value="all" size="small">All Cards</wa-radio>
+                  <wa-radio appearance="button" value="shared" size="small">POOL</wa-radio>
+                  <wa-radio appearance="button" value="basics-by-deck" size="small">Basics by Deck</wa-radio>
+                  <wa-radio appearance="button" value="removed" id="removed-filter-btn" size="small">Removed</wa-radio>
                 </wa-radio-group>
                 <!-- Search -->
                 <wa-input id="results-search" placeholder="Search cards..." size="medium" style="max-width: 400px;">
@@ -345,7 +346,7 @@
                 <!-- SCRY-Mode launcher (hidden in Removed view) -->
                 <wa-button id="btn-scry" appearance="filled" variant="brand" size="small">
                   <wa-icon slot="start" name="expand"></wa-icon>
-                  Scry-Mode
+                  SCRY-Mode
                 </wa-button>
               </div>
 
@@ -603,7 +604,7 @@
     </wa-dialog>
 
     <!-- SCRY-Mode Dialog -->
-    <wa-dialog id="scry-dialog" label="Scry-Mode" style="--width: 100vw; --height: 100vh;">
+    <wa-dialog id="scry-dialog" label="SCRY-Mode" style="--width: 100vw; --height: 100vh;">
       <div id="scry-progress" class="wa-caption-m" style="text-align:center;padding-bottom:var(--wa-space-s);"></div>
       <div id="scry-content" class="wa-stack wa-align-items-center" style="justify-content:center;min-height:200px;"></div>
       <div slot="footer" class="wa-split" style="width:100%;">

--- a/guide.html
+++ b/guide.html
@@ -39,7 +39,7 @@ Share your staples across every deck. PRISM tracks what goes where so you don't 
         <section class="wa-stack wa-gap-m" style="padding-block: var(--wa-space-xl);">
           <h2 class="wa-heading-xl">How PRISM Marks Work</h2>
           <p>PRISM uses colored marks on the edge of your sleeves to show which decks a card belongs to. Whether you mark the left or right edge depends on how you fan your cards. Pick whichever side is visible when you fan, and stay consistent.</p>
-          <p>Each deck gets a unique color (choose from 23 defaults or set your own) and a stripe position (1 through 48 along the sleeve edge). Fan your cards and you can see at a glance which decks each card belongs to.</p>
+          <p>Each deck gets a unique color (choose from 22 defaults or set your own) and a stripe position (1 through 48 along the sleeve edge). Fan your cards and you can see at a glance which decks each card belongs to.</p>
         </section>
 
         <wa-divider></wa-divider>
@@ -138,7 +138,7 @@ Share your staples across every deck. PRISM tracks what goes where so you don't 
           <wa-callout variant="brand" appearance="outlined">
             <wa-icon slot="icon"  name="handshake-angle"></wa-icon>
               <strong>Use the Spirit Guide.</strong><br />
-              A marking jig with position guides makes the process faster and more consistent. It holds the sleeve in place so you can add all colors for that card at once rather than batching by color. Find the 3D-printable STL on the <a href="tools.html">Tools page</a>.
+              A marking jig with position guides makes the process faster and more consistent. It holds the sleeve in place so you can add all colors for that card at once rather than batching by color. The 3D-printable STL is coming to the <a href="tools.html">Tools page</a> — until then, any straight-edge jig or ruler works.
           </wa-callout>
 
           <div class="wa-stack wa-gap-m">
@@ -196,15 +196,15 @@ Share your staples across every deck. PRISM tracks what goes where so you don't 
             <h3 class="wa-heading-m">Split styles</h3>
             <p>You have two options for how variants are marked on Side B:</p>
             <ul style="padding-left: var(--wa-space-xl); line-height: 1.8;">
-              <li><strong>Stripes.</strong> Each variant gets a unique color stripe on the opposite edge of the sleeve. Clear and easy to read, but uses more stripe positions.</li>
-              <li><strong>Dots.</strong> Variant 1 gets no dot (just the shared Side A stripe). Variant 2 gets one colored dot next to the Side A stripe. Variant 3 gets two dots. Keeps everything on one edge but requires closer inspection.</li>
+              <li><strong>Stripes.</strong> Each variant gets a unique color stripe on the opposite edge of the sleeve (2-8 variants). A card in <em>all</em> variants keeps only the shared Side A stripe; a card in a subset of variants also gets each matching variant's Side B stripe. Clear and easy to read, but uses more stripe positions.</li>
+              <li><strong>Dots.</strong> Limited to exactly 2 variants (one dot hole per card). A card in <em>both</em> variants keeps only the shared Side A stripe — no dot. A card in just one variant gets a single dot in that variant's color next to the Side A stripe. Keeps everything on one edge and uses no extra stripe positions, but requires closer inspection.</li>
             </ul>
-            <p>Pick stripes if you have 2-3 variants and plenty of unused positions. Pick dots if you're running tight on positions or want to keep all marks on one edge.</p>
+            <p>Pick stripes if you have 3 or more variants or plenty of unused positions. Pick dots for exactly two variants when you're running tight on positions or want to keep all marks on one edge.</p>
           </div>
 
           <div class="wa-stack wa-gap-m">
             <h3 class="wa-heading-m">Creating a split</h3>
-            <p>On the Decks tab, click the split icon on any deck card. Choose how many variants you want (2-8) and which split style to use. Each variant gets its own card list, commander, and bracket rating. Cards shared across all variants keep the parent's Side A mark. Cards unique to a variant get both Side A and their variant's Side B mark.</p>
+            <p>On the Decks tab, click the split icon on any deck card. Choose which split style to use and how many variants you want (2-8 for stripes, exactly 2 for dots). Each variant gets its own card list, commander, and bracket rating. Cards shared across all variants keep the parent's Side A mark. Cards unique to a variant get both Side A and their variant's Side B mark.</p>
           </div>
         </section>
 
@@ -222,12 +222,12 @@ Share your staples across every deck. PRISM tracks what goes where so you don't 
 
           <div class="wa-stack wa-gap-m">
             <h3 class="wa-heading-m">Bulk reordering</h3>
-            <p>The Export tab has a dropdown list that lets you reorder multiple decks at once. Drag decks up or down in the list to rearrange their stripe positions.</p>
+            <p>The Export tab has a position list that lets you reorder multiple decks at once. Pick a new slot from each deck's dropdown, or use the up/down buttons to swap a deck with its neighbour.</p>
           </div>
 
           <div class="wa-stack wa-gap-m">
             <h3 class="wa-heading-m">Stripe starting corner</h3>
-            <p>By default, stripe position 1 starts at the top of the sleeve edge. In the deck settings, you can change the starting corner to top-left, top-right, bottom-left, or bottom-right. This affects the card preview display but not your stored data. Pick whichever corner is most visible when you fan your cards and don't change it after you've started marking.</p>
+            <p>By default, stripe position 1 starts at the top-right corner of the sleeve. In Stripe Settings on the Decks tab, you can change the starting corner to top-left, top-right, bottom-left, or bottom-right. Applying the change renumbers every deck's slot so Slot 1 sits at the chosen corner — each mark stays at the same physical spot on the sleeve, only the numbering shifts. Pick whichever corner is most visible when you fan your cards and don't change it after you've started marking.</p>
           </div>
         </section>
 
@@ -284,7 +284,7 @@ Share your staples across every deck. PRISM tracks what goes where so you don't 
           <h2 class="wa-heading-xl">Managing Multiple PRISMs</h2>
           <p>If you have more decks than a single PRISM can hold (up to 48 with stripe splits, or 96 with dot splits), or if you want to organize your collection into separate groups, create multiple PRISMs.</p>
           <p>Each PRISM is independent: its own deck list, its own stripe positions, its own marking guide. You might separate by sleeve color (all black-sleeved decks in one PRISM, all colored sleeves in another), by power level, or by format once non-Commander formats are supported.</p>
-          <p>Switch between PRISMs from the header. Your current PRISM is always auto-saved before switching.</p>
+          <p>Switch between PRISMs from the My PRISMs page. Your current PRISM is always auto-saved before switching.</p>
         </section>
 
         <wa-divider></wa-divider>

--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
             <div class="wa-stack wa-gap-s wa-align-items-center" style="text-align: center;">
               <div style="font-size: 3rem;"><wa-icon name="3"></wa-icon></div>
               <h3 class="wa-heading-m">Mark your sleeves</h3>
-              <p>Export a printable marking guide. Use paint pens and the Spirit Guide tool to mark each sleeve edge. Mark the <strong>inner Perfect Fit sleeve</strong> (double-sleeved), never the outer. Fan your cards to find any deck instantly.</p>
+              <p>Export a printable marking guide. Use paint pens and the Spirit Guide marking jig to mark each sleeve edge. Mark the <strong>inner Perfect Fit sleeve</strong> (double-sleeved), never the outer. Fan your cards to find any deck instantly.</p>
             </div>
           </div>
         </section>
@@ -145,7 +145,7 @@
 
           <wa-details>
             <span slot="summary" class="wa-heading-m">What about basic lands?</span>
-            <p>Basics aren't singleton, so PRISM tracks the maximum quantity you need across all decks. If Deck A needs 12 Islands and Deck B needs 5, you need 12 total. All 12 get Deck A's mark. 8 of them also get Deck B's mark. The "Basics by Deck" filter shows the exact count for each deck.</p>
+            <p>Basics aren't singleton, so PRISM tracks the maximum quantity you need across all decks. If Deck A needs 12 Islands and Deck B needs 5, you need 12 total. All 12 get Deck A's mark. 5 of them also get Deck B's mark. The "Basics by Deck" filter shows the exact count for each deck.</p>
           </wa-details>
 
           <wa-details>
@@ -165,7 +165,7 @@
 
           <wa-details>
             <span slot="summary" class="wa-heading-m">Where is my data stored?</span>
-            <p>All PRISM data is stored locally in your browser. Nothing is sent to any server. You can export your data as JSON anytime for backup or to move between devices.</p>
+            <p>PRISM is local-first: your decks and marks are stored in your browser and work without an account. If you create an account, your PRISMs also sync to our database so you can use them across devices. We use privacy-respecting aggregate analytics — see the <a href="privacy.html">Privacy Policy</a> for details. You can export your data as JSON anytime for backup or to move between devices.</p>
           </wa-details>
 
           <wa-details>


### PR DESCRIPTION
Tier 1 copy/markup fixes from the beta review report.

**build.html**
- Repair malformed `class` attribute on the color-picker block (missing closing quote swallowed the style)
- Add the missing `<span>` inside `#color-warning` so the duplicate-color message can actually render
- Default-hide the marking-prereq callout so dismissal persists across reloads
- Fix missing spaces after `<strong>` tags ("marking.Mid-session" → "marking. Mid-session")
- `size="s"` → `size="small"` on the results filter radios
- "Scry-Mode" → "SCRY-Mode" (button + dialog label)

**index.html**
- Basic-lands FAQ math: Deck B needs 5, so 5 (not 8) also get its mark
- Data-storage FAQ rewritten to match reality (local-first + optional account sync + analytics) instead of "Nothing is sent to any server"
- Spirit Guide introduced as a "marking jig" on first mention

**guide.html**
- Dot-variant section rewritten to match the implemented system (2-variant cap, dot = subset membership in the variant's color) — the old text described count-based dots that would cause mis-marked sleeves
- Starting-corner paragraph corrected: Apply renumbers stored slots (marks stay put physically)
- Bulk reorder described as dropdown + up/down buttons (no drag exists)
- STL reference softened to "coming to the Tools page"
- 22 default colors (was "23")
- PRISM switching happens on the My PRISMs page (was "from the header")

**Verify on the Netlify deploy preview:**
1. Build page → add-deck form: color-picker block lays out correctly; pick a color already used by another deck → warning text appears next to the icon
2. Results tab: dismiss the "Finalize your decks" callout, reload → it stays dismissed
3. Landing FAQ + guide: read the updated sections above

https://claude.ai/code/session_01JRe1m3EKrqewMVr3jwAgDT

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRe1m3EKrqewMVr3jwAgDT)_