### PR TITLE
feat(design): update WUBRG palette to new web values; OKLCH for declarative colors

### DIFF
--- a/build.html
+++ b/build.html
@@ -156,7 +156,7 @@
                   <div class="wa-flank wa-align-items-start">
                     <div class="wa-stack wa-gap-xs style="--flank-size:175px;">
                       <label class="wa-caption-m">Current Marker</label>
-                        <input type="color" id="deck-color" value="#ecc933" title="Pick a custom color" style="width: 40px; height: 32px; border: 2px dashed var(--wa-color-neutral-stroke); border-radius: var(--wa-border-radius-m); cursor: pointer;" />
+                        <input type="color" id="deck-color" value="#EEB41B" title="Pick a custom color" style="width: 40px; height: 32px; border: 2px dashed var(--wa-color-neutral-stroke); border-radius: var(--wa-border-radius-m); cursor: pointer;" />
                         <div id="color-warning" class="wa-caption-s" style="color: var(--wa-color-warning-text); display: none;">
                           <wa-icon name="triangle-exclamation" style="font-size: 0.9em;"></wa-icon>
                         </div>

--- a/js/features/analysis.js
+++ b/js/features/analysis.js
@@ -75,8 +75,13 @@ export function renderOverlapMatrix() {
               }
               const count = overlapMap[`${rowDeck.id}|${colDeck.id}`] || 0;
               const intensity = count / maxOverlap;
+              // Heat color mixes the brand token in OKLCH (declarative colors
+              // use OKLCH by convention). The old rgba() relied on an
+              // undefined --wa-color-brand-60-rgb and always fell back to a
+              // hardcoded off-brand indigo.
+              const mixPct = Math.round((0.1 + intensity * 0.5) * 100);
               const bg = count > 0
-                ? `rgba(var(--wa-color-brand-60-rgb, 99, 102, 241), ${0.1 + intensity * 0.5})`
+                ? `color-mix(in oklch, var(--wa-color-brand-fill) ${mixPct}%, transparent)`
                 : 'transparent';
               return `<td class="overlap-cell${count > 0 ? ' overlap-has-value' : ''}"
                 style="background: ${bg};"

--- a/js/modules/processor.js
+++ b/js/modules/processor.js
@@ -10,11 +10,12 @@ import { normalizeCardName } from "./parser.js";
  * 15 distinct colors for maximum deck support
  */
 export const DEFAULT_COLORS = [
-	"#ecc933", // Yellow
-	"#558CC1", // Blue
-	"#6B5597", // Purple
-	"#C73D2B", // Red
-	"#70AF63", // Green
+	// First five are the WUBRG slots (web palette, updated June 2026)
+	"#EEB41B", // Yellow (W)
+	"#3995D9", // Blue (U)
+	"#8662D2", // Purple (B)
+	"#E2484B", // Red (R)
+	"#4FAB33", // Green (G)
 	"#EEEEEE", // White
 	"#7A5E68", // Brown
 	"#3C5890", // Navy
@@ -41,6 +42,13 @@ export const DEFAULT_COLORS = [
  */
 export function getColorName(hex) {
 	const colorNames = {
+		"#EEB41B": "Yellow",
+		"#3995D9": "Blue",
+		"#8662D2": "Purple",
+		"#E2484B": "Red",
+		"#4FAB33": "Green",
+		// Legacy WUBRG values (pre-June-2026 palette) kept so existing decks
+		// saved with the old hexes still display a color name.
 		"#ECC933": "Yellow",
 		"#558CC1": "Blue",
 		"#6B5597": "Purple",


### PR DESCRIPTION
The first five `DEFAULT_COLORS` are the WUBRG slots. Updated to the new web palette:

| Slot | Old | New |
|---|---|---|
| Yellow (W) | `#ECC933` | `#EEB41B` |
| Blue (U) | `#558CC1` | `#3995D9` |
| Purple (B) | `#6B5597` | `#8662D2` |
| Red (R) | `#C73D2B` | `#E2484B` |
| Green (G) | `#70AF63` | `#4FAB33` |

Legacy hexes stay in the `getColorName` map so decks saved with the old palette keep their color names. The color input's initial value now matches the first default. Stored deck colors remain hex (required by `<input type="color">` and the persisted data model).

Per the new convention, declarative CSS colors use OKLCH: the overlap-matrix heat cell now mixes the brand token via `color-mix(in oklch, var(--wa-color-brand-fill) N%, transparent)` — replacing an `rgba()` that referenced an undefined `--wa-color-brand-60-rgb` and always fell back to hardcoded off-brand indigo.

**Verify on the Netlify deploy preview:**
1. Build page → Add a Deck: first five swatches show the new W/U/B/R/G values; default picker value is the new yellow
2. Add 2+ overlapping decks → Results tab → open the Overlap Matrix: heat cells tint in the brand purple, scaling with overlap

`npm test` 6/6 pass.

https://claude.ai/code/session_01JRe1m3EKrqewMVr3jwAgDT

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRe1m3EKrqewMVr3jwAgDT)_