### PR TITLE
feat(ux): restore onboarding callout, loading states, deck-filter empty state

### DIFF
--- a/build.html
+++ b/build.html
@@ -63,6 +63,21 @@
           <wa-tab-panel name="decks">
             <div class="wa-stack wa-gap-xl">
 
+              <!-- First-run orientation (dismissal persisted in localStorage,
+                   wired by the inline onboarding script at the end of body) -->
+              <wa-card id="onboarding-callout" style="display: none;">
+                <div class="wa-flank:end">
+                  <div class="wa-stack wa-gap-xs">
+                    <strong>Welcome to PRISM.</strong> Add the Commander decks that share cards, and PRISM works out a colored-stripe plan so every sleeve shows which decks it belongs to.
+                    <span>New to sleeve marking? Read the <a href="guide.html">marking guide</a> first.</span>
+                  </div>
+                  <wa-button id="onboarding-dismiss" appearance="filled-outlined" size="small">
+                    <wa-icon slot="start" name="xmark"></wa-icon>
+                    Dismiss
+                  </wa-button>
+                </div>
+              </wa-card>
+
               <!-- Existing Decks List -->
               <section id="decks-list" class="wa-stack wa-gap-m">
                 <!-- Deck cards will be inserted here -->
@@ -218,7 +233,7 @@
                   </div>
 
                   <div class="wa-cluster wa-gap-s">
-                    <wa-button type="submit" variant="brand">
+                    <wa-button type="submit" id="btn-add-deck" variant="brand">
                       <wa-icon slot="start" name="plus"></wa-icon>
                       Add Deck
                     </wa-button>

