### PR TITLE
feat(beta): password-recovery flow, global error reporting, funnel events

### DIFF
--- a/js/core/telemetry.js
+++ b/js/core/telemetry.js
@@ -1,0 +1,37 @@
+/**
+ * Global error reporting.
+ * Surfaces unhandled errors as GA events (anonymous users included) and
+ * Supabase app_logs rows (authenticated users only — logToSupabase gates on
+ * session). Capped per page load so a render-loop error can't flood either
+ * sink.
+ */
+
+import { logToSupabase } from '../modules/supabase-client.js';
+
+const MAX_REPORTS_PER_PAGE = 5;
+let reported = 0;
+let installed = false;
+
+function report(kind, message, source = '') {
+  if (reported >= MAX_REPORTS_PER_PAGE) return;
+  reported++;
+  logToSupabase('error', 'unhandled_error', {
+    kind,
+    message: String(message).slice(0, 500),
+    source,
+    page: window.location.pathname,
+  });
+}
+
+export function initGlobalErrorReporting() {
+  if (installed) return;
+  installed = true;
+
+  window.addEventListener('error', (e) => {
+    report('error', e.message || e.error?.message || 'unknown', `${e.filename || ''}:${e.lineno || 0}`);
+  });
+
+  window.addEventListener('unhandledrejection', (e) => {
+    report('unhandledrejection', e.reason?.message || e.reason || 'unknown');
+  });
+}

--- a/js/features/deck-list.js
+++ b/js/features/deck-list.js
@@ -23,6 +23,7 @@ import {
   updateSplitGroupInPrism,
 } from "../modules/processor.js";
 import { savePrism, setCurrentPrism, recordUnmarkedCards } from "../modules/storage.js";
+import { trackEvent } from "../modules/supabase-client.js";
 import { canonicalizeCards } from "../modules/scryfall.js";
 import { hideEditImportMessages } from "./deck-import.js";
 import { initColorSwatches, resetDeckForm } from "./deck-form.js";
