### PR TITLE
fix: unify marked-done semantics; repair Basics-by-Deck and CSV export for split groups

### DIFF
--- a/js/core/utils.js
+++ b/js/core/utils.js
@@ -93,6 +93,27 @@ export function stripeNumberLabel(position, { exact } = {}) {
   return exact ? slotNumberLabel(position) : stripePositionLabel(position);
 }
 
+/**
+ * Whether a processed card is fully marked ("done").
+ * Non-basics are done when their plain name key is in markedCards. Basics can
+ * also be marked per logical deck from the Basics-by-Deck view (one row per
+ * Side A stripe, key "Name|DeckName"), so a basic counts as done when its
+ * plain key is marked OR every one of its per-deck keys is marked.
+ * Shared by the Marked progress stat and the undone-list exports so all
+ * surfaces agree on what "done" means.
+ * @param {Object} card - Processed card ({ name, isBasicLand, stripes })
+ * @param {Set<string>} markedSet - markedCards as a Set
+ * @returns {boolean}
+ */
+export function isCardDone(card, markedSet) {
+  if (markedSet.has(card.name)) return true;
+  if (!card.isBasicLand) return false;
+  const sideAKeys = (card.stripes || [])
+    .filter(s => s.side === 'a')
+    .map(s => `${card.name}|${s.deckName}`);
+  return sideAKeys.length > 0 && sideAKeys.every(k => markedSet.has(k));
+}
+
 export function escapeHtml(text) {
   const div = document.createElement('div');
   div.textContent = text;

--- a/js/features/results.js
+++ b/js/features/results.js
@@ -3,7 +3,7 @@
  */
 
 import { state } from '../core/state.js';
-import { escapeHtml, stripeNumberLabel, countVisibleMarks, STRIPE_SPARSE_MAX } from '../core/utils.js';
+import { escapeHtml, stripeNumberLabel, countVisibleMarks, STRIPE_SPARSE_MAX, isCardDone } from '../core/utils.js';
 import { getPreferences } from '../modules/storage.js';
 import { processCards, formatSlotLabel } from '../modules/processor.js';
 import { prefetchCards } from '../modules/scryfall.js';
@@ -104,7 +104,9 @@ export function updateMarkedProgress() {
   const cards = state.processedCards || [];
   const markedSet = new Set(state.currentPrism?.markedCards || []);
   const totalCount = cards.reduce((sum, c) => sum + c.totalQuantity, 0);
-  const markedCount = cards.reduce((sum, c) => sum + (markedSet.has(c.name) ? c.totalQuantity : 0), 0);
+  // isCardDone also honours per-deck basic marks ("Name|DeckName" keys from the
+  // Basics-by-Deck view) so progress can reach 100% for users of that view.
+  const markedCount = cards.reduce((sum, c) => sum + (isCardDone(c, markedSet) ? c.totalQuantity : 0), 0);
 
   if (state.elements.statMarked) state.elements.statMarked.textContent = `${markedCount}/${totalCount}`;
   if (state.elements.markedProgress) {
@@ -156,30 +158,42 @@ export function renderResults() {
     filteredCards = filteredCards.filter(c => c.logicalDeckCount > 1);
     displayCards = filteredCards;
   } else if (filter === 'basics-by-deck') {
-    // Show only basic lands, split into per-deck rows
+    // Show only basic lands, one row per LOGICAL deck. Standalone decks and
+    // split groups each emit exactly one Side A stripe, so iterating Side A
+    // gives the right row set — split variants share physical cards, so the
+    // group row carries the max quantity across its children. Iterating all
+    // stripes (the old behaviour) leaked invisible membership anchors and
+    // group-level stripes with no deckId, producing bogus rows with qty 1.
+    const findQty = (deck, cardName) =>
+      deck?.cards.find(c => c.name.toLowerCase() === cardName.toLowerCase())?.quantity || 0;
     displayCards = [];
     for (const card of filteredCards) {
-      if (card.isBasicLand) {
-        // Create a separate row for each deck this basic appears in
-        for (const stripe of card.stripes) {
-          // Find the quantity for this specific deck
-          const deck = state.currentPrism.decks.find(d => d.id === stripe.deckId);
-          const deckCard = deck?.cards.find(c => c.name.toLowerCase() === card.name.toLowerCase());
-          const quantity = deckCard?.quantity || 1;
+      if (!card.isBasicLand) continue; // Non-basics are excluded from this view
+      for (const stripe of card.stripes) {
+        if (stripe.side !== 'a') continue;
 
-          displayCards.push({
-            name: `${card.name} (${stripe.deckName})`,
-            displayName: card.name,
-            deckName: stripe.deckName,
-            isBasicLand: true,
-            isBasicByDeck: true,
-            totalQuantity: quantity,
-            deckCount: 1,
-            stripes: [stripe]
-          });
+        let quantity = 1;
+        if (stripe.deckId) {
+          const deck = state.currentPrism.decks.find(d => d.id === stripe.deckId);
+          quantity = findQty(deck, card.name) || 1;
+        } else if (stripe.groupId) {
+          const group = (state.currentPrism.splitGroups || []).find(g => g.id === stripe.groupId);
+          const childQtys = (group?.childDeckIds || [])
+            .map(id => findQty(state.currentPrism.decks.find(d => d.id === id), card.name));
+          quantity = Math.max(1, ...childQtys);
         }
+
+        displayCards.push({
+          name: `${card.name} (${stripe.deckName})`,
+          displayName: card.name,
+          deckName: stripe.deckName,
+          isBasicLand: true,
+          isBasicByDeck: true,
+          totalQuantity: quantity,
+          deckCount: 1,
+          stripes: [stripe]
+        });
       }
-      // Non-basic cards are excluded from this view
     }
     // Sort by land type first, then by deck name
     displayCards.sort((a, b) => {

--- a/js/modules/export.js
+++ b/js/modules/export.js
@@ -4,7 +4,7 @@
  */
 
 import { processCards, getColorName, formatSlotLabel } from './processor.js';
-import { stripeNumberLabel, countVisibleMarks, STRIPE_SPARSE_MAX, escapeHtml } from '../core/utils.js';
+import { stripeNumberLabel, countVisibleMarks, STRIPE_SPARSE_MAX, escapeHtml, isCardDone } from '../core/utils.js';
 import { getPreferences } from './storage.js';
 
 /**
@@ -37,8 +37,11 @@ function escapeCSV(value) {
  * @returns {string} Human-readable summary
  */
 function generateStripeSummary(stripes) {
+  // 'membership' anchors carry no physical mark — exporting them would tell
+  // the user to paint marks that must not exist.
   return stripes
-    .map(s => `${formatSlotLabel(s.position)}: ${getColorName(s.color)} (${s.deckName})`)
+    .filter(s => s.markType !== 'membership')
+    .map(s => `${formatSlotLabel(s.position)}: ${s.markType === 'dot' ? 'Dot ' : ''}${getColorName(s.color)} (${s.deckName})`)
     .join('; ');
 }
 
@@ -87,16 +90,25 @@ export function exportToCSV(prism) {
       escapeCSV(generateStripeSummary(card.stripes))
     ];
     
-    // Create a map of position -> stripe for easy lookup
-    const stripeMap = new Map(card.stripes.map(s => [s.position, s]));
+    // Group visible marks per position. A slot can hold several marks (a Side A
+    // stripe plus dot-variant dots), so values are joined with " / " — the old
+    // single-entry Map silently dropped all but the last mark and leaked
+    // invisible 'membership' anchors.
+    const marksByPos = new Map();
+    for (const s of card.stripes) {
+      if (s.markType === 'membership') continue;
+      if (!marksByPos.has(s.position)) marksByPos.set(s.position, []);
+      marksByPos.get(s.position).push(s);
+    }
 
     // Add slot columns
     for (let i = 1; i <= maxSlot; i++) {
-      const stripe = stripeMap.get(i);
-      if (stripe) {
-        row.push(escapeCSV(getColorName(stripe.color)));
-        row.push(escapeCSV(stripe.deckName));
-        row.push(escapeCSV(stripe.bracket));
+      const marks = marksByPos.get(i);
+      if (marks && marks.length > 0) {
+        const colorLabel = (s) => `${s.markType === 'dot' ? 'Dot ' : ''}${getColorName(s.color)}`;
+        row.push(escapeCSV(marks.map(colorLabel).join(' / ')));
+        row.push(escapeCSV(marks.map(s => s.deckName).join(' / ')));
+        row.push(escapeCSV(marks.map(s => s.bracket ?? '').join(' / ')));
       } else {
         row.push('');
         row.push('');
@@ -545,8 +557,10 @@ export function exportUndoneTxt(prism) {
   const processedCards = processCards(prism);
   const markedSet = new Set(prism.markedCards || []);
 
+  // isCardDone also honours per-deck basic marks ("Name|DeckName" keys from
+  // the Basics-by-Deck view) so fully-marked basics drop off the undone list.
   const lines = processedCards
-    .filter(card => !markedSet.has(card.name))
+    .filter(card => !isCardDone(card, markedSet))
     .map(card => `${card.totalQuantity} ${card.name}`);
 
   return lines.join('\n');


### PR DESCRIPTION
Tier 2 correctness fixes from the beta review (items 2–4): one shared definition of "marked done", correct Basics-by-Deck rows for split groups, and a CSV export that no longer lies about physical marks.

- **Unified marked-done semantics** — new shared `isCardDone(card, markedSet)` in `core/utils.js`: a card is done when its plain name key is marked, or (for basics) when every per-deck `Name|DeckName` key from the Basics-by-Deck view is marked. The Marked progress stat and the undone-list export/copy now use it, so per-deck basic marks finally count and progress can reach 100%.
- **Basics-by-Deck rows** — one row per *logical* deck by iterating Side A stripes (standalone decks and split groups each emit exactly one). The old loop leaked invisible membership anchors and group-level stripes as bogus qty-1 rows. Group rows carry the max quantity across child variants, since variants share physical cards.
- **CSV export** — stripe summary and per-slot columns exclude membership anchors (no physical mark), label dots as `Dot <color>`, and join co-located marks with ` / ` instead of last-wins dropping them.

**Verify on the Netlify deploy preview:**
1. Split a deck into dot variants sharing some basics → Results → Basics by Deck: one row per group (group name, max qty), no "(undefined)" or qty-1 ghost rows
2. Mark all per-deck basic rows + all normal cards → Marked progress reaches N/N and the undone export comes back empty
3. Export CSV from a PRISM with a dots split → no membership-only columns; a slot holding stripe + dot shows both joined with " / "

`npm test` 6/6 pass; eslint clean on changed files.

https://claude.ai/code/session_01JRe1m3EKrqewMVr3jwAgDT

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRe1m3EKrqewMVr3jwAgDT)_