--- a/js/features/deck-form.js
+++ b/js/features/deck-form.js
@@ -84,6 +84,11 @@ export async function handleDeckSubmit(e) {
   if (_submitting) return;
   _submitting = true;
 
+  // Spinner while card names are canonicalized via Scryfall — the await below
+  // is network-bound and can exceed 300ms with no other feedback.
+  const submitBtn = document.getElementById("btn-add-deck");
+  submitBtn?.setAttribute("loading", "");
+
   try {
     debugLog("PRISM: Form submitted");
 
@@ -224,6 +229,7 @@ export async function handleDeckSubmit(e) {
     showSuccess(message);
   } finally {
     _submitting = false;
+    submitBtn?.removeAttribute("loading");
   }
 }
 

--- a/js/features/deck-list.js
+++ b/js/features/deck-list.js
@@ -119,6 +119,18 @@ export function autoClearRemovedCards(newCards) {
   return before - state.currentPrism.removedCards.length;
 }
 
+// Slot to record in removedCards for a deck's cleared marks. Dot variants own
+// no slot of their own (stripePosition null) — their physical marks live at
+// the parent group's Side A position, so record that instead of null (which
+// rendered as "Remove from Side A - Slot null" in the Removed view).
+function getRemovalStripePosition(deck) {
+  if (typeof deck.stripePosition === 'number') return deck.stripePosition;
+  const group = (state.currentPrism.splitGroups || []).find(
+    (g) => g.id === deck.splitGroupId,
+  );
+  return group?.sideAPosition ?? null;
+}
+
 // ============================================================================
 // Mark toggle
 // ============================================================================
@@ -346,6 +358,7 @@ export async function handleEditConfirm() {
 
   const now = new Date().toISOString();
   let removedCount = 0;
+  const removalPosition = getRemovalStripePosition(deck);
 
   for (const removedCard of removedFromDeck) {
     if (
@@ -360,7 +373,7 @@ export async function handleEditConfirm() {
         deckId: deck.id,
         deckName: deck.name,
         deckColor: deck.color,
-        stripePosition: deck.stripePosition,
+        stripePosition: removalPosition,
         removedAt: now,
       });
       removedCount++;
@@ -376,7 +389,7 @@ export async function handleEditConfirm() {
           deckId: deck.id,
           deckName: deck.name,
           deckColor: deck.color,
-          stripePosition: deck.stripePosition,
+          stripePosition: removalPosition,
           removedAt: now,
         });
         removedCount++;
@@ -428,6 +441,7 @@ export function handleDeleteConfirm() {
 
   const now = new Date().toISOString();
   let removedCount = 0;
+  const removalPosition = getRemovalStripePosition(deck);
 
   for (const card of deck.cards) {
     if (
@@ -438,7 +452,7 @@ export function handleDeleteConfirm() {
         deckId: deck.id,
         deckName: deck.name,
         deckColor: deck.color,
-        stripePosition: deck.stripePosition,
+        stripePosition: removalPosition,
         removedAt: now,
       });
       removedCount++;
@@ -454,7 +468,7 @@ export function handleDeleteConfirm() {
           deckId: deck.id,
           deckName: deck.name,
           deckColor: deck.color,
-          stripePosition: deck.stripePosition,
+          stripePosition: removalPosition,
           removedAt: now,
         });
         removedCount++;

--- a/js/features/deck-list.js
+++ b/js/features/deck-list.js
@@ -321,10 +321,15 @@ export async function handleEditConfirm() {
 
   const parseResult = parseDecklist(decklistText, commander);
 
+  // Spinner for the Scryfall round-trip — the only network-bound wait here.
+  const saveBtn = state.elements.btnConfirmEdit;
+  saveBtn?.setAttribute("loading", "");
   try {
     await canonicalizeCards(parseResult.cards);
   } catch (err) {
     console.warn("Card canonicalization failed, using raw names:", err.message);
+  } finally {
+    saveBtn?.removeAttribute("loading");
   }
 
   const validation = validateDecklist(parseResult);

--- a/js/features/deck-list.js
+++ b/js/features/deck-list.js
@@ -606,9 +606,11 @@ export function handleNewPrism() {
 }
 
 export function handleStripeReorder(deckId, direction) {
-  const sortedDecks = [...state.currentPrism.decks].sort(
-    (a, b) => a.stripePosition - b.stripePosition,
-  );
+  // Dot variants own no slot (stripePosition null) — exclude them so the
+  // neighbour-swap logic only ever targets decks with a real position.
+  const sortedDecks = state.currentPrism.decks
+    .filter((d) => typeof d.stripePosition === "number")
+    .sort((a, b) => a.stripePosition - b.stripePosition);
   const currentIndex = sortedDecks.findIndex((d) => d.id === deckId);
   if (currentIndex === -1) return;
 
@@ -722,14 +724,16 @@ function kebabItem(deck, cls, icon, label) {
 }
 
 function getMoveKebabItemHtml(deck, isInGroup) {
-  if (!isInGroup) {
+  const group = isInGroup
+    ? state.currentPrism.splitGroups?.find(g => g.id === deck.splitGroupId)
+    : null;
+  const splitStyle = group?.splitStyle || 'stripes';
+  // Standalone decks AND stripes-style variants are fully moveable — matches
+  // the inline Move button. Only dot variants are locked (they own no slot).
+  if (!isInGroup || splitStyle === 'stripes') {
     return kebabItem(deck, "btn-move-deck", "up-down-left-right", "Move to slot");
   }
-  const group = state.currentPrism.splitGroups?.find(g => g.id === deck.splitGroupId);
-  const splitStyle = group?.splitStyle || 'stripes';
-  const reason = splitStyle === 'stripes'
-    ? "Stripe variant decks can't be moved yet. This is coming in a future update."
-    : `Dot variants move with their parent. Move &quot;${escapeHtml(group?.name || 'parent deck')}&quot; instead.`;
+  const reason = `Dot variants move with their parent. Move &quot;${escapeHtml(group?.name || 'parent deck')}&quot; instead.`;
   return `
     <wa-button class="kebab-item" appearance="plain" variant="neutral" size="small" disabled title="${reason}">
       <wa-icon slot="start" name="up-down-left-right"></wa-icon>Move to slot

--- a/js/features/export-view.js
+++ b/js/features/export-view.js
@@ -64,7 +64,7 @@ export function renderExport() {
           ${children.map(child => `
             <div class="wa-cluster wa-gap-xs wa-align-items-center" style="padding-left: var(--wa-space-l);">
               <div class="deck-color-indicator small" style="background-color: ${child.color};"></div>
-              <span><strong>${formatSlotLabel(child.stripePosition)}:</strong> ${escapeHtml(child.name)}</span>
+              <span><strong>${typeof child.stripePosition === 'number' ? formatSlotLabel(child.stripePosition) : 'Dot variant'}:</strong> ${escapeHtml(child.name)}</span>
             </div>
           `).join('')}
         </div>`;

--- a/js/features/export-view.js
+++ b/js/features/export-view.js
@@ -71,12 +71,15 @@ export function renderExport() {
     }).join('');
   }
 
-  // Stripe position list with slot picker
+  // Stripe position list with slot picker. Dot variants own no slot
+  // (stripePosition null) — they move with their parent group, so they are
+  // excluded from the bulk reorder list.
   if (state.elements.stripeReorderList) {
     const occupants = getPositionOccupants(state.currentPrism);
-    const maxSlot = Math.max(24, ...sortedDecks.map(d => d.stripePosition));
+    const slotDecks = sortedDecks.filter(d => typeof d.stripePosition === 'number');
+    const maxSlot = Math.max(24, ...slotDecks.map(d => d.stripePosition));
 
-    state.elements.stripeReorderList.innerHTML = sortedDecks.map((deck, index) => {
+    state.elements.stripeReorderList.innerHTML = slotDecks.map((deck, index) => {
       // Build select options for all available slots
       const options = [];
       for (let slot = 1; slot <= maxSlot; slot++) {
@@ -124,7 +127,7 @@ export function renderExport() {
             size="small"
             class="btn-move-down"
             data-deck-id="${deck.id}"
-            ${index === sortedDecks.length - 1 ? 'disabled' : ''}
+            ${index === slotDecks.length - 1 ? 'disabled' : ''}
             title="Move down"
           >
             <wa-icon name="chevron-down"></wa-icon>

--- a/js/features/results.js
+++ b/js/features/results.js
@@ -556,7 +556,10 @@ function renderDeckFilterMenu() {
   const sortedDecks = [...state.currentPrism.decks].sort((a, b) => a.stripePosition - b.stripePosition);
 
   if (sortedDecks.length === 0) {
-    state.elements.deckFilterMenu.innerHTML = '<wa-menu-item disabled>No decks added</wa-menu-item>';
+    // Plain wa-button like the rest of this menu — wa-menu-item is avoided
+    // codebase-wide (flaky CDN autoload, see CLAUDE.md).
+    state.elements.deckFilterMenu.innerHTML =
+      '<wa-button disabled appearance="plain" variant="neutral" size="small">No decks added</wa-button>';
     return;
   }
 

--- a/js/features/results.js
+++ b/js/features/results.js
@@ -276,7 +276,7 @@ export function renderResults() {
               <div
                 class="stripe-indicator"
                 style="background-color: ${card.removedDeckColor};"
-                title="Remove from ${formatSlotLabel(card.removedStripePosition)}"
+                title="Remove from ${card.removedStripePosition != null ? formatSlotLabel(card.removedStripePosition) : 'this deck’s group slot'}"
               ></div>
               <span class="removed-deck-label">Remove from ${escapeHtml(card.removedDeckName)}</span>
             </div>


### PR DESCRIPTION
Beta review Tier 2 items 5–7.

- **Onboarding callout restored** — build.html's dismissal script survived a UI cleanup but its `#onboarding-callout` element was lost, so new users landed on a bare Decks tab. The callout is back (default-hidden, same wa-card pattern as the marking-prereq card); the existing script reveals it unless `prism_onboarding_dismissed` is set.
- **Loading states** — Add Deck and the edit dialog's Save Changes show a wa-button spinner while card names canonicalize via Scryfall (a network-bound wait with no prior feedback).
- **Deck-filter empty state** — disabled plain `wa-button` replaces the lone remaining `wa-menu-item` (avoided codebase-wide for flaky CDN autoload).

**Stacked on #123 → #117** — merge those first and this retargets automatically.

**Verify on the Netlify deploy preview:**
1. Fresh browser (or clear `prism_onboarding_dismissed`): build page Decks tab shows the welcome callout; Dismiss hides it and it stays hidden after reload
2. Add a deck with a real decklist → Add Deck button spins until the success toast; same for Save Changes in the edit dialog
3. With zero decks, open the Results deck-filter dropdown → "No decks added" renders as a proper disabled button

`npm test` 6/6 pass.

https://claude.ai/code/session_01JRe1m3EKrqewMVr3jwAgDT

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRe1m3EKrqewMVr3jwAgDT)_