@@ -130,6 +131,9 @@ export function setCardMarked(cardKey, marked) {
   if (marked) {
     if (!state.currentPrism.markedCards.includes(cardKey)) {
       state.currentPrism.markedCards.push(cardKey);
+      // GA-only funnel step (visit → deck → first mark → export); too chatty
+      // for app_logs rows.
+      trackEvent('card_marked');
     }
   } else {
     state.currentPrism.markedCards = state.currentPrism.markedCards.filter(

--- a/js/features/events.js
+++ b/js/features/events.js
@@ -16,6 +16,7 @@ import { updatePreferences, getPreferences, savePrism, setColorScheme } from '..
 import { applyColorScheme } from '../modules/theme.js';
 import { remapPrismForCorner } from '../modules/processor.js';
 import { renderAll } from './init.js';
+import { logToSupabase } from '../modules/supabase-client.js';
 
 // ============================================================================
 // Event Listeners
@@ -105,27 +106,39 @@ export function setupEventListeners() {
     });
   }
 
-  // Export buttons
+  // Export buttons — each logs an 'export' funnel event (GA + app_logs)
   if (state.elements.btnExportCSV) {
-    state.elements.btnExportCSV.addEventListener('click', () => downloadCSV(state.currentPrism));
+    state.elements.btnExportCSV.addEventListener('click', () => {
+      downloadCSV(state.currentPrism);
+      logToSupabase('info', 'export', { format: 'csv' });
+    });
   }
   if (state.elements.btnExportJSON) {
-    state.elements.btnExportJSON.addEventListener('click', () => downloadJSON(state.currentPrism));
+    state.elements.btnExportJSON.addEventListener('click', () => {
+      downloadJSON(state.currentPrism);
+      logToSupabase('info', 'export', { format: 'json' });
+    });
   }
   if (state.elements.btnPrintGuide) {
     state.elements.btnPrintGuide.addEventListener('click', async () => {
       if (!openPrintableGuide(state.currentPrism)) {
         const { showError } = await import('../core/notifications.js');
         showError('Could not open the printable guide. Please allow popups for this site and try again.');
+        return;
       }
+      logToSupabase('info', 'export', { format: 'print' });
     });
   }
   if (state.elements.btnDownloadUndone) {
-    state.elements.btnDownloadUndone.addEventListener('click', () => downloadUndoneTxt(state.currentPrism));
+    state.elements.btnDownloadUndone.addEventListener('click', () => {
+      downloadUndoneTxt(state.currentPrism);
+      logToSupabase('info', 'export', { format: 'undone_txt' });
+    });
   }
   if (state.elements.btnCopyUndone) {
     state.elements.btnCopyUndone.addEventListener('click', async () => {
       const count = await copyUndoneToClipboard(state.currentPrism);
+      logToSupabase('info', 'export', { format: 'undone_copy' });
       const { showSuccess } = await import('../core/notifications.js');
       showSuccess(`Copied ${count} undone card${count === 1 ? '' : 's'} to clipboard`);
     });

--- a/js/layout.js
+++ b/js/layout.js
@@ -11,6 +11,7 @@
 import { initAuth, setupAuthListeners } from './modules/auth.js';
 import { getColorScheme } from './modules/storage.js';
 import { applyColorScheme } from './modules/theme.js';
+import { initGlobalErrorReporting } from './core/telemetry.js';
 
 // Re-apply when the OS theme changes, but only while preference is 'auto'
 window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
@@ -40,6 +41,7 @@ const NAV_LINKS = [
 export function initLayout(options = {}) {
   const { activePage = '' } = options;
 
+  initGlobalErrorReporting();
   injectHeadResources();
   injectNav(activePage);
   injectHeader(options.headerCta);
@@ -425,6 +427,18 @@ function injectAuthDialog() {
         <wa-button id="btn-back-to-login" type="button" appearance="plain" size="small" style="align-self: center;">
           Back to login
         </wa-button>
+      </div>
+
+      <!-- Set New Password View (opened by the PASSWORD_RECOVERY auth event) -->
+      <div id="auth-recovery-view" class="wa-stack wa-gap-m" style="display: none;">
+        <p class="wa-body-m" style="color: var(--wa-color-neutral-text-subtle);">You followed a password reset link. Choose a new password to finish.</p>
+        <form id="recovery-form" class="wa-stack wa-gap-m">
+          <wa-input id="recovery-password" name="password" type="password" label="New password" placeholder="At least 6 characters" autocomplete="new-password" required minlength="6"></wa-input>
+          <wa-input id="recovery-password-confirm" name="confirm" type="password" label="Confirm new password" placeholder="Repeat new password" autocomplete="new-password" required minlength="6"></wa-input>
+          <div id="recovery-error" hidden class="wa-caption-m" style="color: var(--wa-color-danger-text);"></div>
+          <div id="recovery-success" hidden class="wa-caption-m" style="color: var(--wa-color-success-text);"></div>
+          <wa-button id="btn-recovery-submit" type="submit" variant="brand" style="width: 100%;">Set New Password</wa-button>
+        </form>
       </div>`;
 
   document.body.appendChild(dialog);

--- a/js/modules/auth.js
+++ b/js/modules/auth.js
@@ -77,6 +77,14 @@ export function initAuth() {
         logToSupabase('info', 'user_signed_out');
       }
 
+      // Password-reset email link: the user lands with a recovery session and
+      // must be prompted for a new password, or reset appears broken.
+      if (event === 'PASSWORD_RECOVERY') {
+        wasLoggedOut = false; // recovery session signs the user in — skip the SIGNED_IN reload
+        openPasswordRecovery();
+        return;
+      }
+
       // Sync with Supabase when user freshly logs in (not on session recovery)
       if (event === 'SIGNED_IN' && session?.user && wasLoggedOut) {
         wasLoggedOut = false;
@@ -86,6 +94,14 @@ export function initAuth() {
         window.location.reload();
       }
     });
+
+    // Supabase processes the recovery token from the URL hash at client
+    // creation, which can finish before the listener above registers — check
+    // the URL directly so the set-password dialog opens either way.
+    if (window.location.hash.includes('type=recovery')) {
+      wasLoggedOut = false;
+      openPasswordRecovery();
+    }
 
     return currentUser;
   })().catch(err => {
@@ -195,12 +211,14 @@ function showAuthView(viewName) {
   const loginView = document.getElementById('auth-login-view');
   const signupView = document.getElementById('auth-signup-view');
   const forgotView = document.getElementById('auth-forgot-view');
+  const recoveryView = document.getElementById('auth-recovery-view');
   const dialogTitle = document.getElementById('auth-dialog-title');
 
   // Hide all views
   if (loginView) loginView.style.display = 'none';
   if (signupView) signupView.style.display = 'none';
   if (forgotView) forgotView.style.display = 'none';
+  if (recoveryView) recoveryView.style.display = 'none';
 
   // Show requested view and update title
   switch (viewName) {
@@ -216,16 +234,28 @@ function showAuthView(viewName) {
       if (forgotView) forgotView.style.display = '';
       if (dialogTitle) dialogTitle.textContent = 'Reset Password';
       break;
+    case 'recovery':
+      if (recoveryView) recoveryView.style.display = '';
+      if (dialogTitle) dialogTitle.textContent = 'Set a New Password';
+      break;
   }
 
   // Clear any error/success messages
   clearAuthMessages();
 }
 
+// Open the auth dialog on the set-new-password view (password-reset landing)
+function openPasswordRecovery() {
+  const dialog = document.getElementById('auth-dialog');
+  if (!dialog) return;
+  showAuthView('recovery');
+  dialog.setAttribute('open', '');
+}
+
 // Clear all error and success messages
 function clearAuthMessages() {
-  const errorEls = document.querySelectorAll('#login-error, #signup-error, #forgot-error');
-  const successEls = document.querySelectorAll('#signup-success, #forgot-success');
+  const errorEls = document.querySelectorAll('#login-error, #signup-error, #forgot-error, #recovery-error');
+  const successEls = document.querySelectorAll('#signup-success, #forgot-success, #recovery-success');
 
   errorEls.forEach(el => {
     if (el) el.hidden = true;
@@ -339,6 +369,7 @@ export function setupAuthListeners() {
         if (successEl) successEl.hidden = true;
 
         await signUp(email, password);
+        logToSupabase('info', 'user_signed_up');
 
         // Show success message
         if (successEl) {
@@ -384,6 +415,53 @@ export function setupAuthListeners() {
         }
       } catch (err) {
         console.error('Password reset error:', err);
+        if (errorEl) {
+          errorEl.textContent = err.message;
+          errorEl.hidden = false;
+        }
+      } finally {
+        if (submitBtn) submitBtn.loading = false;
+      }
+    });
+  }
+
+  // Set-new-password form (password-reset landing)
+  const recoveryForm = document.getElementById('recovery-form');
+  if (recoveryForm) {
+    recoveryForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const password = document.getElementById('recovery-password')?.value;
+      const confirm = document.getElementById('recovery-password-confirm')?.value;
+      const submitBtn = document.getElementById('btn-recovery-submit');
+      const errorEl = document.getElementById('recovery-error');
+      const successEl = document.getElementById('recovery-success');
+
+      if (password !== confirm) {
+        if (errorEl) {
+          errorEl.textContent = 'Passwords do not match.';
+          errorEl.hidden = false;
+        }
+        return;
+      }
+
+      try {
+        if (submitBtn) submitBtn.loading = true;
+        if (errorEl) errorEl.hidden = true;
+
+        await updatePassword(password);
+        logToSupabase('info', 'password_recovered');
+
+        if (successEl) {
+          successEl.textContent = 'Password updated. You are signed in.';
+          successEl.hidden = false;
+        }
+
+        // Let the confirmation register, then close the dialog
+        setTimeout(() => {
+          document.getElementById('auth-dialog')?.removeAttribute('open');
+        }, 1500);
+      } catch (err) {
+        console.error('Password update error:', err);
         if (errorEl) {
           errorEl.textContent = err.message;
           errorEl.hidden = false;

--- a/js/modules/supabase-client.js
+++ b/js/modules/supabase-client.js
@@ -20,15 +20,35 @@ export function isConfigured() {
   return SUPABASE_URL !== 'YOUR_SUPABASE_URL' && SUPABASE_ANON_KEY !== 'YOUR_SUPABASE_ANON_KEY';
 }
 
+// Fire a Google Analytics event if gtag is present. Centralised here so every
+// logToSupabase call doubles as a funnel event — GA covers anonymous users,
+// who can't write to app_logs (RLS restricts INSERT to authenticated users).
+export function trackEvent(name, params = {}) {
+  try {
+    if (typeof window.gtag !== 'function') return;
+    const safe = { ...params };
+    delete safe.email; // never send PII to GA
+    window.gtag('event', name, safe);
+  } catch {
+    // Analytics must never break the app.
+  }
+}
+
 // Log helper for debugging
 export async function logToSupabase(level, message, metadata = null) {
+  trackEvent(message, { level, ...(metadata || {}) });
+
   const client = getSupabase();
   if (!client) return;
 
   try {
-    const { data: { user } } = await client.auth.getUser();
+    // getSession reads the locally cached session — no network round-trip
+    // (getUser made one per log call). Anonymous inserts are rejected by RLS
+    // anyway, so skip them instead of erroring into the console.
+    const { data: { session } } = await client.auth.getSession();
+    if (!session?.user) return;
     await client.from('app_logs').insert({
-      user_id: user?.id || null,
+      user_id: session.user.id,
       level,
       message,
       metadata


### PR DESCRIPTION
Beta review Tier 2 items 8–9. Based on main — independent of the stacked deck-list PRs.

- **Password recovery finally completes** — landing from a reset email opens the auth dialog on a new *Set a New Password* view (password + confirm → `supabase.auth.updateUser`). Triggered by both the `PASSWORD_RECOVERY` auth event and a direct `type=recovery` URL-hash check, since Supabase can process the token before our listener registers. The recovery session no longer trips the fresh-login page reload.
- **Global error visibility** — new `js/core/telemetry.js` installs `window` error/unhandledrejection handlers (capped at 5 reports per page load) reporting through `logToSupabase`; wired on every page by `initLayout`.
- **Funnel events** — `logToSupabase` now always fires a matching GA event via a new `trackEvent` helper (email stripped, no PII to GA), so anonymous sessions become measurable. Export buttons log `export {format}`, signup logs `user_signed_up`, and the first mark-checkbox tick fires a GA-only `card_marked`. Covers the visit → first deck → first mark → export funnel.
- **logToSupabase gating** — uses locally cached `getSession()` instead of a network `getUser()` per log, and skips inserts for anonymous users (RLS rejects those rows anyway; they just errored into the console).

**Verify on the Netlify deploy preview:**
1. Request a password reset from "Having trouble signing in?", follow the email link back → the Set a New Password dialog opens; setting a matching password signs you in and the dialog closes
2. Anonymous session: console shows no `app_logs` 4xx errors while adding decks
3. GA DebugView (or `?gtag_debug`): `deck_added`, `card_marked`, `export` events arrive

`npm test` 6/6 pass; eslint clean on changed files.

https://claude.ai/code/session_01JRe1m3EKrqewMVr3jwAgDT

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRe1m3EKrqewMVr3jwAgDT)_