### PR TITLE
fix: stop rendering "Slot null" for dot variants (removed view + export legend)

### DIFF
--- a/js/features/deck-list.js
+++ b/js/features/deck-list.js
@@ -119,6 +119,18 @@ export function autoClearRemovedCards(newCards) {
   return before - state.currentPrism.removedCards.length;
 }
 
+// Slot to record in removedCards for a deck's cleared marks. Dot variants own
+// no slot of their own (stripePosition null) — their physical marks live at
+// the parent group's Side A position, so record that instead of null (which
+// rendered as "Remove from Side A - Slot null" in the Removed view).
+function getRemovalStripePosition(deck) {
+  if (typeof deck.stripePosition === 'number') return deck.stripePosition;
+  const group = (state.currentPrism.splitGroups || []).find(
+    (g) => g.id === deck.splitGroupId,
+  );
+  return group?.sideAPosition ?? null;
+}
+
 // ============================================================================
 // Mark toggle
 // ============================================================================
@@ -346,6 +358,7 @@ export async function handleEditConfirm() {
 
   const now = new Date().toISOString();
   let removedCount = 0;
+  const removalPosition = getRemovalStripePosition(deck);
 
   for (const removedCard of removedFromDeck) {
     if (
@@ -360,7 +373,7 @@ export async function handleEditConfirm() {
         deckId: deck.id,
         deckName: deck.name,
         deckColor: deck.color,
-        stripePosition: deck.stripePosition,
+        stripePosition: removalPosition,
         removedAt: now,
       });
       removedCount++;
@@ -376,7 +389,7 @@ export async function handleEditConfirm() {
           deckId: deck.id,
           deckName: deck.name,
           deckColor: deck.color,
-          stripePosition: deck.stripePosition,
+          stripePosition: removalPosition,
           removedAt: now,
         });
         removedCount++;
@@ -428,6 +441,7 @@ export function handleDeleteConfirm() {
 
   const now = new Date().toISOString();
   let removedCount = 0;
+  const removalPosition = getRemovalStripePosition(deck);
 
   for (const card of deck.cards) {
     if (
@@ -438,7 +452,7 @@ export function handleDeleteConfirm() {
         deckId: deck.id,
         deckName: deck.name,
         deckColor: deck.color,
-        stripePosition: deck.stripePosition,
+        stripePosition: removalPosition,
         removedAt: now,
       });
       removedCount++;
@@ -454,7 +468,7 @@ export function handleDeleteConfirm() {
           deckId: deck.id,
           deckName: deck.name,
           deckColor: deck.color,
-          stripePosition: deck.stripePosition,
+          stripePosition: removalPosition,
           removedAt: now,
         });
         removedCount++;

--- a/js/features/deck-list.js
+++ b/js/features/deck-list.js
@@ -606,9 +606,11 @@ export function handleNewPrism() {
 }
 
 export function handleStripeReorder(deckId, direction) {
-  const sortedDecks = [...state.currentPrism.decks].sort(
-    (a, b) => a.stripePosition - b.stripePosition,
-  );
+  // Dot variants own no slot (stripePosition null) — exclude them so the
+  // neighbour-swap logic only ever targets decks with a real position.
+  const sortedDecks = state.currentPrism.decks
+    .filter((d) => typeof d.stripePosition === "number")
+    .sort((a, b) => a.stripePosition - b.stripePosition);
   const currentIndex = sortedDecks.findIndex((d) => d.id === deckId);
   if (currentIndex === -1) return;
 
@@ -722,14 +724,16 @@ function kebabItem(deck, cls, icon, label) {
 }
 
 function getMoveKebabItemHtml(deck, isInGroup) {
-  if (!isInGroup) {
+  const group = isInGroup
+    ? state.currentPrism.splitGroups?.find(g => g.id === deck.splitGroupId)
+    : null;
+  const splitStyle = group?.splitStyle || 'stripes';
+  // Standalone decks AND stripes-style variants are fully moveable — matches
+  // the inline Move button. Only dot variants are locked (they own no slot).
+  if (!isInGroup || splitStyle === 'stripes') {
     return kebabItem(deck, "btn-move-deck", "up-down-left-right", "Move to slot");
   }
-  const group = state.currentPrism.splitGroups?.find(g => g.id === deck.splitGroupId);
-  const splitStyle = group?.splitStyle || 'stripes';
-  const reason = splitStyle === 'stripes'
-    ? "Stripe variant decks can't be moved yet. This is coming in a future update."
-    : `Dot variants move with their parent. Move &quot;${escapeHtml(group?.name || 'parent deck')}&quot; instead.`;
+  const reason = `Dot variants move with their parent. Move &quot;${escapeHtml(group?.name || 'parent deck')}&quot; instead.`;
   return `
     <wa-button class="kebab-item" appearance="plain" variant="neutral" size="small" disabled title="${reason}">
       <wa-icon slot="start" name="up-down-left-right"></wa-icon>Move to slot

--- a/js/features/export-view.js
+++ b/js/features/export-view.js
@@ -64,7 +64,7 @@ export function renderExport() {
           ${children.map(child => `
             <div class="wa-cluster wa-gap-xs wa-align-items-center" style="padding-left: var(--wa-space-l);">
               <div class="deck-color-indicator small" style="background-color: ${child.color};"></div>
-              <span><strong>${formatSlotLabel(child.stripePosition)}:</strong> ${escapeHtml(child.name)}</span>
+              <span><strong>${typeof child.stripePosition === 'number' ? formatSlotLabel(child.stripePosition) : 'Dot variant'}:</strong> ${escapeHtml(child.name)}</span>
             </div>
           `).join('')}
         </div>`;

--- a/js/features/export-view.js
+++ b/js/features/export-view.js
@@ -71,12 +71,15 @@ export function renderExport() {
     }).join('');
   }
 
-  // Stripe position list with slot picker
+  // Stripe position list with slot picker. Dot variants own no slot
+  // (stripePosition null) — they move with their parent group, so they are
+  // excluded from the bulk reorder list.
   if (state.elements.stripeReorderList) {
     const occupants = getPositionOccupants(state.currentPrism);
-    const maxSlot = Math.max(24, ...sortedDecks.map(d => d.stripePosition));
+    const slotDecks = sortedDecks.filter(d => typeof d.stripePosition === 'number');
+    const maxSlot = Math.max(24, ...slotDecks.map(d => d.stripePosition));
 
-    state.elements.stripeReorderList.innerHTML = sortedDecks.map((deck, index) => {
+    state.elements.stripeReorderList.innerHTML = slotDecks.map((deck, index) => {
       // Build select options for all available slots
       const options = [];
       for (let slot = 1; slot <= maxSlot; slot++) {
@@ -124,7 +127,7 @@ export function renderExport() {
             size="small"
             class="btn-move-down"
             data-deck-id="${deck.id}"
-            ${index === sortedDecks.length - 1 ? 'disabled' : ''}
+            ${index === slotDecks.length - 1 ? 'disabled' : ''}
             title="Move down"
           >
             <wa-icon name="chevron-down"></wa-icon>

--- a/js/features/results.js
+++ b/js/features/results.js
@@ -276,7 +276,7 @@ export function renderResults() {
               <div
                 class="stripe-indicator"
                 style="background-color: ${card.removedDeckColor};"
-                title="Remove from ${formatSlotLabel(card.removedStripePosition)}"
+                title="Remove from ${card.removedStripePosition != null ? formatSlotLabel(card.removedStripePosition) : 'this deck’s group slot'}"
               ></div>
               <span class="removed-deck-label">Remove from ${escapeHtml(card.removedDeckName)}</span>
             </div>


### PR DESCRIPTION
Tier 2 item 1 from the beta review: dot variants have `stripePosition: null` (their marks live at the parent group's Side A slot), but two surfaces rendered that null as "Side A - Slot null".

- **removedCards** — all four push sites in `handleEditConfirm`/`handleDeleteConfirm` now record the group's `sideAPosition` via a new `getRemovalStripePosition(deck)` helper, so clearing marks for a deleted/edited dot variant points at the real slot.
- **Export legend** — slot-less children are labelled **Dot variant** instead of "Side A - Slot null".
- **Removed view** — tooltip falls back gracefully for legacy entries that already stored a null position.

**Stacked on #117** (same files) — merge that first and this retargets to main automatically.

**Verify on the Netlify deploy preview:**
1. Split a deck into dot variants → Export tab legend shows "Dot variant: <name>" for each child
2. Delete one dot variant → Results → Removed: the stripe-indicator tooltip reads "Remove from Side A - Slot N" (the group's slot), not "Slot null"

`npm test` 6/6 pass.

https://claude.ai/code/session_01JRe1m3EKrqewMVr3jwAgDT

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRe1m3EKrqewMVr3jwAgDT)_