### PR TITLE
feat: make My PRISMs list available without an account

### DIFF
--- a/js/layout.js
+++ b/js/layout.js
@@ -23,6 +23,9 @@ const NAV_LINKS = [
   { href: 'guide.html', label: 'Guide', page: 'guide' },
   { href: 'tools.html', label: 'Tools', page: 'tools' },
   { href: 'build.html', label: 'My PRISM', page: 'build' },
+  // PRISM switching is localStorage-backed and works without an account,
+  // so the list page is reachable for everyone (not just logged-in users).
+  { href: 'profile.html', label: 'My PRISMs', page: 'profile' },
 ];
 
 /**

--- a/js/profile.js
+++ b/js/profile.js
@@ -134,6 +134,10 @@ function handleAuthChange(user) {
   // Update nav auth UI
   updateAuthUI(user);
 
+  // The PRISM list is localStorage-backed and works without an account, so it
+  // renders for everyone — only the account sections below it are auth-gated.
+  renderPrismsList();
+
   if (user) {
     // Show logged in state - use style.display for reliability with Web Awesome CSS
     if (elements.profileLoggedOut) elements.profileLoggedOut.style.display = 'none';
@@ -142,9 +146,6 @@ function handleAuthChange(user) {
       elements.profileLoggedIn.style.display = '';
     }
     if (elements.profileEmail) elements.profileEmail.textContent = user.email;
-
-    // Load PRISMs
-    renderPrismsList();
   } else {
     // Show logged out state
     if (elements.profileLoggedOut) elements.profileLoggedOut.style.display = '';

--- a/profile.html
+++ b/profile.html
@@ -18,12 +18,33 @@
   <body>
     <wa-page mobile-breakpoint="768">
       <main style="max-width: 800px; margin: 0 auto; padding: var(--wa-space-xl);">
+        <!-- My PRISMs Section (always visible — PRISMs live in localStorage
+             and switching works without an account) -->
+        <section class="wa-stack wa-gap-m" style="padding-block: var(--wa-space-xl);">
+          <div class="wa-split wa-align-items-center">
+            <h1 class="wa-heading-xl">My PRISMs</h1>
+            <wa-button id="btn-new-prism" variant="neutral" appearance="outlined" size="small">
+              <wa-icon slot="start" name="plus"></wa-icon>
+              New PRISM
+            </wa-button>
+          </div>
+
+          <div id="prisms-list" class="wa-stack wa-gap-m">
+            <div class="wa-stack wa-gap-m wa-align-items-center" style="padding: var(--wa-space-xl); color: var(--wa-color-neutral-text-subtle);">
+              <wa-icon name="layer-group" style="font-size: 2rem;"></wa-icon>
+              <p>Loading your PRISMs...</p>
+            </div>
+          </div>
+        </section>
+
+        <wa-divider></wa-divider>
+
         <!-- Not Logged In State -->
         <div id="profile-logged-out" class="wa-stack wa-gap-l wa-align-items-center" style="padding: var(--wa-space-2xl);">
           <wa-icon name="circle-user" style="font-size: 4rem; color: var(--wa-color-neutral-text-subtle);"></wa-icon>
-          <h1 class="wa-heading-xl">Profile</h1>
+          <h2 class="wa-heading-xl">Account</h2>
           <p style="text-align: center; color: var(--wa-color-neutral-text-subtle);">
-            Sign in to manage your PRISMs across devices and access your account settings.
+            Your PRISMs are saved in this browser. Sign in to sync them across devices and access your account settings.
           </p>
           <wa-button id="btn-profile-login" variant="brand" size="large">
             <wa-icon slot="start" name="right-to-bracket"></wa-icon>
@@ -34,35 +55,15 @@
         <!-- Logged In State -->
         <div id="profile-logged-in" hidden>
           <!-- Profile Header -->
-          <div class="wa-stack wa-gap-m" style="padding-bottom: var(--wa-space-xl);">
+          <div class="wa-stack wa-gap-m" style="padding-block: var(--wa-space-xl);">
             <div class="wa-cluster wa-gap-m wa-align-items-center">
               <wa-icon name="circle-user" style="font-size: 3rem; color: var(--wa-color-brand-fill);"></wa-icon>
               <div class="wa-stack wa-gap-2xs">
-                <h1 class="wa-heading-xl">Profile</h1>
+                <h2 class="wa-heading-xl">Profile</h2>
                 <span id="profile-email" class="wa-body-m" style="color: var(--wa-color-neutral-text-subtle);"></span>
               </div>
             </div>
           </div>
-
-          <wa-divider></wa-divider>
-
-          <!-- My PRISMs Section -->
-          <section class="wa-stack wa-gap-m" style="padding-block: var(--wa-space-xl);">
-            <div class="wa-split wa-align-items-center">
-              <h2 class="wa-heading-l">My PRISMs</h2>
-              <wa-button id="btn-new-prism" variant="neutral" appearance="outlined" size="small">
-                <wa-icon slot="start" name="plus"></wa-icon>
-                New PRISM
-              </wa-button>
-            </div>
-
-            <div id="prisms-list" class="wa-stack wa-gap-m">
-              <div class="wa-stack wa-gap-m wa-align-items-center" style="padding: var(--wa-space-xl); color: var(--wa-color-neutral-text-subtle);">
-                <wa-icon name="layer-group" style="font-size: 2rem;"></wa-icon>
-                <p>Loading your PRISMs...</p>
-              </div>
-            </div>
-          </section>
 
           <wa-divider></wa-divider>
 


### PR DESCRIPTION
Fixes the Tier 1 data-stranding issue from the beta review: anonymous users could create a new PRISM from the build page but had no way to switch back — the PRISM list lived on profile.html behind login, and the Profile nav entry was itself hidden when logged out. The previous PRISM stayed in localStorage but was unreachable from the UI.

- Nav gains an always-visible **My PRISMs** link to profile.html
- The My PRISMs section moves out of the auth-gated block and renders for everyone (it is entirely localStorage-backed: list, Set Active, open, delete, New PRISM all work anonymously)
- Account settings and the sign-in pitch remain auth-gated below it, with copy explaining that signing in adds cross-device sync

**Verify on the Netlify deploy preview:**
1. Logged out: build page → New PRISM → nav → My PRISMs → both PRISMs listed; Set Active / open the old one works
2. Logged out: the Account section below the list shows the sign-in pitch
3. Logged in: list plus email header, account settings, and sign-out render as before

https://claude.ai/code/session_01JRe1m3EKrqewMVr3jwAgDT

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRe1m3EKrqewMVr3jwAgDT)_