### PR TITLE
chore: eslint to green (delete dead code); correct CLAUDE.md corner-remap note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ Preferences: { colorScheme, defaultColors, stripeStartCorner ('top-right'|'top-l
   - Card in **subset**, stripes-style → child Side B stripe per matching variant
   - Card in **subset**, dots-style, exactly 1 variant → dot in that variant's color
   - Card in **subset**, dots-style, 2+ variants → dot conflict; membership anchors only, parent stripe only
-- **Stripe starting corner** — global preference controlling which card corner stripes originate from. Affects card preview, not stored data.
+- **Stripe starting corner** — global preference controlling which card corner stripes originate from. Applying it runs `remapPrismForCorner` (processor.js), which rewrites every stored `stripePosition`/`sideAPosition` so physical mark locations are preserved under the new numbering — slot numbers change and are saved/synced; the marks on sleeves don't move.
 - **markedCards** tracks which cards the user has physically marked (checkbox state)
 - **removedCards** tracks cards removed from decks that still need physical marks cleared
 - **syncState** is local-only metadata used for Supabase merge reconciliation; it is not part of the PRISM domain model. Baseline shape per prism: `{ updatedAt, deckUpdatedAts, splitGroupUpdatedAts, deletedDecks, deletedSplitGroups, unmarkedCards: { [cardKey]: isoTimestamp } }`

--- a/js/features/analysis.js
+++ b/js/features/analysis.js
@@ -4,7 +4,7 @@
 
 import { state } from '../core/state.js';
 import { escapeHtml } from '../core/utils.js';
-import { processCards, calculateOverlap, getColorName } from '../modules/processor.js';
+import { processCards, calculateOverlap } from '../modules/processor.js';
 
 // ============================================================================
 // Overlap Matrix

--- a/js/features/export-view.js
+++ b/js/features/export-view.js
@@ -4,7 +4,7 @@
 
 import { state } from '../core/state.js';
 import { escapeHtml } from '../core/utils.js';
-import { formatSlotLabel, getColorName, getPositionOccupants } from '../modules/processor.js';
+import { formatSlotLabel, getPositionOccupants } from '../modules/processor.js';
 import { handleStripeReorder, handlePositionChange } from './deck-list.js';
 
 // ============================================================================

--- a/js/features/stripe-reorder-dialog.js
+++ b/js/features/stripe-reorder-dialog.js
@@ -285,39 +285,6 @@ function renderSleeveVisualization(activeDeck, slotMap) {
 }
 
 // ============================================================================
-// Legend (occupied slots only)
-// ============================================================================
-
-function renderLegend(slotMap, activeDeckId) {
-  const occupied = [...slotMap.entries()].sort((a, b) => a[0] - b[0]);
-  if (occupied.length === 0) return null;
-
-  const activeDeck = state.currentPrism.decks.find(d => d.id === activeDeckId);
-
-  const legend = document.createElement('div');
-  legend.className = 'stripe-reorder-legend';
-
-  const items = occupied.map(([pos, info]) => {
-    const isActive = activeDeck?.stripePosition === pos;
-    const disabledNote = info.disabled ? ' <span style="opacity:0.6;">(locked)</span>' : '';
-    const activeNote = isActive ? ' <span style="color: var(--wa-color-success-text);">(moving)</span>' : '';
-    return `
-      <div class="wa-cluster wa-gap-xs wa-align-items-center">
-        <div class="deck-color-indicator small" style="background-color: ${info.color}; opacity: ${info.disabled ? '0.5' : '1'};"></div>
-        <span class="wa-caption-s">${escapeHtml(formatSlotLabel(pos))}: ${escapeHtml(info.name)}${activeNote}${disabledNote}</span>
-      </div>
-    `;
-  });
-
-  legend.innerHTML = `
-    <p class="wa-caption-xs" style="color: var(--wa-color-neutral-text-subtle); margin-bottom: var(--wa-space-2xs);">OCCUPIED SLOTS</p>
-    <div class="wa-cluster wa-gap-s" style="flex-wrap: wrap;">${items.join('')}</div>
-  `;
-
-  return legend;
-}
-
-// ============================================================================
 // Public helpers used by deck-list.js
 // ============================================================================
 

--- a/js/modules/card-preview.js
+++ b/js/modules/card-preview.js
@@ -14,7 +14,6 @@ function frontFaceName(name) {
 // Display dimensions (half of Scryfall 'normal' 488x680)
 const DISPLAY_WIDTH = 244;
 const DISPLAY_HEIGHT = 340;
-const SCALE = 0.5; // Display scale factor
 
 // Stripe positioning at display scale
 // 24 slots per side, spanning the card art area

--- a/js/modules/moxfield.js
+++ b/js/modules/moxfield.js
@@ -56,7 +56,7 @@ export function transformMoxfieldDeck(moxfieldDeck) {
 
   // Process commanders first
   if (moxfieldDeck.boards?.commanders?.cards) {
-    for (const [cardName, cardData] of Object.entries(moxfieldDeck.boards.commanders.cards)) {
+    for (const cardData of Object.values(moxfieldDeck.boards.commanders.cards)) {
       // Use first commander as the deck's commander
       if (!commander) {
         commander = cardData.card.name;
@@ -72,7 +72,7 @@ export function transformMoxfieldDeck(moxfieldDeck) {
 
   // Process mainboard
   if (moxfieldDeck.boards?.mainboard?.cards) {
-    for (const [cardName, cardData] of Object.entries(moxfieldDeck.boards.mainboard.cards)) {
+    for (const cardData of Object.values(moxfieldDeck.boards.mainboard.cards)) {
       const card = cardData.card;
       const isBasicLand = isBasicLandCard(card);
 
@@ -87,7 +87,7 @@ export function transformMoxfieldDeck(moxfieldDeck) {
 
   // Process companions (add to mainboard)
   if (moxfieldDeck.boards?.companions?.cards) {
-    for (const [cardName, cardData] of Object.entries(moxfieldDeck.boards.companions.cards)) {
+    for (const cardData of Object.values(moxfieldDeck.boards.companions.cards)) {
       cards.push({
         name: cardData.card.name,
         quantity: cardData.quantity || 1,

--- a/js/modules/processor.js
+++ b/js/modules/processor.js
@@ -1050,7 +1050,6 @@ export function unsplitGroup(prism, groupId) {
 
 	const now = new Date().toISOString();
 	const childIds = new Set(group.childDeckIds);
-	const firstChild = prism.decks.find((d) => d.id === group.childDeckIds[0]);
 
 	// Convert first child back to standalone at the group's Side A position
 	const updatedDecks = prism.decks

--- a/js/modules/scryfall.js
+++ b/js/modules/scryfall.js
@@ -30,7 +30,7 @@ function loadCache() {
 function saveCache(cache) {
   try {
     localStorage.setItem(CACHE_KEY, JSON.stringify(cache));
-  } catch (e) {
+  } catch {
     // localStorage full - clear old entries
     console.warn('Scryfall cache full, clearing old entries');
     clearExpiredCache();

--- a/js/modules/storage.js
+++ b/js/modules/storage.js
@@ -515,7 +515,7 @@ export function onSyncStatusChange(cb) {
 
 function emitSyncStatus(status, detail) {
   syncStatusListeners.forEach(cb => {
-    try { cb(status, detail); } catch (_) {}
+    try { cb(status, detail); } catch { /* listener errors must not break sync */ }
   });
 }
 


### PR DESCRIPTION
Beta review Tier 2 items 12–13. `npx eslint js/` now exits clean (was 11 errors), entirely by deleting dead code:

- Unused `getColorName` imports (analysis.js, export-view.js)
- Dead `renderLegend` in stripe-reorder-dialog.js (built a legend node that was never appended)
- Unused `SCALE` constant (card-preview.js) and `firstChild` lookup (processor.js `unsplitGroup`)
- moxfield.js board loops iterate `Object.values` instead of destructuring an unused `cardName` (×3)
- Unused catch bindings in scryfall.js `saveCache` and storage.js `emitSyncStatus` (the empty block gains an explanatory comment)

Also corrects the stale CLAUDE.md stripe-starting-corner bullet: since the Apply-remap change, switching corners rewrites stored slot numbers via `remapPrismForCorner` (physical mark locations preserved) — it is not a preview-only preference.

No behaviour changes. `npm test` 6/6 pass.

Note: the unused `getColorName` import removal in export-view.js touches the same import line region as nothing else — but analysis.js/export-view.js are also edited by open PRs in *different* hunks; merge order doesn't matter, git resolves them.

https://claude.ai/code/session_01JRe1m3EKrqewMVr3jwAgDT

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRe1m3EKrqewMVr3jwAgDT)_