### PR TITLE
feat(a11y): aria-labels on icon-only buttons; larger touch targets

### DIFF
--- a/build.html
+++ b/build.html
@@ -63,6 +63,21 @@
           <wa-tab-panel name="decks">
             <div class="wa-stack wa-gap-xl">
 
+              <!-- First-run orientation (dismissal persisted in localStorage,
+                   wired by the inline onboarding script at the end of body) -->
+              <wa-card id="onboarding-callout" style="display: none;">
+                <div class="wa-flank:end">
+                  <div class="wa-stack wa-gap-xs">
+                    <strong>Welcome to PRISM.</strong> Add the Commander decks that share cards, and PRISM works out a colored-stripe plan so every sleeve shows which decks it belongs to.
+                    <span>New to sleeve marking? Read the <a href="guide.html">marking guide</a> first.</span>
+                  </div>
+                  <wa-button id="onboarding-dismiss" appearance="filled-outlined" size="small">
+                    <wa-icon slot="start" name="xmark"></wa-icon>
+                    Dismiss
+                  </wa-button>
+                </div>
+              </wa-card>
+
               <!-- Existing Decks List -->
               <section id="decks-list" class="wa-stack wa-gap-m">
                 <!-- Deck cards will be inserted here -->
@@ -218,7 +233,7 @@
                   </div>
 
                   <div class="wa-cluster wa-gap-s">
-                    <wa-button type="submit" variant="brand">
+                    <wa-button type="submit" id="btn-add-deck" variant="brand">
                       <wa-icon slot="start" name="plus"></wa-icon>
                       Add Deck
                     </wa-button>

--- a/build.html
+++ b/build.html
@@ -32,7 +32,7 @@
             </div>
             <div class="wa-cluster wa-gap-s wa-align-items-center">
               <span id="sync-status" class="sync-status-indicator" style="display: none;"></span>
-              <wa-button id="btn-sync-now" size="small" appearance="plain" variant="neutral" title="Sync now" style="display: none;">
+              <wa-button id="btn-sync-now" size="small" appearance="plain" variant="neutral" title="Sync now" aria-label="Sync now" style="display: none;">
                 <wa-icon name="arrows-rotate"></wa-icon>
               </wa-button>
               <wa-tag id="deck-count-tag" variant="neutral" size="small">0 decks</wa-tag>

