### PR TITLE
feat: allow stripe-variant moves on mobile; exclude dot variants from bulk reorder

### DIFF
--- a/js/features/deck-list.js
+++ b/js/features/deck-list.js
@@ -606,9 +606,11 @@ export function handleNewPrism() {
 }
 
 export function handleStripeReorder(deckId, direction) {
-  const sortedDecks = [...state.currentPrism.decks].sort(
-    (a, b) => a.stripePosition - b.stripePosition,
-  );
+  // Dot variants own no slot (stripePosition null) — exclude them so the
+  // neighbour-swap logic only ever targets decks with a real position.
+  const sortedDecks = state.currentPrism.decks
+    .filter((d) => typeof d.stripePosition === "number")
+    .sort((a, b) => a.stripePosition - b.stripePosition);
   const currentIndex = sortedDecks.findIndex((d) => d.id === deckId);
   if (currentIndex === -1) return;
 
@@ -722,14 +724,16 @@ function kebabItem(deck, cls, icon, label) {
 }
 
 function getMoveKebabItemHtml(deck, isInGroup) {
-  if (!isInGroup) {
+  const group = isInGroup
+    ? state.currentPrism.splitGroups?.find(g => g.id === deck.splitGroupId)
+    : null;
+  const splitStyle = group?.splitStyle || 'stripes';
+  // Standalone decks AND stripes-style variants are fully moveable — matches
+  // the inline Move button. Only dot variants are locked (they own no slot).
+  if (!isInGroup || splitStyle === 'stripes') {
     return kebabItem(deck, "btn-move-deck", "up-down-left-right", "Move to slot");
   }
-  const group = state.currentPrism.splitGroups?.find(g => g.id === deck.splitGroupId);
-  const splitStyle = group?.splitStyle || 'stripes';
-  const reason = splitStyle === 'stripes'
-    ? "Stripe variant decks can't be moved yet. This is coming in a future update."
-    : `Dot variants move with their parent. Move &quot;${escapeHtml(group?.name || 'parent deck')}&quot; instead.`;
+  const reason = `Dot variants move with their parent. Move &quot;${escapeHtml(group?.name || 'parent deck')}&quot; instead.`;
   return `
     <wa-button class="kebab-item" appearance="plain" variant="neutral" size="small" disabled title="${reason}">
       <wa-icon slot="start" name="up-down-left-right"></wa-icon>Move to slot

--- a/js/features/export-view.js
+++ b/js/features/export-view.js
@@ -71,12 +71,15 @@ export function renderExport() {
     }).join('');
   }
 
-  // Stripe position list with slot picker
+  // Stripe position list with slot picker. Dot variants own no slot
+  // (stripePosition null) — they move with their parent group, so they are
+  // excluded from the bulk reorder list.
   if (state.elements.stripeReorderList) {
     const occupants = getPositionOccupants(state.currentPrism);
-    const maxSlot = Math.max(24, ...sortedDecks.map(d => d.stripePosition));
+    const slotDecks = sortedDecks.filter(d => typeof d.stripePosition === 'number');
+    const maxSlot = Math.max(24, ...slotDecks.map(d => d.stripePosition));
 
-    state.elements.stripeReorderList.innerHTML = sortedDecks.map((deck, index) => {
+    state.elements.stripeReorderList.innerHTML = slotDecks.map((deck, index) => {
       // Build select options for all available slots
       const options = [];
       for (let slot = 1; slot <= maxSlot; slot++) {
@@ -124,7 +127,7 @@ export function renderExport() {
             size="small"
             class="btn-move-down"
             data-deck-id="${deck.id}"
-            ${index === sortedDecks.length - 1 ? 'disabled' : ''}
+            ${index === slotDecks.length - 1 ? 'disabled' : ''}
             title="Move down"
           >
             <wa-icon name="chevron-down"></wa-icon>


### PR DESCRIPTION
Resolves the variant-movement contradiction flagged in the beta review (decision: **allow everywhere**). Stripe-style split variants were already moveable from the desktop Move button and the slot-picker dialog, but the mobile kebab disabled the same action with stale "coming in a future update" copy. The kebab now offers Move for standalone decks and stripes-style variants alike.

Dot variants own no slot (`stripePosition: null`) and move with their parent group, so they are now excluded from the Export tab's bulk reorder list (which previously rendered them as "Slot null") and from the up/down neighbour-swap ordering.

**Stacked on** the security-escaping PR (#116) — it touches the same kebab function; merge that first and this PR will retarget to main automatically.

**Verify on the Netlify deploy preview:**
1. Split a deck into stripe variants; at ≤768px width open a variant's kebab (⋮) → "Move to slot" is enabled and opens the slot picker
2. Split a deck into dot variants → Export tab's position list no longer shows "Slot null" rows for them; the variant kebab still shows the dots-locked explanation

`npm test` 6/6 pass.

https://claude.ai/code/session_01JRe1m3EKrqewMVr3jwAgDT

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRe1m3EKrqewMVr3jwAgDT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced deck reordering logic to correctly handle different deck type variants
* "Move to slot" action now properly enabled/disabled based on deck type
* Streamlined bulk reorder interface to display only individually moveable decks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->