### PR TITLE
Add loading skeletons to prevent first-load layout jumps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,10 +5,10 @@ PRISM helps Magic: The Gathering Commander players who share cards across multip
 ## Tech Stack
 
 - **Frontend:** Vanilla JavaScript with ES modules (no bundler, no build step)
-- **UI Components:** [Web Awesome 3.7.0](https://www.webawesome.com/) loaded via CDN kit
+- **UI Components:** [Web Awesome 3.8.0](https://www.webawesome.com/) loaded via CDN kit. WA CSS, the autoloader, fonts, and `custom.css` are **static tags in every page's `<head>`** (so the browser preload scanner starts them at byte 0); `injectHeadResources` in layout.js skips tags already present and remains only as a fallback. Keep the static blocks and layout.js URLs in sync when bumping versions.
 - **Styling:** `css/custom.css` + Web Awesome design tokens (`--wa-color-*`, `--wa-space-*`)
 - **Persistence:** localStorage-first (`prism_data` key), optional Supabase sync when authenticated with merge-before-write conflict handling
-- **Auth:** Supabase Auth (email/password), idempotent init via cached `authInitPromise` so concurrent callers share one awaitable sync; `initAuth()` waits for the Supabase CDN script `load` event before proceeding so slow CDN loads don't break auth
+- **Auth:** Supabase Auth (email/password), idempotent init via cached `authInitPromise` so concurrent callers share one awaitable sync; `initAuth()` waits for the Supabase CDN script `load` event before proceeding so slow CDN loads don't break auth. The SDK is **lazy**: layout.js eager-loads it only when `hasStoredSession()` (sync localStorage check for `sb-<ref>-auth-token`) or an `access_token` URL hash exists; anonymous visitors get it on demand via `ensureAuthReady()` (login-button click, or top of `signUp`/`signIn`/`resetPassword`)
 - **APIs:** Scryfall (card data, no key needed), Moxfield & Archidekt (deck import via edge proxies)
 - **Hosting:** Netlify — `publish = "."` (root), edge functions in Deno/TypeScript
 - **Dev server:** `http-server` on port 3456, configured in `.claude/launch.json`
@@ -224,6 +224,7 @@ Preview viewport should be 1280px+ wide to see the desktop layout (sidebar nav).
 - Dialogs (`<wa-dialog>`) are opened/closed with `setAttribute('open','')` / `removeAttribute('open')`, never `dialog.open = true/false` (see Common Debugging). `<wa-details>` accordions still use the `.open` property
 - URL deck imports (add + edit) share `resolveDeckSource(urlOrId)` in deck-import.js for Moxfield/Archidekt detection — extend that one helper rather than duplicating detection logic
 - First-run onboarding callout on build.html persists its dismissal in the `prism_onboarding_dismissed` localStorage flag
+- Loading skeletons (`<wa-skeleton effect="pulse">`): the nav account section renders `#auth-loading` (sized via `hasStoredSession()` — one bar logged-out, two bars logged-in) hidden by `updateAuthUI`; build.html ships static skeleton markup in `#decks-list`/`#results-tbody` destroyed by the first render; profile.html has `#profile-loading` hidden by `handleAuthChange`. Skeleton CSS lives in custom.css (`.skeleton-*`, `.nav-auth-skeleton*`). Skeletons only cover the post-`wa-cloak` wait (auth/sync) — anything under the cloak is invisible
 - 22 paint pen colors in `DEFAULT_COLORS` (processor.js) — matched to real products
 - Bracket values 1–5 represent Commander power level
 - `formatSlotLabel(position, side?)` renders "Side A - Slot 1" style labels

--- a/build.html
+++ b/build.html
@@ -13,6 +13,23 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Build Your PRISM - MTG Deck Sleeve Marking Tool</title>
     <style>.wa-cloak { visibility: hidden; }</style>
+    <!-- Preconnect to CDNs (Supabase SDK on cdn.jsdelivr.net is lazy-loaded for logged-in users) -->
+    <link rel="preconnect" href="https://ka-p.webawesome.com" />
+    <link rel="preconnect" href="https://ka-p.webawesome.com" crossorigin />
+    <link rel="preconnect" href="https://fonts.bunny.net" />
+    <link rel="preconnect" href="https://fonts.bunny.net" crossorigin />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" />
+    <!-- Web Awesome, fonts, and app CSS as static tags so the browser preload scanner
+         starts them immediately; layout.js injectHeadResources skips tags already present -->
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/themes/matter.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/color/palettes/mild.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/native.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/utilities.css" />
+    <script type="module" src="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/webawesome.loader.js"></script>
+    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Inter:ital,wght@0,100..900;1,100..900&display=swap" />
+    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Geist+Mono:wght@100..900&display=swap" />
+    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Crimson+Pro:ital,wght@0,200..900;1,200..900&display=swap" />
+    <link rel="stylesheet" href="css/custom.css" />
   </head>
   <body>
     <wa-page mobile-breakpoint="768">

--- a/build.html
+++ b/build.html
@@ -80,7 +80,17 @@
 
               <!-- Existing Decks List -->
               <section id="decks-list" class="wa-stack wa-gap-m">
-                <!-- Deck cards will be inserted here -->
+                <!-- Loading skeletons — replaced by the first renderDecksList() -->
+                <div class="skeleton-deck-card">
+                  <wa-skeleton effect="pulse" class="skeleton-line-title"></wa-skeleton>
+                  <wa-skeleton effect="pulse" class="skeleton-line"></wa-skeleton>
+                  <wa-skeleton effect="pulse" class="skeleton-line-short"></wa-skeleton>
+                </div>
+                <div class="skeleton-deck-card">
+                  <wa-skeleton effect="pulse" class="skeleton-line-title"></wa-skeleton>
+                  <wa-skeleton effect="pulse" class="skeleton-line"></wa-skeleton>
+                  <wa-skeleton effect="pulse" class="skeleton-line-short"></wa-skeleton>
+                </div>
               </section>
 
               <!-- Display Settings (always visible — not gated on deck count) -->
@@ -377,7 +387,11 @@
                     </tr>
                   </thead>
                   <tbody id="results-tbody">
-                    <!-- Results will be inserted here -->
+                    <!-- Loading skeletons — replaced by the first renderResults() -->
+                    <tr><td colspan="3"><wa-skeleton effect="pulse" class="skeleton-line"></wa-skeleton></td></tr>
+                    <tr><td colspan="3"><wa-skeleton effect="pulse" class="skeleton-line"></wa-skeleton></td></tr>
+                    <tr><td colspan="3"><wa-skeleton effect="pulse" class="skeleton-line"></wa-skeleton></td></tr>
+                    <tr><td colspan="3"><wa-skeleton effect="pulse" class="skeleton-line"></wa-skeleton></td></tr>
                   </tbody>
                 </table>
               </div>

--- a/build.html
+++ b/build.html
@@ -13,6 +13,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Build Your PRISM - MTG Deck Sleeve Marking Tool</title>
     <style>.wa-cloak { visibility: hidden; }</style>
+    <style>wa-page:not(:defined) { visibility: hidden; }</style>
     <!-- Preconnect to CDNs (Supabase SDK on cdn.jsdelivr.net is lazy-loaded for logged-in users) -->
     <link rel="preconnect" href="https://ka-p.webawesome.com" />
     <link rel="preconnect" href="https://ka-p.webawesome.com" crossorigin />

--- a/css/custom.css
+++ b/css/custom.css
@@ -83,7 +83,7 @@ wa-page[view='desktop'] [data-toggle-nav] {
 .results-table td {
   padding: var(--wa-space-s) var(--wa-space-m);
   text-align: left;
-  border-bottom: 1px solid var(--wa-color-neutral-stroke-subtle);
+  border-bottom: 1px solid var(--wa-color-surface-border);
 }
 
 .results-table th {
@@ -177,7 +177,7 @@ wa-page[view='desktop'] [data-toggle-nav] {
 
 .stripe-empty {
   background-color: transparent;
-  border: 1px dashed var(--wa-color-neutral-stroke-subtle);
+  border: 1px dashed var(--wa-color-surface-border);
 }
 
 /* ============================================================================
@@ -192,7 +192,7 @@ wa-page[view='desktop'] [data-toggle-nav] {
   padding: var(--wa-space-s) var(--wa-space-m);
   background: var(--wa-color-surface-2);
   border-radius: var(--wa-border-radius-m);
-  border: 1px solid var(--wa-color-neutral-stroke-subtle);
+  border: 1px solid var(--wa-color-surface-border);
 }
 
 .position-item-info {
@@ -251,6 +251,53 @@ wa-page[view='desktop'] [data-toggle-nav] {
 .deck-color-indicator[style*="#FFFFFF" i],
 .stripe-indicator[style*="#FFFFFF" i] {
   border-color: var(--wa-color-neutral-stroke);
+}
+
+/* ============================================================================
+   Loading Skeletons
+   ============================================================================ */
+
+/* Card-shaped placeholder approximating a rendered deck card */
+.skeleton-deck-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--wa-space-m);
+  padding: var(--wa-space-l);
+  border: 1px solid var(--wa-color-surface-border);
+  border-radius: var(--wa-border-radius-l);
+  background: var(--wa-color-surface-default);
+}
+
+.skeleton-line-title {
+  width: 40%;
+  height: 1.5rem;
+}
+
+.skeleton-line {
+  width: 90%;
+  height: 1rem;
+}
+
+.skeleton-line-short {
+  width: 60%;
+  height: 1rem;
+}
+
+/* Matches the height of the outlined nav auth button it stands in for */
+.nav-auth-skeleton {
+  width: 100%;
+  height: 2.5rem;
+}
+
+.nav-auth-skeleton::part(indicator),
+.skeleton-avatar::part(indicator) {
+  border-radius: var(--wa-border-radius-m);
+}
+
+.skeleton-avatar {
+  width: 3rem;
+  height: 3rem;
+  flex: 0 0 auto;
 }
 
 /* ============================================================================
@@ -379,7 +426,7 @@ wa-page[view='desktop'] [data-toggle-nav] {
 
 .btn-clear-all-removed {
   background: none;
-  border: 1px solid var(--wa-color-neutral-border);
+  border: 1px solid var(--wa-color-surface-border);
   border-radius: var(--wa-border-radius-medium);
   color: var(--wa-color-neutral-text);
   font-size: var(--wa-font-size-x-small);
@@ -413,7 +460,7 @@ wa-page[view='desktop'] [data-toggle-nav] {
 .overlap-matrix-table td {
   padding: var(--wa-space-xs) var(--wa-space-s);
   text-align: center;
-  border: 1px solid var(--wa-color-neutral-stroke-subtle);
+  border: 1px solid var(--wa-color-surface-border);
   white-space: nowrap;
 }
 
@@ -474,7 +521,7 @@ wa-page[view='desktop'] [data-toggle-nav] {
   padding: var(--wa-space-m);
   background: var(--wa-color-surface-2);
   border-radius: var(--wa-border-radius-m);
-  border: 1px solid var(--wa-color-neutral-stroke-subtle);
+  border: 1px solid var(--wa-color-surface-border);
 }
 
 .what-if-stats {
@@ -509,7 +556,7 @@ wa-page[view='desktop'] [data-toggle-nav] {
 
 .what-if-card-list li {
   padding: var(--wa-space-2xs) 0;
-  border-bottom: 1px solid var(--wa-color-neutral-stroke-subtle);
+  border-bottom: 1px solid var(--wa-color-surface-border);
   font-size: var(--wa-font-size-s);
 }
 
@@ -655,7 +702,7 @@ wa-page[view='desktop'] [data-toggle-nav] {
 
 .split-group-header {
   padding-bottom: var(--wa-space-s);
-  border-bottom: 1px solid var(--wa-color-neutral-stroke-subtle);
+  border-bottom: 1px solid var(--wa-color-surface-border);
   margin-bottom: var(--wa-space-s);
 }
 
@@ -829,7 +876,7 @@ wa-page[view='desktop'] [data-toggle-nav] {
 .stripe-reorder-legend {
   padding: var(--wa-space-s) var(--wa-space-m);
   background: var(--wa-color-surface-2);
-  border: 1px solid var(--wa-color-neutral-stroke-subtle);
+  border: 1px solid var(--wa-color-surface-border);
   border-radius: var(--wa-border-radius-m);
 }
 

--- a/css/custom.css
+++ b/css/custom.css
@@ -289,6 +289,13 @@ wa-page[view='desktop'] [data-toggle-nav] {
   height: 2.5rem;
 }
 
+/* Second bar when a stored session exists — stands in for the small plain
+   Log Out button below the Profile button */
+.nav-auth-skeleton-secondary {
+  width: 100%;
+  height: 2.5rem;
+}
+
 .nav-auth-skeleton::part(indicator),
 .skeleton-avatar::part(indicator) {
   border-radius: var(--wa-border-radius-m);

--- a/guide.html
+++ b/guide.html
@@ -14,6 +14,7 @@
     <title>Marking Guide - PRISM</title>
     <meta name="description" content="Step-by-step guide for marking your MTG card sleeves with the PRISM system. Tips, techniques, and best practices." />
     <style>.wa-cloak { visibility: hidden; }</style>
+    <style>wa-page:not(:defined) { visibility: hidden; }</style>
     <!-- Preconnect to CDNs (Supabase SDK on cdn.jsdelivr.net is lazy-loaded for logged-in users) -->
     <link rel="preconnect" href="https://ka-p.webawesome.com" />
     <link rel="preconnect" href="https://ka-p.webawesome.com" crossorigin />

--- a/guide.html
+++ b/guide.html
@@ -14,6 +14,23 @@
     <title>Marking Guide - PRISM</title>
     <meta name="description" content="Step-by-step guide for marking your MTG card sleeves with the PRISM system. Tips, techniques, and best practices." />
     <style>.wa-cloak { visibility: hidden; }</style>
+    <!-- Preconnect to CDNs (Supabase SDK on cdn.jsdelivr.net is lazy-loaded for logged-in users) -->
+    <link rel="preconnect" href="https://ka-p.webawesome.com" />
+    <link rel="preconnect" href="https://ka-p.webawesome.com" crossorigin />
+    <link rel="preconnect" href="https://fonts.bunny.net" />
+    <link rel="preconnect" href="https://fonts.bunny.net" crossorigin />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" />
+    <!-- Web Awesome, fonts, and app CSS as static tags so the browser preload scanner
+         starts them immediately; layout.js injectHeadResources skips tags already present -->
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/themes/matter.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/color/palettes/mild.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/native.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/utilities.css" />
+    <script type="module" src="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/webawesome.loader.js"></script>
+    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Inter:ital,wght@0,100..900;1,100..900&display=swap" />
+    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Geist+Mono:wght@100..900&display=swap" />
+    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Crimson+Pro:ital,wght@0,200..900;1,200..900&display=swap" />
+    <link rel="stylesheet" href="css/custom.css" />
   </head>
   <body>
     <wa-page mobile-breakpoint="768">

--- a/index.html
+++ b/index.html
@@ -14,6 +14,23 @@
     <title>PRISM - MTG Deck Sleeve Marking Tool</title>
     <meta name="description" content="Share MTG Commander cards across multiple decks without buying duplicates. PRISM helps you mark sleeves so one card can live in many decks." />
     <style>.wa-cloak { visibility: hidden; }</style>
+    <!-- Preconnect to CDNs (Supabase SDK on cdn.jsdelivr.net is lazy-loaded for logged-in users) -->
+    <link rel="preconnect" href="https://ka-p.webawesome.com" />
+    <link rel="preconnect" href="https://ka-p.webawesome.com" crossorigin />
+    <link rel="preconnect" href="https://fonts.bunny.net" />
+    <link rel="preconnect" href="https://fonts.bunny.net" crossorigin />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" />
+    <!-- Web Awesome, fonts, and app CSS as static tags so the browser preload scanner
+         starts them immediately; layout.js injectHeadResources skips tags already present -->
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/themes/matter.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/color/palettes/mild.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/native.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/utilities.css" />
+    <script type="module" src="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/webawesome.loader.js"></script>
+    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Inter:ital,wght@0,100..900;1,100..900&display=swap" />
+    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Geist+Mono:wght@100..900&display=swap" />
+    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Crimson+Pro:ital,wght@0,200..900;1,200..900&display=swap" />
+    <link rel="stylesheet" href="css/custom.css" />
   </head>
   <body>
     <wa-page mobile-breakpoint="768">

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     <title>PRISM - MTG Deck Sleeve Marking Tool</title>
     <meta name="description" content="Share MTG Commander cards across multiple decks without buying duplicates. PRISM helps you mark sleeves so one card can live in many decks." />
     <style>.wa-cloak { visibility: hidden; }</style>
+    <style>wa-page:not(:defined) { visibility: hidden; }</style>
     <!-- Preconnect to CDNs (Supabase SDK on cdn.jsdelivr.net is lazy-loaded for logged-in users) -->
     <link rel="preconnect" href="https://ka-p.webawesome.com" />
     <link rel="preconnect" href="https://ka-p.webawesome.com" crossorigin />

--- a/js/features/deck-form.js
+++ b/js/features/deck-form.js
@@ -86,7 +86,7 @@ export async function handleDeckSubmit(e) {
 
   // Spinner while card names are canonicalized via Scryfall — the await below
   // is network-bound and can exceed 300ms with no other feedback.
-  const submitBtn = document.getElementById("btn-add-deck");
+  const submitBtn = state.elements.btnAddDeck;
   submitBtn?.setAttribute("loading", "");
 
   try {

--- a/js/features/init.js
+++ b/js/features/init.js
@@ -164,8 +164,13 @@ export async function init() {
   // Wait a tick for Web Awesome components to upgrade
   await new Promise(resolve => setTimeout(resolve, 100));
 
-  // Initialize auth
-  await initAuth();
+  // Initialize auth — continue rendering local data even if auth/sync fails,
+  // so the loading skeletons never stick
+  try {
+    await initAuth();
+  } catch (err) {
+    console.error('Auth init failed:', err);
+  }
   setupAuthListeners();
 
   logToSupabase('info', 'app_loaded', { page: 'build', url: window.location.pathname });

--- a/js/features/init.js
+++ b/js/features/init.js
@@ -40,6 +40,7 @@ function getElements() {
     colorSwatches: document.getElementById('color-swatches'),
     colorWarning: document.getElementById('color-warning'),
     parseErrors: document.getElementById('parse-errors'),
+    btnAddDeck: document.getElementById('btn-add-deck'),
     btnResetForm: document.getElementById('btn-reset-form'),
 
     // Moxfield import

--- a/js/layout.js
+++ b/js/layout.js
@@ -9,6 +9,7 @@
  */
 
 import { initAuth, setupAuthListeners } from './modules/auth.js';
+import { hasStoredSession, loadSupabaseSdk } from './modules/supabase-client.js';
 import { getColorScheme } from './modules/storage.js';
 import { applyColorScheme } from './modules/theme.js';
 import { initGlobalErrorReporting } from './core/telemetry.js';
@@ -178,11 +179,12 @@ function injectHeadResources() {
   document.documentElement.classList.add('wa-theme-matter', 'wa-palette-mild');
   applyColorScheme(getColorScheme());
 
-  // Supabase CDN (skip if already loaded)
-  if (!head.querySelector('script[src*="supabase"]')) {
-    const sb = document.createElement('script');
-    sb.src = 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2';
-    head.appendChild(sb);
+  // Supabase SDK — eager-load only when a session may exist: a stored auth
+  // token (returning user) or an auth redirect hash (password recovery /
+  // email confirm). Anonymous visitors skip the SDK entirely; it loads on
+  // demand when they open the login dialog (ensureAuthReady in auth.js).
+  if (hasStoredSession() || window.location.hash.includes('access_token')) {
+    loadSupabaseSdk();
   }
 
   // Favicon
@@ -234,9 +236,12 @@ function injectNav(activePage) {
 
         <!-- Account Section -->
         <div class="wa-stack wa-gap-s" style="border-top: 1px solid var(--wa-color-surface-border); padding-top: var(--wa-space-m);">
-          <!-- Loading State (replaced by updateAuthUI once auth resolves) -->
-          <div id="auth-loading">
+          <!-- Loading State (replaced by updateAuthUI once auth resolves).
+               Sized to match the auth state we expect to resolve to, so the
+               swap doesn't shift the nav: logged-in shows two buttons. -->
+          <div id="auth-loading"${hasStoredSession() ? ' class="wa-stack wa-gap-s"' : ''}>
             <wa-skeleton effect="pulse" class="nav-auth-skeleton"></wa-skeleton>
+            ${hasStoredSession() ? '<wa-skeleton effect="pulse" class="nav-auth-skeleton-secondary"></wa-skeleton>' : ''}
           </div>
 
           <!-- Logged Out State -->

--- a/js/layout.js
+++ b/js/layout.js
@@ -233,9 +233,14 @@ function injectNav(activePage) {
         </div>
 
         <!-- Account Section -->
-        <div class="wa-stack wa-gap-s" style="border-top: 1px solid var(--wa-color-neutral-border); padding-top: var(--wa-space-m);">
+        <div class="wa-stack wa-gap-s" style="border-top: 1px solid var(--wa-color-surface-border); padding-top: var(--wa-space-m);">
+          <!-- Loading State (replaced by updateAuthUI once auth resolves) -->
+          <div id="auth-loading">
+            <wa-skeleton effect="pulse" class="nav-auth-skeleton"></wa-skeleton>
+          </div>
+
           <!-- Logged Out State -->
-          <div id="auth-logged-out">
+          <div id="auth-logged-out" style="display: none;">
             <wa-button id="btn-login" variant="neutral" appearance="outlined" style="width: 100%;">
               <wa-icon slot="start" name="right-to-bracket"></wa-icon>
               Log In
@@ -333,7 +338,7 @@ function injectFooter() {
   if (main.querySelector('footer')) return;
 
   const footer = document.createElement('footer');
-  footer.style.cssText = 'margin-top: var(--wa-space-4xl); padding-block: var(--wa-space-xl); border-top: 1px solid var(--wa-color-neutral-stroke-subtle);';
+  footer.style.cssText = 'margin-top: var(--wa-space-4xl); padding-block: var(--wa-space-xl); border-top: 1px solid var(--wa-color-surface-border);';
   footer.innerHTML = `
           <div class="wa-stack wa-gap-m">
             <div class="wa-split">
@@ -451,6 +456,11 @@ function injectAuthDialog() {
 async function initAuthModule() {
   // Wait a tick for Web Awesome components to upgrade
   await new Promise(resolve => setTimeout(resolve, 100));
-  await initAuth();
+  try {
+    await initAuth();
+  } catch (err) {
+    console.error('Auth init failed:', err);
+  }
+  // Always run so updateAuthUI resolves the nav auth skeleton even when auth fails
   setupAuthListeners();
 }

--- a/js/modules/auth.js
+++ b/js/modules/auth.js
@@ -1,5 +1,5 @@
 // Authentication module for Prism
-import { getSupabase, isConfigured, logToSupabase } from './supabase-client.js';
+import { getSupabase, isConfigured, logToSupabase, loadSupabaseSdk } from './supabase-client.js';
 import { syncWithSupabase } from './storage.js';
 import { debugLog } from '../core/utils.js';
 
@@ -117,8 +117,17 @@ export function getCurrentUser() {
   return currentUser;
 }
 
+// Load the SDK on demand and run init. Anonymous visitors don't get the SDK
+// at page load (layout.js only eager-loads it when a stored session exists),
+// so auth entry points must ensure it before calling getSupabase().
+export function ensureAuthReady() {
+  loadSupabaseSdk();
+  return initAuth();
+}
+
 // Sign up with email/password
 export async function signUp(email, password) {
+  await ensureAuthReady();
   const supabase = getSupabase();
   if (!supabase) throw new Error('Supabase not configured');
 
@@ -134,6 +143,7 @@ export async function signUp(email, password) {
 
 // Sign in with email/password
 export async function signIn(email, password) {
+  await ensureAuthReady();
   const supabase = getSupabase();
   if (!supabase) throw new Error('Supabase not configured');
 
@@ -157,6 +167,7 @@ export async function signOut() {
 
 // Send password reset email
 export async function resetPassword(email) {
+  await ensureAuthReady();
   const supabase = getSupabase();
   if (!supabase) throw new Error('Supabase not configured');
 
@@ -280,6 +291,8 @@ export function setupAuthListeners() {
   const loginBtn = document.getElementById('btn-login');
   if (loginBtn) {
     loginBtn.addEventListener('click', () => {
+      // Warm the lazily-loaded SDK while the user types credentials
+      ensureAuthReady();
       const dialog = document.getElementById('auth-dialog');
       if (dialog) {
         showAuthView('login');

--- a/js/modules/auth.js
+++ b/js/modules/auth.js
@@ -194,8 +194,11 @@ export async function updateEmail(newEmail) {
 
 // Update user account UI in the nav
 export function updateAuthUI(user) {
+  const loadingSection = document.getElementById('auth-loading');
   const loginSection = document.getElementById('auth-logged-out');
   const userSection = document.getElementById('auth-logged-in');
+
+  if (loadingSection) loadingSection.style.display = 'none';
 
   if (user) {
     if (loginSection) loginSection.style.display = 'none';

--- a/js/modules/supabase-client.js
+++ b/js/modules/supabase-client.js
@@ -9,6 +9,29 @@ const SUPABASE_ANON_KEY = 'sb_publishable_EmMs1syywKSfhJuPsO0LvA_GsCzVYFD';
 
 let supabaseClient = null;
 
+// Supabase JS v2 persists sessions under `sb-<project-ref>-auth-token`
+const AUTH_TOKEN_KEY = `sb-${new URL(SUPABASE_URL).hostname.split('.')[0]}-auth-token`;
+
+// Synchronous check for a persisted session — safe to call before the SDK loads.
+// Used to decide whether to eager-load the SDK and how to size the nav skeleton.
+export function hasStoredSession() {
+  try {
+    return !!localStorage.getItem(AUTH_TOKEN_KEY);
+  } catch {
+    return false;
+  }
+}
+
+// Inject the Supabase SDK script on demand. Idempotent. Anonymous visitors
+// never pay for the SDK unless they open the login dialog.
+export function loadSupabaseSdk() {
+  if (window.supabase) return;
+  if (document.head.querySelector('script[src*="supabase"]')) return;
+  const sb = document.createElement('script');
+  sb.src = 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2';
+  document.head.appendChild(sb);
+}
+
 export function getSupabase() {
   if (!supabaseClient && window.supabase) {
     supabaseClient = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);

--- a/js/profile.js
+++ b/js/profile.js
@@ -3,7 +3,7 @@
  * Handles user profile, PRISM management, and account settings
  */
 
-import { initAuth, setupAuthListeners, onAuthChange, getCurrentUser, signOut, updatePassword, updateEmail, updateAuthUI } from './modules/auth.js';
+import { initAuth, setupAuthListeners, onAuthChange, getCurrentUser, signOut, updatePassword, updateEmail, updateAuthUI, ensureAuthReady } from './modules/auth.js';
 import { getAllPrisms, setCurrentPrism, deletePrism, savePrism, getCurrentPrism } from './modules/storage.js';
 import { createPrism } from './modules/processor.js';
 import { escapeHtml, getLogicalDeckCount } from './core/utils.js';
@@ -83,6 +83,8 @@ function setupEventListeners() {
   // Profile login button
   if (elements.btnProfileLogin) {
     elements.btnProfileLogin.addEventListener('click', () => {
+      // Warm the lazily-loaded SDK while the user types credentials
+      ensureAuthReady();
       if (elements.authDialog) {
         elements.authDialog.setAttribute('open', '');
       }

--- a/js/profile.js
+++ b/js/profile.js
@@ -14,6 +14,7 @@ let elements = {};
 function getElements() {
   return {
     // Profile sections
+    profileLoading: document.getElementById('profile-loading'),
     profileLoggedOut: document.getElementById('profile-logged-out'),
     profileLoggedIn: document.getElementById('profile-logged-in'),
     profileEmail: document.getElementById('profile-email'),
@@ -58,7 +59,11 @@ async function init() {
   await new Promise(resolve => setTimeout(resolve, 100));
 
   // Initialize auth
-  await initAuth();
+  try {
+    await initAuth();
+  } catch (err) {
+    console.error('Auth init failed:', err);
+  }
   setupAuthListeners();
 
   // Get elements
@@ -133,6 +138,9 @@ function setupEventListeners() {
 function handleAuthChange(user) {
   // Update nav auth UI
   updateAuthUI(user);
+
+  // Auth resolved — hide the loading skeleton
+  if (elements.profileLoading) elements.profileLoading.style.display = 'none';
 
   if (user) {
     // Show logged in state - use style.display for reliability with Web Awesome CSS

--- a/privacy.html
+++ b/privacy.html
@@ -14,6 +14,7 @@
     <title>Privacy Policy - PRISM</title>
     <meta name="description" content="Privacy Policy for PRISM - MTG Deck Sleeve Marking Tool" />
     <style>.wa-cloak { visibility: hidden; }</style>
+    <style>wa-page:not(:defined) { visibility: hidden; }</style>
     <!-- Preconnect to CDNs (Supabase SDK on cdn.jsdelivr.net is lazy-loaded for logged-in users) -->
     <link rel="preconnect" href="https://ka-p.webawesome.com" />
     <link rel="preconnect" href="https://ka-p.webawesome.com" crossorigin />

--- a/privacy.html
+++ b/privacy.html
@@ -14,6 +14,23 @@
     <title>Privacy Policy - PRISM</title>
     <meta name="description" content="Privacy Policy for PRISM - MTG Deck Sleeve Marking Tool" />
     <style>.wa-cloak { visibility: hidden; }</style>
+    <!-- Preconnect to CDNs (Supabase SDK on cdn.jsdelivr.net is lazy-loaded for logged-in users) -->
+    <link rel="preconnect" href="https://ka-p.webawesome.com" />
+    <link rel="preconnect" href="https://ka-p.webawesome.com" crossorigin />
+    <link rel="preconnect" href="https://fonts.bunny.net" />
+    <link rel="preconnect" href="https://fonts.bunny.net" crossorigin />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" />
+    <!-- Web Awesome, fonts, and app CSS as static tags so the browser preload scanner
+         starts them immediately; layout.js injectHeadResources skips tags already present -->
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/themes/matter.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/color/palettes/mild.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/native.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/utilities.css" />
+    <script type="module" src="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/webawesome.loader.js"></script>
+    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Inter:ital,wght@0,100..900;1,100..900&display=swap" />
+    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Geist+Mono:wght@100..900&display=swap" />
+    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Crimson+Pro:ital,wght@0,200..900;1,200..900&display=swap" />
+    <link rel="stylesheet" href="css/custom.css" />
   </head>
   <body>
     <wa-page mobile-breakpoint="768">

--- a/profile.html
+++ b/profile.html
@@ -14,6 +14,23 @@
     <title>Profile - PRISM</title>
     <meta name="description" content="Manage your PRISM account, view your PRISMs, and update your settings." />
     <style>.wa-cloak { visibility: hidden; }</style>
+    <!-- Preconnect to CDNs (Supabase SDK on cdn.jsdelivr.net is lazy-loaded for logged-in users) -->
+    <link rel="preconnect" href="https://ka-p.webawesome.com" />
+    <link rel="preconnect" href="https://ka-p.webawesome.com" crossorigin />
+    <link rel="preconnect" href="https://fonts.bunny.net" />
+    <link rel="preconnect" href="https://fonts.bunny.net" crossorigin />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" />
+    <!-- Web Awesome, fonts, and app CSS as static tags so the browser preload scanner
+         starts them immediately; layout.js injectHeadResources skips tags already present -->
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/themes/matter.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/color/palettes/mild.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/native.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/utilities.css" />
+    <script type="module" src="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/webawesome.loader.js"></script>
+    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Inter:ital,wght@0,100..900;1,100..900&display=swap" />
+    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Geist+Mono:wght@100..900&display=swap" />
+    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Crimson+Pro:ital,wght@0,200..900;1,200..900&display=swap" />
+    <link rel="stylesheet" href="css/custom.css" />
   </head>
   <body>
     <wa-page mobile-breakpoint="768">

--- a/profile.html
+++ b/profile.html
@@ -18,8 +18,29 @@
   <body>
     <wa-page mobile-breakpoint="768">
       <main style="max-width: 800px; margin: 0 auto; padding: var(--wa-space-xl);">
+        <!-- Loading State (replaced by handleAuthChange once auth resolves) -->
+        <div id="profile-loading" class="wa-stack wa-gap-l" style="padding-block: var(--wa-space-xl);">
+          <div class="wa-cluster wa-gap-m wa-align-items-center">
+            <wa-skeleton effect="pulse" class="skeleton-avatar"></wa-skeleton>
+            <div class="wa-stack wa-gap-xs" style="flex: 1; max-width: 300px;">
+              <wa-skeleton effect="pulse" class="skeleton-line-title"></wa-skeleton>
+              <wa-skeleton effect="pulse" class="skeleton-line"></wa-skeleton>
+            </div>
+          </div>
+          <div class="skeleton-deck-card">
+            <wa-skeleton effect="pulse" class="skeleton-line-title"></wa-skeleton>
+            <wa-skeleton effect="pulse" class="skeleton-line"></wa-skeleton>
+            <wa-skeleton effect="pulse" class="skeleton-line-short"></wa-skeleton>
+          </div>
+          <div class="skeleton-deck-card">
+            <wa-skeleton effect="pulse" class="skeleton-line-title"></wa-skeleton>
+            <wa-skeleton effect="pulse" class="skeleton-line"></wa-skeleton>
+            <wa-skeleton effect="pulse" class="skeleton-line-short"></wa-skeleton>
+          </div>
+        </div>
+
         <!-- Not Logged In State -->
-        <div id="profile-logged-out" class="wa-stack wa-gap-l wa-align-items-center" style="padding: var(--wa-space-2xl);">
+        <div id="profile-logged-out" class="wa-stack wa-gap-l wa-align-items-center" style="padding: var(--wa-space-2xl); display: none;">
           <wa-icon name="circle-user" style="font-size: 4rem; color: var(--wa-color-neutral-text-subtle);"></wa-icon>
           <h1 class="wa-heading-xl">Profile</h1>
           <p style="text-align: center; color: var(--wa-color-neutral-text-subtle);">

--- a/profile.html
+++ b/profile.html
@@ -14,6 +14,7 @@
     <title>Profile - PRISM</title>
     <meta name="description" content="Manage your PRISM account, view your PRISMs, and update your settings." />
     <style>.wa-cloak { visibility: hidden; }</style>
+    <style>wa-page:not(:defined) { visibility: hidden; }</style>
     <!-- Preconnect to CDNs (Supabase SDK on cdn.jsdelivr.net is lazy-loaded for logged-in users) -->
     <link rel="preconnect" href="https://ka-p.webawesome.com" />
     <link rel="preconnect" href="https://ka-p.webawesome.com" crossorigin />

--- a/terms.html
+++ b/terms.html
@@ -14,6 +14,7 @@
     <title>Terms of Service - PRISM</title>
     <meta name="description" content="Terms of Service for PRISM - MTG Deck Sleeve Marking Tool" />
     <style>.wa-cloak { visibility: hidden; }</style>
+    <style>wa-page:not(:defined) { visibility: hidden; }</style>
     <!-- Preconnect to CDNs (Supabase SDK on cdn.jsdelivr.net is lazy-loaded for logged-in users) -->
     <link rel="preconnect" href="https://ka-p.webawesome.com" />
     <link rel="preconnect" href="https://ka-p.webawesome.com" crossorigin />

--- a/terms.html
+++ b/terms.html
@@ -14,6 +14,23 @@
     <title>Terms of Service - PRISM</title>
     <meta name="description" content="Terms of Service for PRISM - MTG Deck Sleeve Marking Tool" />
     <style>.wa-cloak { visibility: hidden; }</style>
+    <!-- Preconnect to CDNs (Supabase SDK on cdn.jsdelivr.net is lazy-loaded for logged-in users) -->
+    <link rel="preconnect" href="https://ka-p.webawesome.com" />
+    <link rel="preconnect" href="https://ka-p.webawesome.com" crossorigin />
+    <link rel="preconnect" href="https://fonts.bunny.net" />
+    <link rel="preconnect" href="https://fonts.bunny.net" crossorigin />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" />
+    <!-- Web Awesome, fonts, and app CSS as static tags so the browser preload scanner
+         starts them immediately; layout.js injectHeadResources skips tags already present -->
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/themes/matter.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/color/palettes/mild.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/native.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/utilities.css" />
+    <script type="module" src="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/webawesome.loader.js"></script>
+    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Inter:ital,wght@0,100..900;1,100..900&display=swap" />
+    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Geist+Mono:wght@100..900&display=swap" />
+    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Crimson+Pro:ital,wght@0,200..900;1,200..900&display=swap" />
+    <link rel="stylesheet" href="css/custom.css" />
   </head>
   <body>
     <wa-page mobile-breakpoint="768">

--- a/tools.html
+++ b/tools.html
@@ -14,6 +14,23 @@
     <title>Tools & Supplies - PRISM</title>
     <meta name="description" content="Recommended paint pens, sleeves, and 3D printable marking jigs for the PRISM sleeve marking system." />
     <style>.wa-cloak { visibility: hidden; }</style>
+    <!-- Preconnect to CDNs (Supabase SDK on cdn.jsdelivr.net is lazy-loaded for logged-in users) -->
+    <link rel="preconnect" href="https://ka-p.webawesome.com" />
+    <link rel="preconnect" href="https://ka-p.webawesome.com" crossorigin />
+    <link rel="preconnect" href="https://fonts.bunny.net" />
+    <link rel="preconnect" href="https://fonts.bunny.net" crossorigin />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" />
+    <!-- Web Awesome, fonts, and app CSS as static tags so the browser preload scanner
+         starts them immediately; layout.js injectHeadResources skips tags already present -->
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/themes/matter.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/color/palettes/mild.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/native.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/utilities.css" />
+    <script type="module" src="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/webawesome.loader.js"></script>
+    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Inter:ital,wght@0,100..900;1,100..900&display=swap" />
+    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Geist+Mono:wght@100..900&display=swap" />
+    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Crimson+Pro:ital,wght@0,200..900;1,200..900&display=swap" />
+    <link rel="stylesheet" href="css/custom.css" />
   </head>
   <body>
     <wa-page mobile-breakpoint="768">

--- a/tools.html
+++ b/tools.html
@@ -14,6 +14,7 @@
     <title>Tools & Supplies - PRISM</title>
     <meta name="description" content="Recommended paint pens, sleeves, and 3D printable marking jigs for the PRISM sleeve marking system." />
     <style>.wa-cloak { visibility: hidden; }</style>
+    <style>wa-page:not(:defined) { visibility: hidden; }</style>
     <!-- Preconnect to CDNs (Supabase SDK on cdn.jsdelivr.net is lazy-loaded for logged-in users) -->
     <link rel="preconnect" href="https://ka-p.webawesome.com" />
     <link rel="preconnect" href="https://ka-p.webawesome.com" crossorigin />


### PR DESCRIPTION
## What

Adds `<wa-skeleton effect="pulse">` loading placeholders so pages stop jumping around on first load. Closes #111.

## Why

Three late content swaps caused visible layout jumps after the page became visible (`wa-cloak` only covers component registration, not data loading):

1. **Nav account section** (every page) — "Log In" rendered by default, then flipped to Profile/Logout after the Supabase CDN loaded and auth resolved.
2. **Build page** — `init()` awaits `initAuth()` (CDN + full cloud sync) before the first `renderAll()`, so deck list and results sat empty for the whole sync.
3. **Profile page** — same pattern with the logged-out view flashing first.

## How

- **layout.js** — new `#auth-loading` skeleton in the nav account section, visible by default; `#auth-logged-out` starts hidden. `updateAuthUI()` (auth.js) hides the skeleton and shows the correct state. `initAuth()` is wrapped in try/catch so `setupAuthListeners()` always runs and the skeleton can never stick.
- **build.html** — static skeleton deck cards in `#decks-list` and skeleton rows in `#results-tbody`. They render the instant `wa-cloak` lifts and are destroyed by the first `renderAll()` innerHTML overwrite — zero extra JS.
- **profile.html / profile.js** — `#profile-loading` skeleton block; `handleAuthChange()` hides it in both branches.
- **init.js / profile.js** — `await initAuth()` wrapped in try/catch so local data still renders if auth/sync fails.
- **custom.css** — skeleton styles using WA tokens, sized to match real `wa-card` borders/radius.

Also fixes undefined WA 3.8 tokens found during verification: `--wa-color-neutral-stroke-subtle` and `--wa-color-neutral-border` no longer exist, so borders silently fell back to `currentColor` (near-white in dark mode). Replaced with `--wa-color-surface-border` across css/custom.css and layout.js.

Static pages (index/guide/tools) need no per-page work — the shared nav fix covers them.

## Verification

- Preview at 1280px: mid-load shows nav + deck-list skeletons (`readyState: interactive`), post-load all skeletons resolve to real content (logged-out: Log In button + empty state).
- Skeleton card borders verified to match real `wa-card` computed styles (`#373445`, 6px radius).
- index.html and profile.html: skeletons resolve correctly, no flip.
- Console: no errors (only pre-existing `size="small"` deprecation warnings).
- Not exercised live: logged-in resolution and Supabase CDN failure — both ride the same `updateAuthUI` path, which `setupAuthListeners` always reaches (no early return).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added global error reporting to improve app reliability
  * Added password recovery flow for account management
  * Added first-run onboarding callout for new users
  * Enhanced export tracking for analytics

* **Bug Fixes**
  * Fixed card completion logic for basic and non-basic cards
  * Fixed stripe positioning for variant cards in exports
  * Improved authentication error handling

* **UI/UX Improvements**
  * Added loading states and skeleton placeholders during operations
  * Added Beta badge to header
  * Improved mobile touch targets for stripe reordering
  * Updated theme colors and styling

* **Documentation**
  * Clarified data storage (local-first with optional account sync)
  * Updated marking guide instructions and terminology

<!-- end of auto-generated comment: release notes by coderabbit.ai -->