### PR TITLE
fix(security): escape user-supplied names in printable guide and title attributes

### DIFF
--- a/js/features/deck-list.js
+++ b/js/features/deck-list.js
@@ -690,7 +690,7 @@ function getMoveButtonHtml(deck, isInGroup) {
 
   // Dot variants have no slot of their own — mark lives on the parent group's slot.
   if (isInGroup && splitStyle === 'dots') {
-    const parentName = group?.name || 'parent deck';
+    const parentName = escapeHtml(group?.name || 'parent deck');
     return `
       <wa-button appearance="plain" variant="neutral" size="small" disabled
         title="Dot variants don't own a slot. Move &quot;${parentName}&quot; instead.">
@@ -729,7 +729,7 @@ function getMoveKebabItemHtml(deck, isInGroup) {
   const splitStyle = group?.splitStyle || 'stripes';
   const reason = splitStyle === 'stripes'
     ? "Stripe variant decks can't be moved yet. This is coming in a future update."
-    : `Dot variants move with their parent. Move &quot;${group?.name || 'parent deck'}&quot; instead.`;
+    : `Dot variants move with their parent. Move &quot;${escapeHtml(group?.name || 'parent deck')}&quot; instead.`;
   return `
     <wa-button class="kebab-item" appearance="plain" variant="neutral" size="small" disabled title="${reason}">
       <wa-icon slot="start" name="up-down-left-right"></wa-icon>Move to slot

--- a/js/modules/export.js
+++ b/js/modules/export.js
@@ -4,7 +4,7 @@
  */
 
 import { processCards, getColorName, formatSlotLabel } from './processor.js';
-import { stripeNumberLabel, countVisibleMarks, STRIPE_SPARSE_MAX } from '../core/utils.js';
+import { stripeNumberLabel, countVisibleMarks, STRIPE_SPARSE_MAX, escapeHtml } from '../core/utils.js';
 import { getPreferences } from './storage.js';
 
 /**
@@ -244,7 +244,7 @@ export function generatePrintableGuide(prism) {
 <!DOCTYPE html>
 <html>
 <head>
-  <title>PRISM Marking Guide - ${prism.name}</title>
+  <title>PRISM Marking Guide - ${escapeHtml(prism.name)}</title>
   <style>
     body { font-family: system-ui, sans-serif; padding: 20px; max-width: 800px; margin: 0 auto; }
     h1 { border-bottom: 2px solid #333; padding-bottom: 10px; }
@@ -354,7 +354,7 @@ export function generatePrintableGuide(prism) {
 </head>
 <body>
   <h1>🔮 PRISM Marking Guide</h1>
-  <p><strong>${prism.name}</strong> — ${prism.decks.length} decks, ${processedCards.length} unique cards</p>
+  <p><strong>${escapeHtml(prism.name)}</strong> — ${prism.decks.length} decks, ${processedCards.length} unique cards</p>
 
   <h2>Deck Legend</h2>
   <div class="deck-legend">
@@ -366,7 +366,7 @@ export function generatePrintableGuide(prism) {
     html += `
     <div class="deck-item" style="width: 100%;">
       <div class="color-swatch" style="background: ${group.sideAColor}"></div>
-      <span><strong>${formatSlotLabel(group.sideAPosition, 'a')}:</strong> ${group.name} (split group · ${isDots ? 'dot variants' : 'stripe variants'})</span>
+      <span><strong>${formatSlotLabel(group.sideAPosition, 'a')}:</strong> ${escapeHtml(group.name)} (split group · ${isDots ? 'dot variants' : 'stripe variants'})</span>
     </div>`;
 
     const childDecks = prism.decks
@@ -375,14 +375,14 @@ export function generatePrintableGuide(prism) {
 
     if (isDots) {
       for (const deck of childDecks) {
-        const dotHtml = `<div class="variant-dot" style="background: ${deck.color}" title="${deck.name}"></div>`;
+        const dotHtml = `<div class="variant-dot" style="background: ${deck.color}" title="${escapeHtml(deck.name)}"></div>`;
         html += `
     <div class="deck-item" style="padding-left: 20px;">
       <div class="legend-slot">
         <div class="legend-dot-row">${dotHtml}</div>
         <div class="stripe-square" style="background: ${group.sideAColor}"></div>
       </div>
-      <span>${deck.name} · Bracket ${deck.bracket}</span>
+      <span>${escapeHtml(deck.name)} · Bracket ${deck.bracket}</span>
     </div>`;
       }
     } else {
@@ -390,7 +390,7 @@ export function generatePrintableGuide(prism) {
         html += `
     <div class="deck-item" style="padding-left: 20px;">
       <div class="color-swatch side-b" style="background: ${deck.color}"></div>
-      <span><strong>${formatSlotLabel(deck.stripePosition, 'b')}:</strong> ${deck.name} (Side B) · Bracket ${deck.bracket}</span>
+      <span><strong>${formatSlotLabel(deck.stripePosition, 'b')}:</strong> ${escapeHtml(deck.name)} (Side B) · Bracket ${deck.bracket}</span>
     </div>`;
       }
     }
@@ -401,7 +401,7 @@ export function generatePrintableGuide(prism) {
     html += `
     <div class="deck-item">
       <div class="color-swatch" style="background: ${deck.color}"></div>
-      <span><strong>${formatSlotLabel(deck.stripePosition)}:</strong> ${deck.name} (Bracket ${deck.bracket})</span>
+      <span><strong>${formatSlotLabel(deck.stripePosition)}:</strong> ${escapeHtml(deck.name)} (Bracket ${deck.bracket})</span>
     </div>`;
   }
 
@@ -486,12 +486,12 @@ export function generatePrintableGuide(prism) {
     for (const pos of allPositions) {
       const stripe = stripeMap.get(pos);
       const dots = dotsByPos.get(pos) || [];
-      const dotHtml = dots.map(d => `<div class="variant-dot" style="background: ${d.color}" title="Dot: ${d.deckName}"></div>`).join('');
+      const dotHtml = dots.map(d => `<div class="variant-dot" style="background: ${d.color}" title="Dot: ${escapeHtml(d.deckName)}"></div>`).join('');
       const dotRow = `<div class="slot-dot-row">${dotHtml}</div>`;
 
       let squareHtml;
       if (stripe) {
-        squareHtml = `<div class="stripe-square${stripe.side === 'b' ? ' side-b' : ''}" style="background: ${stripe.color}" title="${formatSlotLabel(stripe.position)}: ${stripe.deckName}"></div>`;
+        squareHtml = `<div class="stripe-square${stripe.side === 'b' ? ' side-b' : ''}" style="background: ${stripe.color}" title="${formatSlotLabel(stripe.position)}: ${escapeHtml(stripe.deckName)}"></div>`;
       } else {
         squareHtml = `<div class="stripe-empty" title="${formatSlotLabel(pos)}: Empty"></div>`;
       }
@@ -502,7 +502,7 @@ export function generatePrintableGuide(prism) {
 
     html += `
       <tr class="${rowClass}">
-        <td class="${nameClass}">${card.name}${card.isBasicLand ? ' (Basic)' : ''}</td>
+        <td class="${nameClass}">${escapeHtml(card.name)}${card.isBasicLand ? ' (Basic)' : ''}</td>
         <td><div class="stripe-indicator">${stripeIndicators}</div></td>
       </tr>`;
   }


### PR DESCRIPTION
The printable marking guide interpolated prism, deck, group, and card names raw into HTML written via `document.write`, and two deck-card `title` attributes interpolated the raw group name inside a double-quoted attribute. All of these are free-text user input (card names fall back to raw text when Scryfall canonicalization fails), so a crafted name could inject markup into the guide window or break out of the attribute.

Every interpolation now goes through `escapeHtml`, which also encodes quotes for attribute contexts. No visual change for normal names.

**Verify on the Netlify deploy preview:**
1. Create a deck named ``&lt;img src=x onerror=alert(1)&gt;`` with a couple of cards
2. Export tab → Printable Guide: the name renders as literal text, no alert
3. Split a deck into dot variants and hover the disabled Move button — tooltip shows the group name as text

`npm test` 6/6 pass.

https://claude.ai/code/session_01JRe1m3EKrqewMVr3jwAgDT

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRe1m3EKrqewMVr3jwAgDT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed improper handling of special characters in group names within move action tooltips.
  * Fixed improper handling of special characters in group, deck, and card names in the printable guide output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->