--- a/css/custom.css
+++ b/css/custom.css
@@ -764,6 +764,16 @@ wa-page[view='desktop'] [data-toggle-nav] {
   cursor: pointer;
   flex-shrink: 0;
   transition: box-shadow 0.12s ease, border-color 0.12s ease;
+  position: relative;
+}
+
+/* Invisible tap-area extension. The 24-slot column is a to-scale sleeve edge,
+   so slots can't be 44px tall — instead each slot's hit area bleeds sideways
+   and into the 2px gaps so fingers get a much larger effective target. */
+.stripe-reorder-slot::after {
+  content: '';
+  position: absolute;
+  inset: -1px -10px;
 }
 
 .stripe-reorder-slot--empty {
@@ -827,12 +837,21 @@ wa-page[view='desktop'] [data-toggle-nav] {
 /* Wider touch targets on mobile */
 @media (max-width: 768px) {
   .stripe-reorder-slot {
-    width: 32px;
-    height: 12px;
+    width: 44px;
+    height: 14px;
+  }
+
+  .stripe-reorder-slot::after {
+    inset: -1px -14px;
   }
 
   .stripe-reorder-sleeve {
-    min-height: 360px;
+    min-height: 400px;
+  }
+
+  .results-table .mark-checkbox {
+    width: 24px;
+    height: 24px;
   }
 }
 

--- a/js/features/deck-form.js
+++ b/js/features/deck-form.js
@@ -84,6 +84,11 @@ export async function handleDeckSubmit(e) {
   if (_submitting) return;
   _submitting = true;
 
+  // Spinner while card names are canonicalized via Scryfall — the await below
+  // is network-bound and can exceed 300ms with no other feedback.
+  const submitBtn = document.getElementById("btn-add-deck");
+  submitBtn?.setAttribute("loading", "");
+
   try {
     debugLog("PRISM: Form submitted");
 
@@ -224,6 +229,7 @@ export async function handleDeckSubmit(e) {
     showSuccess(message);
   } finally {
     _submitting = false;
+    submitBtn?.removeAttribute("loading");
   }
 }
 

--- a/js/features/deck-list.js
+++ b/js/features/deck-list.js
@@ -119,6 +119,18 @@ export function autoClearRemovedCards(newCards) {
   return before - state.currentPrism.removedCards.length;
 }
 
+// Slot to record in removedCards for a deck's cleared marks. Dot variants own
+// no slot of their own (stripePosition null) — their physical marks live at
+// the parent group's Side A position, so record that instead of null (which
+// rendered as "Remove from Side A - Slot null" in the Removed view).
+function getRemovalStripePosition(deck) {
+  if (typeof deck.stripePosition === 'number') return deck.stripePosition;
+  const group = (state.currentPrism.splitGroups || []).find(
+    (g) => g.id === deck.splitGroupId,
+  );
+  return group?.sideAPosition ?? null;
+}
+
 // ============================================================================
 // Mark toggle
 // ============================================================================
@@ -346,6 +358,7 @@ export async function handleEditConfirm() {
 
   const now = new Date().toISOString();
   let removedCount = 0;
+  const removalPosition = getRemovalStripePosition(deck);
 
   for (const removedCard of removedFromDeck) {
     if (
@@ -360,7 +373,7 @@ export async function handleEditConfirm() {
         deckId: deck.id,
         deckName: deck.name,
         deckColor: deck.color,
-        stripePosition: deck.stripePosition,
+        stripePosition: removalPosition,
         removedAt: now,
       });
       removedCount++;
@@ -376,7 +389,7 @@ export async function handleEditConfirm() {
           deckId: deck.id,
           deckName: deck.name,
           deckColor: deck.color,
-          stripePosition: deck.stripePosition,
+          stripePosition: removalPosition,
           removedAt: now,
         });
         removedCount++;
@@ -428,6 +441,7 @@ export function handleDeleteConfirm() {
 
   const now = new Date().toISOString();
   let removedCount = 0;
+  const removalPosition = getRemovalStripePosition(deck);
 
   for (const card of deck.cards) {
     if (
@@ -438,7 +452,7 @@ export function handleDeleteConfirm() {
         deckId: deck.id,
         deckName: deck.name,
         deckColor: deck.color,
-        stripePosition: deck.stripePosition,
+        stripePosition: removalPosition,
         removedAt: now,
       });
       removedCount++;
@@ -454,7 +468,7 @@ export function handleDeleteConfirm() {
           deckId: deck.id,
           deckName: deck.name,
           deckColor: deck.color,
-          stripePosition: deck.stripePosition,
+          stripePosition: removalPosition,
           removedAt: now,
         });
         removedCount++;

--- a/js/features/deck-list.js
+++ b/js/features/deck-list.js
@@ -321,10 +321,15 @@ export async function handleEditConfirm() {
 
   const parseResult = parseDecklist(decklistText, commander);
 
+  // Spinner for the Scryfall round-trip — the only network-bound wait here.
+  const saveBtn = state.elements.btnConfirmEdit;
+  saveBtn?.setAttribute("loading", "");
   try {
     await canonicalizeCards(parseResult.cards);
   } catch (err) {
     console.warn("Card canonicalization failed, using raw names:", err.message);
+  } finally {
+    saveBtn?.removeAttribute("loading");
   }
 
   const validation = validateDecklist(parseResult);

--- a/js/features/deck-list.js
+++ b/js/features/deck-list.js
@@ -714,7 +714,8 @@ function getMoveButtonHtml(deck, isInGroup) {
     const parentName = escapeHtml(group?.name || 'parent deck');
     return `
       <wa-button appearance="plain" variant="neutral" size="small" disabled
-        title="Dot variants don't own a slot. Move &quot;${parentName}&quot; instead.">
+        title="Dot variants don't own a slot. Move &quot;${parentName}&quot; instead."
+        aria-label="Move ${escapeHtml(deck.name)} (unavailable for dot variants)">
         <wa-icon name="up-down-left-right"></wa-icon>
       </wa-button>
     `;
@@ -723,7 +724,8 @@ function getMoveButtonHtml(deck, isInGroup) {
   // Standalone decks AND stripes-style variants: fully moveable.
   return `
     <wa-button appearance="plain" variant="neutral" size="small"
-      class="btn-move-deck" data-deck-id="${deck.id}" title="Move to a different slot">
+      class="btn-move-deck" data-deck-id="${deck.id}" title="Move to a different slot"
+      aria-label="Move ${escapeHtml(deck.name)} to a different slot">
       <wa-icon name="up-down-left-right"></wa-icon>
     </wa-button>
   `;
@@ -769,7 +771,8 @@ function getDeckActionsKebabHtml(deck, isInGroup) {
     : "";
   return `
     <wa-dropdown class="deck-actions-kebab">
-      <wa-button slot="trigger" appearance="plain" variant="neutral" size="small" title="Actions">
+      <wa-button slot="trigger" appearance="plain" variant="neutral" size="small" title="Actions"
+        aria-label="Actions for ${escapeHtml(deck.name)}">
         <wa-icon name="ellipsis-vertical"></wa-icon>
       </wa-button>
       <div class="wa-stack wa-gap-0 deck-actions-kebab-menu">
@@ -814,7 +817,8 @@ export function renderDeckCard(deck, showActions = true, processedCards = null) 
             state.currentPrism.decks.length >= 2
               ? `
           <wa-button appearance="plain" variant="neutral" size="small"
-            class="btn-what-if" data-deck-id="${deck.id}" title="What if I remove this deck?">
+            class="btn-what-if" data-deck-id="${deck.id}" title="What if I remove this deck?"
+            aria-label="What if I remove ${escapeHtml(deck.name)}?">
             <wa-icon name="flask"></wa-icon>
           </wa-button>
           `
@@ -825,18 +829,21 @@ export function renderDeckCard(deck, showActions = true, processedCards = null) 
             !isInGroup
               ? `
           <wa-button appearance="plain" variant="neutral" size="small"
-            class="btn-split-deck" data-deck-id="${deck.id}" title="Split into variants">
+            class="btn-split-deck" data-deck-id="${deck.id}" title="Split into variants"
+            aria-label="Split ${escapeHtml(deck.name)} into variants">
             <wa-icon name="code-branch"></wa-icon>
           </wa-button>
           `
               : ""
           }
           <wa-button appearance="plain" variant="neutral" size="small"
-            class="btn-edit-deck" data-deck-id="${deck.id}" title="Edit deck">
+            class="btn-edit-deck" data-deck-id="${deck.id}" title="Edit deck"
+            aria-label="Edit ${escapeHtml(deck.name)}">
             <wa-icon name="pen-to-square"></wa-icon>
           </wa-button>
           <wa-button appearance="plain" variant="neutral" size="small"
-            class="btn-delete-deck" data-deck-id="${deck.id}" title="Delete deck">
+            class="btn-delete-deck" data-deck-id="${deck.id}" title="Delete deck"
+            aria-label="Delete ${escapeHtml(deck.name)}">
             <wa-icon name="trash"></wa-icon>
           </wa-button>
         </div>
@@ -933,20 +940,24 @@ export function renderDecksList() {
             </div>
             <div class="wa-cluster wa-gap-xs">
               <wa-button appearance="plain" variant="neutral" size="small"
-                class="btn-move-group" data-group-id="${group.id}" title="Move group to a different slot">
+                class="btn-move-group" data-group-id="${group.id}" title="Move group to a different slot"
+                aria-label="Move ${escapeHtml(group.name)} to a different slot">
                 <wa-icon name="up-down-left-right"></wa-icon>
               </wa-button>
               <wa-button appearance="plain" variant="neutral" size="small"
-                class="btn-edit-group" data-group-id="${group.id}" title="Edit group name and color">
+                class="btn-edit-group" data-group-id="${group.id}" title="Edit group name and color"
+                aria-label="Edit ${escapeHtml(group.name)} name and color">
                 <wa-icon name="pen-to-square"></wa-icon>
               </wa-button>
               <wa-button appearance="plain" variant="neutral" size="small"
                 class="btn-add-split" data-group-id="${group.id}" title="Add another variant"
+                aria-label="Add another variant to ${escapeHtml(group.name)}"
                 ${(group.splitStyle || 'stripes') === 'dots' && group.childDeckIds.length >= 2 ? 'disabled' : ''}>
                 <wa-icon name="plus"></wa-icon>
               </wa-button>
               <wa-button appearance="plain" variant="neutral" size="small"
-                class="btn-unsplit" data-group-id="${group.id}" title="Merge back into one deck">
+                class="btn-unsplit" data-group-id="${group.id}" title="Merge back into one deck"
+                aria-label="Merge ${escapeHtml(group.name)} back into one deck">
                 <wa-icon name="code-merge"></wa-icon>
               </wa-button>
             </div>

--- a/js/features/deck-list.js
+++ b/js/features/deck-list.js
@@ -606,9 +606,11 @@ export function handleNewPrism() {
 }
 
 export function handleStripeReorder(deckId, direction) {
-  const sortedDecks = [...state.currentPrism.decks].sort(
-    (a, b) => a.stripePosition - b.stripePosition,
-  );
+  // Dot variants own no slot (stripePosition null) — exclude them so the
+  // neighbour-swap logic only ever targets decks with a real position.
+  const sortedDecks = state.currentPrism.decks
+    .filter((d) => typeof d.stripePosition === "number")
+    .sort((a, b) => a.stripePosition - b.stripePosition);
   const currentIndex = sortedDecks.findIndex((d) => d.id === deckId);
   if (currentIndex === -1) return;
 
@@ -722,14 +724,16 @@ function kebabItem(deck, cls, icon, label) {
 }
 
 function getMoveKebabItemHtml(deck, isInGroup) {
-  if (!isInGroup) {
+  const group = isInGroup
+    ? state.currentPrism.splitGroups?.find(g => g.id === deck.splitGroupId)
+    : null;
+  const splitStyle = group?.splitStyle || 'stripes';
+  // Standalone decks AND stripes-style variants are fully moveable — matches
+  // the inline Move button. Only dot variants are locked (they own no slot).
+  if (!isInGroup || splitStyle === 'stripes') {
     return kebabItem(deck, "btn-move-deck", "up-down-left-right", "Move to slot");
   }
-  const group = state.currentPrism.splitGroups?.find(g => g.id === deck.splitGroupId);
-  const splitStyle = group?.splitStyle || 'stripes';
-  const reason = splitStyle === 'stripes'
-    ? "Stripe variant decks can't be moved yet. This is coming in a future update."
-    : `Dot variants move with their parent. Move &quot;${escapeHtml(group?.name || 'parent deck')}&quot; instead.`;
+  const reason = `Dot variants move with their parent. Move &quot;${escapeHtml(group?.name || 'parent deck')}&quot; instead.`;
   return `
     <wa-button class="kebab-item" appearance="plain" variant="neutral" size="small" disabled title="${reason}">
       <wa-icon slot="start" name="up-down-left-right"></wa-icon>Move to slot

--- a/js/features/export-view.js
+++ b/js/features/export-view.js
@@ -64,7 +64,7 @@ export function renderExport() {
           ${children.map(child => `
             <div class="wa-cluster wa-gap-xs wa-align-items-center" style="padding-left: var(--wa-space-l);">
               <div class="deck-color-indicator small" style="background-color: ${child.color};"></div>
-              <span><strong>${formatSlotLabel(child.stripePosition)}:</strong> ${escapeHtml(child.name)}</span>
+              <span><strong>${typeof child.stripePosition === 'number' ? formatSlotLabel(child.stripePosition) : 'Dot variant'}:</strong> ${escapeHtml(child.name)}</span>
             </div>
           `).join('')}
         </div>`;

--- a/js/features/export-view.js
+++ b/js/features/export-view.js
@@ -71,12 +71,15 @@ export function renderExport() {
     }).join('');
   }
 
-  // Stripe position list with slot picker
+  // Stripe position list with slot picker. Dot variants own no slot
+  // (stripePosition null) — they move with their parent group, so they are
+  // excluded from the bulk reorder list.
   if (state.elements.stripeReorderList) {
     const occupants = getPositionOccupants(state.currentPrism);
-    const maxSlot = Math.max(24, ...sortedDecks.map(d => d.stripePosition));
+    const slotDecks = sortedDecks.filter(d => typeof d.stripePosition === 'number');
+    const maxSlot = Math.max(24, ...slotDecks.map(d => d.stripePosition));
 
-    state.elements.stripeReorderList.innerHTML = sortedDecks.map((deck, index) => {
+    state.elements.stripeReorderList.innerHTML = slotDecks.map((deck, index) => {
       // Build select options for all available slots
       const options = [];
       for (let slot = 1; slot <= maxSlot; slot++) {
@@ -124,7 +127,7 @@ export function renderExport() {
             size="small"
             class="btn-move-down"
             data-deck-id="${deck.id}"
-            ${index === sortedDecks.length - 1 ? 'disabled' : ''}
+            ${index === slotDecks.length - 1 ? 'disabled' : ''}
             title="Move down"
           >
             <wa-icon name="chevron-down"></wa-icon>

--- a/js/features/results.js
+++ b/js/features/results.js
@@ -290,6 +290,7 @@ export function renderResults() {
               data-card-name="${escapeHtml(card.name)}"
               data-deck-id="${card.removedDeckId}"
               title="Mark as cleared"
+              aria-label="Mark ${escapeHtml(card.name)} as cleared"
             >
               <wa-icon name="check"></wa-icon>
             </wa-button>

--- a/js/features/results.js
+++ b/js/features/results.js
@@ -556,7 +556,10 @@ function renderDeckFilterMenu() {
   const sortedDecks = [...state.currentPrism.decks].sort((a, b) => a.stripePosition - b.stripePosition);
 
   if (sortedDecks.length === 0) {
-    state.elements.deckFilterMenu.innerHTML = '<wa-menu-item disabled>No decks added</wa-menu-item>';
+    // Plain wa-button like the rest of this menu — wa-menu-item is avoided
+    // codebase-wide (flaky CDN autoload, see CLAUDE.md).
+    state.elements.deckFilterMenu.innerHTML =
+      '<wa-button disabled appearance="plain" variant="neutral" size="small">No decks added</wa-button>';
     return;
   }
 

--- a/js/features/results.js
+++ b/js/features/results.js
@@ -276,7 +276,7 @@ export function renderResults() {
               <div
                 class="stripe-indicator"
                 style="background-color: ${card.removedDeckColor};"
-                title="Remove from ${formatSlotLabel(card.removedStripePosition)}"
+                title="Remove from ${card.removedStripePosition != null ? formatSlotLabel(card.removedStripePosition) : 'this deck’s group slot'}"
               ></div>
               <span class="removed-deck-label">Remove from ${escapeHtml(card.removedDeckName)}</span>
             </div>


### PR DESCRIPTION
Beta review Tier 2 items 10–11.

- **aria-labels** — every icon-only action button now has an accessible name including its target: deck-card actions (what-if, move, split, edit, delete, kebab trigger), split-group header actions (move, edit, add variant, unsplit), the Removed view's clear button, and the header Sync Now button. Mark checkboxes already had labels (E2).
- **Touch targets** — slot-picker slots get an invisible `::after` hit-area extension bleeding sideways and into the 2px gaps; the 24-slot column is a to-scale sleeve edge, so slots can't literally be 44px tall, but the effective tap zone is now much larger. On mobile: slots grow to 44×14 visual, the sleeve to 400px min-height, and mark checkboxes to 24×24.

**Stacked on #124 → #123 → #117** — merge in order and this retargets automatically.

**Verify on the Netlify deploy preview:**
1. VoiceOver/NVDA or browser a11y inspector over a deck card → buttons announce "Edit <deck name>", "Delete <deck name>", etc.
2. On a phone (or 375px responsive mode), open the Move slot picker → slots are comfortably tappable, including just beside a slot
3. Results table on mobile → mark checkboxes noticeably bigger

`npm test` 6/6 pass.

https://claude.ai/code/session_01JRe1m3EKrqewMVr3jwAgDT

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRe1m3EKrqewMVr3jwAgDT)_