### PR TITLE
Claude/mpc autofill stripe positioning kc98p4

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -915,3 +915,120 @@ wa-page[view='desktop'] [data-toggle-nav] {
     cursor: pointer;
   }
 }
+
+/* ============================================
+   MPC Stripe Compositor (mpc-stripes.html)
+   ============================================ */
+
+.mpc-preview-layout {
+  display: grid;
+  grid-template-columns: minmax(260px, 360px) 1fr;
+  gap: var(--wa-space-xl);
+  align-items: start;
+}
+
+@media (max-width: 768px) {
+  .mpc-preview-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Canvas is native image resolution; scale it down to fit its column */
+.mpc-preview-canvas {
+  width: 100%;
+  height: auto;
+  border-radius: var(--wa-border-radius-s);
+  box-shadow: var(--wa-shadow-m);
+  background: var(--wa-color-surface-2);
+}
+
+.mpc-geom-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+  gap: var(--wa-space-m);
+}
+
+.mpc-match-table-wrap {
+  max-height: 420px;
+  overflow: auto;
+  border: 1px solid var(--wa-color-surface-border);
+  border-radius: var(--wa-border-radius-s);
+}
+
+.mpc-match-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--wa-font-size-s);
+}
+
+.mpc-match-table th,
+.mpc-match-table td {
+  padding: var(--wa-space-xs) var(--wa-space-s);
+  text-align: left;
+  border-bottom: 1px solid var(--wa-color-surface-border);
+  vertical-align: middle;
+}
+
+.mpc-match-table thead th {
+  position: sticky;
+  top: 0;
+  background: var(--wa-color-surface-2);
+  z-index: 1;
+}
+
+.mpc-filename {
+  font-family: var(--wa-font-family-code, monospace);
+  word-break: break-all;
+}
+
+.mpc-match-ok {
+  font-weight: var(--wa-font-weight-semibold);
+}
+
+.mpc-match-marks {
+  margin-left: var(--wa-space-xs);
+  color: var(--wa-color-neutral-text-subtle);
+  font-size: var(--wa-font-size-xs);
+}
+
+.mpc-match-select {
+  max-width: 260px;
+  padding: 4px 6px;
+  border-radius: var(--wa-border-radius-s);
+  border: 1px solid var(--wa-color-surface-border);
+  background: var(--wa-color-surface-1);
+  color: inherit;
+  font: inherit;
+  font-size: var(--wa-font-size-s);
+}
+
+.mpc-row-unmatched {
+  background: var(--wa-color-warning-fill-quiet, rgba(255, 200, 0, 0.08));
+}
+
+.mpc-row-skipped {
+  opacity: 0.5;
+}
+
+.mpc-process-log {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: var(--wa-font-size-s);
+}
+
+.mpc-process-log li {
+  padding: var(--wa-space-2xs) 0;
+}
+
+.mpc-log-summary {
+  padding-bottom: var(--wa-space-xs);
+}
+
+.mpc-log-warn {
+  color: var(--wa-color-warning-text);
+}
+
+.mpc-log-error {
+  color: var(--wa-color-danger-text);
+}

--- a/docs/mpc-stripe-compositor-plan.md
+++ b/docs/mpc-stripe-compositor-plan.md
@@ -1,0 +1,279 @@
+# MPC Stripe Compositor — Plan & Implementation Prompt
+
+Print PRISM stripe/dot marks directly onto MakePlayingCards (MPC) card images, positioned
+like the card preview in build.html's results pane / SCRY view, so cards ordered through
+[MPC-Autofill](https://github.com/chilli-axe/mpc-autofill) come back pre-marked in the same
+spots the physical Spirit Guide jig would place them on sleeves.
+
+Status: **planned, not implemented**. Part 3 is a ready-to-paste prompt for the
+implementation session. Exact mm offsets will be calibrated after test prints.
+
+---
+
+## Part 1 — Approach, workflow & decisions
+
+### Why no fork of MPC-Autofill
+
+MPC-Autofill's desktop tool downloads every image in the order XML into a local `cards/`
+folder next to the executable — and **skips downloading any file that already exists
+there** (the `file_exists()` check in `desktop-tool/src/order.py`; it even supports
+explicit `LOCAL_FILE` sources). That means: if we composite stripes onto the images in
+`cards/` while keeping the exact same filenames, the desktop tool uploads the striped
+versions with **zero changes to MPC-Autofill**.
+
+Forking was considered and rejected — mpc-autofill is a Django backend + Next.js frontend
++ Python/Selenium desktop tool, and a fork would carry merge burden on every upstream
+release for something we can do entirely from outside.
+
+### The tool: an unlisted page inside PRISM
+
+A new page in this repo (working name `mpc-stripes.html`) that:
+
+1. Reads the current PRISM straight from localStorage (no JSON round-trip needed; JSON
+   import kept as a secondary source).
+2. Lets the user pick their MPC-Autofill `cards/` folder via the File System Access API.
+3. Matches image filenames to PRISM cards, with a manual-fix table for misses.
+4. Shows a live calibration preview (all offsets in mm, adjustable, persisted).
+5. Backs up originals to `cards/originals/`, then overwrites each image in place with the
+   striped version.
+
+**Legal/brand posture:** the page is client-side only — it never hosts, indexes, links to,
+or transmits card imagery (unlike mpcfill.com, whose exposure comes from indexing community
+image drives; this tool just draws colored rectangles on files the user already has).
+Mitigations anyway: unlisted URL, `<meta name="robots" content="noindex,nofollow">`, no nav
+links. And since PRISM has no build step, deploying the page is optional — it runs fine
+from `npx http-server` locally, and could later move to a separate repo/domain cheaply
+because the module is self-contained.
+
+### End-to-end print workflow (once built)
+
+1. Build the order on mpcfill.com as usual → download the order XML.
+2. Run the MPC-Autofill desktop tool once so it downloads all images into `cards/`, then
+   quit before the browser-upload phase starts.
+3. Open the PRISM compositor page → pick the `cards/` folder → review matches → calibrate
+   (first time only) → **Process all**. Originals are backed up to `cards/originals/`;
+   striped versions overwrite in place under the same filenames.
+4. Re-run the desktop tool with the same XML. Every file already exists locally, so it
+   skips downloading and uploads the striped images.
+
+Re-running the compositor is safe: it always composites from `originals/`, never from an
+already-striped file (no double-striping).
+
+---
+
+## Part 2 — Implementation design
+
+### New files
+
+- `mpc-stripes.html` — unlisted page. Standard static head block (WA CSS, autoloader,
+  fonts, `custom.css` — copy from build.html and keep in sync per CLAUDE.md), plus
+  `<meta name="robots" content="noindex,nofollow">`. Calls `initLayout(...)` for the
+  shared chrome but is **not** added to the nav in `js/layout.js`.
+- `js/features/mpc-stripes.js` — page logic (entry module, imported by the page).
+- `css/custom.css` additions — `.mpc-*` classes; reuse `.card-preview-*` patterns where
+  sensible.
+
+### Data source
+
+- **Primary:** current PRISM from localStorage via the existing storage module; run
+  `processCards(prism)` (`js/modules/processor.js`) to get per-card `stripes`. **Filter
+  out `markType === 'membership'`** — those are deck-filter anchors, never rendered.
+- **Secondary:** "Import PRISM JSON" file input consuming the `exportToJSON` shape
+  (`prism.cards[].stripes`). Prerequisite: add `preferences.stripeStartCorner` to
+  `exportToJSON` in `js/modules/export.js` (currently absent) so imported JSON carries
+  corner orientation.
+- Corner orientation comes from `getPreferences().stripeStartCorner`, applied with the
+  same `sideARight` / `topDown` logic as `getCornerConfig()` / `getStripeEdge()` in
+  `js/modules/card-preview.js:26-53`.
+
+### Folder access & filename → card matching
+
+- "Choose cards folder" → `window.showDirectoryPicker({ mode: 'readwrite' })`. Chrome/Edge
+  only; show a graceful unsupported-browser notice elsewhere.
+- Enumerate `.png` / `.jpg` / `.jpeg` files. Derive a card name per file:
+  strip extension → strip trailing ` (driveId)` parens (the desktop tool appends these on
+  name collisions) → strip bracketed set/artist decorations → strip DFC back-face after
+  `//` (reuse the front-face logic already in `card-preview.js`) → `normalizeCardName`
+  (`js/modules/parser.js`) → match against the processed-cards list.
+- Match-review table: auto-matched rows, plus ambiguous/unmatched rows with a manual
+  `<wa-select>` of card names and a "skip this image" option. Card backs / tokens
+  naturally land in "skip".
+
+### Geometry (the core of the feature)
+
+All constants live in **mm relative to the cut line**, in one exported `MPC_GEOMETRY`
+config object, editable in the calibration panel and persisted to localStorage.
+
+- **Image model:** assume MPC full-bleed aspect — 69.09 × 93.98 mm (2.72″ × 3.7″); cut
+  size 63 × 88 mm; bleed ≈ **3.05 mm horizontal / 2.99 mm vertical per side**. Compute
+  `pxPerMm = imageWidth / 69.09` per image (source resolutions vary); warn when an image's
+  aspect ratio deviates > ~2% from full-bleed.
+- **Slot Y:** `y = cutTopPx + (FIRST_SLOT_OFFSET_MM + slotIndex * SLOT_PITCH_MM) * pxPerMm`,
+  flipped when `topDown` is false. Defaults derived from the preview's proportions
+  (preview: 340 px ↔ 88 mm ⇒ `STRIPE_START_Y` 28 px ≈ **7.25 mm**, 12 px pitch ≈
+  **3.1 mm**) — these are starting points; **calibrate against the Spirit Guide after a
+  test print**.
+- **Stripe X:** drawn **from the image edge (x = 0 or x = imageWidth), through the bleed,
+  extending `STRIPE_VISIBLE_MM` (default ~4 mm) past the cut line** onto the visible card
+  face — i.e., the line goes over the bleed and onto the visible part, so it survives any
+  cut-position variance. Thickness default **1.3 mm** (preview: 5 px).
+- **Dots:** same slot Y as the group's Side A position; inset from the edge
+  `DOT_INSET_MM + localIndex * DOT_SPACING_MM`; diameter default ~1.6 mm. `localIndex` is
+  computed at render time per `groupId` exactly like `card-preview.js:95-118` —
+  `dotIndex` is never stored.
+- **Side A/B edge selection:** identical to `getStripeEdge` (slots 1–24 on the primary
+  edge, 25–48 on the opposite edge, corner preference decides primary edge + direction).
+  Factor `getStripeEdge` and `getCornerConfig` into small exported helpers in
+  `card-preview.js` rather than duplicating them.
+
+### Preview & calibration UI
+
+- Live canvas preview of one selected matched image with marks, plus optional overlay
+  guides: cut line, bleed box, slot ruler numbers (mirror `appendRulerGuides` anchors:
+  5, 10, 15, 20, 29, 34, 39, 44).
+- Calibration inputs (mm, step 0.05): first-slot offset, pitch, stripe thickness, visible
+  extent, dot diameter/inset/spacing. "Reset to defaults" button.
+- Calibration procedure note in the UI: process ONE test card, order a cheap test print,
+  hold it against the Spirit Guide, adjust the constants, reprocess.
+
+### Processing pipeline
+
+For each matched file:
+
+1. If `originals/<name>` exists, read source bytes from there (**re-run safety — never
+   double-stripe**); otherwise copy the current file's bytes into `originals/` first.
+2. `createImageBitmap(file, { imageOrientation: 'from-image' })` → canvas/OffscreenCanvas
+   at native resolution → `drawImage` → draw the card's marks. Both edges (Side A and
+   Side B) go on the **front image only**; DFC back images are untouched in v1.
+3. Encode preserving the original extension (`image/png`, or `image/jpeg` at quality
+   ≈ 0.95) → `FileSystemFileHandle.createWritable()` → overwrite in place under the
+   **same filename** (required so the desktop tool's exists-check picks it up).
+4. Progress bar + per-file status; final summary with counts (striped / skipped /
+   unmatched / errors).
+
+No CORS/tainted-canvas issues — all inputs are local files.
+
+### Reuse pointers
+
+- `js/modules/processor.js` — `processCards`, `MAX_STRIPE_SLOTS`, `formatSlotLabel`,
+  `remapSlot` (the physical 2-edge × 24-row model).
+- `js/modules/card-preview.js:15-53, 83-160` — the display geometry to factor out and
+  mirror at print scale.
+- `js/modules/parser.js` — `normalizeCardName`.
+- `js/modules/export.js` — `exportToJSON` shape (lines 130–196), `downloadFile`
+  (lines 204–216).
+- `js/core/notifications.js` — `showError` / `showSuccess`; `js/core/utils.js` — `debugLog`.
+- Conventions: `<wa-dialog>` open/close via `setAttribute('open','')` /
+  `removeAttribute('open')`; static WA head block in the page `<head>`; `debugLog` instead
+  of bare `console.log`.
+
+### Out of scope for v1 (noted follow-ups)
+
+- Marks on DFC back-face images.
+- Auto-downloading images from the mpcfill XML in-browser (Google Drive CORS; the desktop
+  tool already handles downloads).
+- Moving the page to a separate repo/domain for brand distance — keep the module
+  self-contained so this stays cheap.
+
+---
+
+## Part 3 — Ready-to-paste prompt for the implementation session
+
+Copy everything inside the block below into a fresh Claude Code session opened on the
+`codwats/prism` repo.
+
+```text
+Implement the MPC Stripe Compositor described in docs/mpc-stripe-compositor-plan.md
+(read that file first — it is the spec; Part 2 is the implementation design).
+
+Summary: build an UNLISTED page in this repo (mpc-stripes.html + js/features/mpc-stripes.js
++ .mpc-* CSS in css/custom.css) that composites PRISM stripe/dot marks onto MakePlayingCards
+full-bleed card images downloaded by the MPC-Autofill desktop tool, so the printed cards
+arrive pre-marked.
+
+Hard requirements:
+1. Unlisted: <meta name="robots" content="noindex,nofollow">, NOT added to the nav in
+   js/layout.js. Page uses the same static WA head block as build.html and calls initLayout.
+2. Data source: current PRISM from localStorage; run processCards(prism) from
+   js/modules/processor.js; filter OUT stripes with markType === 'membership'. Also support
+   importing a PRISM JSON export as a fallback source — and first add
+   preferences.stripeStartCorner to exportToJSON in js/modules/export.js so the export
+   carries corner orientation.
+3. Folder: window.showDirectoryPicker({ mode: 'readwrite' }) on the MPC-Autofill cards/
+   folder (Chrome/Edge; show a friendly notice on unsupported browsers). Enumerate
+   .png/.jpg/.jpeg. Match filenames to cards: strip extension, trailing " (driveId)"
+   parens, bracketed set/artist decorations, and DFC back-face names after "//" (reuse the
+   front-face stripping already in js/modules/card-preview.js), then normalizeCardName from
+   js/modules/parser.js. Show a match-review table with manual <wa-select> fixes and a
+   per-image "skip".
+4. Geometry: one exported MPC_GEOMETRY config, all values in mm relative to the cut line,
+   editable in a calibration panel and persisted to localStorage. Image model: MPC full
+   bleed 69.09 x 93.98 mm, cut 63 x 88 mm, bleed ~3.05 mm horiz / ~2.99 mm vert per side;
+   pxPerMm = imageWidth / 69.09 computed per image; warn if aspect deviates >2%.
+   Slot Y: y = cutTopPx + (FIRST_SLOT_OFFSET_MM + slotIndex * SLOT_PITCH_MM) * pxPerMm,
+   flipped when the corner preference is bottom-first. Defaults: FIRST_SLOT_OFFSET_MM 7.25,
+   SLOT_PITCH_MM 3.1, thickness 1.3 mm (these mirror the 244x340 preview in
+   card-preview.js and WILL be recalibrated after test prints — keep them in one place).
+   Stripe X: draw from the image edge THROUGH the bleed and STRIPE_VISIBLE_MM (default
+   4 mm) past the cut line onto the visible face. Dots: same Y as the group's Side A slot,
+   inset DOT_INSET_MM + localIndex * DOT_SPACING_MM from the edge, ~1.6 mm diameter,
+   localIndex computed per groupId at render time exactly like card-preview.js:95-118.
+   Edge selection (Side A slots 1-24 on the primary edge, Side B 25-48 opposite, honoring
+   preferences.stripeStartCorner): refactor getStripeEdge + getCornerConfig in
+   js/modules/card-preview.js into exported helpers and use them — do not duplicate.
+5. Preview/calibration UI: live canvas preview of a selected matched image with marks and
+   toggleable guides (cut line, bleed box, ruler numbers at slots 5,10,15,20,29,34,39,44),
+   mm inputs (step 0.05) for every MPC_GEOMETRY value, and a reset-to-defaults button.
+6. Processing ("Process all"): for each matched file — if originals/<name> exists in the
+   picked folder, composite from THAT file (re-run safety: never double-stripe); otherwise
+   copy the original bytes into originals/ first. Then
+   createImageBitmap(file, { imageOrientation: 'from-image' }) -> canvas at native
+   resolution -> drawImage -> draw marks (both edges on the front image only; DFC backs
+   untouched) -> encode keeping the original extension (jpeg quality ~0.95) -> overwrite in
+   place via createWritable() under the SAME filename (the MPC-Autofill desktop tool skips
+   downloading files that already exist, so same-name overwrite is what makes it upload the
+   striped versions). Progress bar + summary (striped/skipped/unmatched/errors).
+7. Follow repo conventions (see CLAUDE.md): no build step, ES modules, wa-dialog via
+   setAttribute('open',''), debugLog not console.log, showError/showSuccess from
+   js/core/notifications.js.
+
+Verify before pushing:
+- npx http-server -p 3456, open /mpc-stripes.html in Chrome at >=1280px.
+- Seed a PRISM with 2+ standalone decks, one stripes-style split group, one dots-style
+  split group, and a non-default stripeStartCorner; confirm the page preview matches the
+  build.html results-pane hover preview for the same card (same edges, same slot order,
+  dots on the correct side of the stripe).
+- Test against a folder of sample full-bleed images (include 816x1110 and one odd
+  resolution): originals/ gets created, files are overwritten in place, marks cross the
+  cut line by STRIPE_VISIBLE_MM, and a second "Process all" run produces identical output
+  (no double-striping).
+- Confirm build.html still works (card-preview.js refactor must not change its behavior).
+```
+
+---
+
+## Part 4 — What you (the human) do
+
+### One-time setup
+
+1. **No fork. No new repo.** Everything lives in `codwats/prism`.
+2. Open a **new Claude Code session** on the prism repo and paste the Part 3 prompt.
+3. Review + merge the resulting branch, or just run it locally (`npx http-server -p 3456`)
+   if you'd rather not deploy the page to prismmtg.com.
+
+### Calibration (first print only)
+
+1. Run the workflow below for a single cheap test card (or a small test order).
+2. Hold the printed card against the Spirit Guide and note how far off the marks are.
+3. Adjust the mm values in the page's calibration panel (they persist), reprocess, reprint
+   if needed. After this, the constants are set — consider baking the final numbers into
+   `MPC_GEOMETRY`'s defaults in a follow-up commit.
+
+### Every print order
+
+1. Build the order on mpcfill.com → download the XML.
+2. Run the MPC-Autofill desktop tool so it downloads images into `cards/`, then quit
+   before the upload phase.
+3. Open the compositor page → pick `cards/` → fix any unmatched filenames → Process all.
+4. Re-run the desktop tool with the same XML — it skips re-downloading (files exist) and
+   uploads the striped images.

--- a/docs/mpc-stripe-compositor-plan.md
+++ b/docs/mpc-stripe-compositor-plan.md
@@ -75,9 +75,11 @@ already-striped file (no double-striping).
 
 ### Data source
 
-- **Primary:** current PRISM from localStorage via the existing storage module; run
-  `processCards(prism)` (`js/modules/processor.js`) to get per-card `stripes`. **Filter
-  out `markType === 'membership'`** — those are deck-filter anchors, never rendered.
+- **Primary:** current PRISM from localStorage via the existing storage module (storage
+  supports multiple prisms under `currentPrismId` — default to the current one, but offer
+  a prism selector); run `processCards(prism)` (`js/modules/processor.js`) to get per-card
+  `stripes`. **Filter out `markType === 'membership'`** — those are deck-filter anchors,
+  never rendered.
 - **Secondary:** "Import PRISM JSON" file input consuming the `exportToJSON` shape
   (`prism.cards[].stripes`). Prerequisite: add `preferences.stripeStartCorner` to
   `exportToJSON` in `js/modules/export.js` (currently absent) so imported JSON carries
@@ -94,7 +96,11 @@ already-striped file (no double-striping).
   strip extension → strip trailing ` (driveId)` parens (the desktop tool appends these on
   name collisions) → strip bracketed set/artist decorations → strip DFC back-face after
   `//` (reuse the front-face logic already in `card-preview.js`) → `normalizeCardName`
-  (`js/modules/parser.js`) → match against the processed-cards list.
+  (`js/modules/parser.js`) → match against the processed-cards list (compare on the
+  `normalizedName` field `processCards()` already returns).
+- Quantity never matters to compositing: one image file serves all copies of a card
+  (including basic lands, which appear in many decks with quantities) — every copy gets
+  the same marks because marks are per card name, not per copy.
 - Match-review table: auto-matched rows, plus ambiguous/unmatched rows with a manual
   `<wa-select>` of card names and a "skip this image" option. Card backs / tokens
   naturally land in "skip".
@@ -108,7 +114,8 @@ config object, editable in the calibration panel and persisted to localStorage.
   size 63 × 88 mm; bleed ≈ **3.05 mm horizontal / 2.99 mm vertical per side**. Compute
   `pxPerMm = imageWidth / 69.09` per image (source resolutions vary); warn when an image's
   aspect ratio deviates > ~2% from full-bleed.
-- **Slot Y:** `y = cutTopPx + (FIRST_SLOT_OFFSET_MM + slotIndex * SLOT_PITCH_MM) * pxPerMm`,
+- **Slot Y:** `y = cutTopPx + (FIRST_SLOT_OFFSET_MM + slotIndex * SLOT_PITCH_MM) * pxPerMm`
+  where `cutTopPx = VERTICAL_BLEED_MM * pxPerMm` (the y of the top cut line),
   flipped when `topDown` is false. Defaults derived from the preview's proportions
   (preview: 340 px ↔ 88 mm ⇒ `STRIPE_START_Y` 28 px ≈ **7.25 mm**, 12 px pitch ≈
   **3.1 mm**) — these are starting points; **calibrate against the Spirit Guide after a
@@ -153,6 +160,11 @@ For each matched file:
 
 No CORS/tainted-canvas issues — all inputs are local files.
 
+Note: the MPC-Autofill desktop tool downscales images above 800 DPI (MPC's max print
+resolution) at upload time by default (`--max-dpi` flag). That scaling is uniform, so
+composited marks keep their relative positions — no action needed, just don't be surprised
+that very-high-resolution sources get resized during upload.
+
 ### Reuse pointers
 
 - `js/modules/processor.js` — `processCards`, `MAX_STRIPE_SLOTS`, `formatSlotLabel`,
@@ -194,7 +206,8 @@ arrive pre-marked.
 Hard requirements:
 1. Unlisted: <meta name="robots" content="noindex,nofollow">, NOT added to the nav in
    js/layout.js. Page uses the same static WA head block as build.html and calls initLayout.
-2. Data source: current PRISM from localStorage; run processCards(prism) from
+2. Data source: current PRISM from localStorage (default currentPrismId, with a selector
+   if multiple prisms exist); run processCards(prism) from
    js/modules/processor.js; filter OUT stripes with markType === 'membership'. Also support
    importing a PRISM JSON export as a fallback source — and first add
    preferences.stripeStartCorner to exportToJSON in js/modules/export.js so the export
@@ -204,14 +217,16 @@ Hard requirements:
    .png/.jpg/.jpeg. Match filenames to cards: strip extension, trailing " (driveId)"
    parens, bracketed set/artist decorations, and DFC back-face names after "//" (reuse the
    front-face stripping already in js/modules/card-preview.js), then normalizeCardName from
-   js/modules/parser.js. Show a match-review table with manual <wa-select> fixes and a
-   per-image "skip".
+   js/modules/parser.js, and compare against the normalizedName field processCards()
+   returns. One image serves all copies of a card (quantity is irrelevant to compositing).
+   Show a match-review table with manual <wa-select> fixes and a per-image "skip".
 4. Geometry: one exported MPC_GEOMETRY config, all values in mm relative to the cut line,
    editable in a calibration panel and persisted to localStorage. Image model: MPC full
    bleed 69.09 x 93.98 mm, cut 63 x 88 mm, bleed ~3.05 mm horiz / ~2.99 mm vert per side;
    pxPerMm = imageWidth / 69.09 computed per image; warn if aspect deviates >2%.
-   Slot Y: y = cutTopPx + (FIRST_SLOT_OFFSET_MM + slotIndex * SLOT_PITCH_MM) * pxPerMm,
-   flipped when the corner preference is bottom-first. Defaults: FIRST_SLOT_OFFSET_MM 7.25,
+   Slot Y: y = cutTopPx + (FIRST_SLOT_OFFSET_MM + slotIndex * SLOT_PITCH_MM) * pxPerMm
+   where cutTopPx = VERTICAL_BLEED_MM * pxPerMm, flipped when the corner preference is
+   bottom-first. Defaults: FIRST_SLOT_OFFSET_MM 7.25,
    SLOT_PITCH_MM 3.1, thickness 1.3 mm (these mirror the 244x340 preview in
    card-preview.js and WILL be recalibrated after test prints — keep them in one place).
    Stripe X: draw from the image edge THROUGH the bleed and STRIPE_VISIBLE_MM (default

--- a/docs/mpc-stripe-compositor-plan.md
+++ b/docs/mpc-stripe-compositor-plan.md
@@ -5,8 +5,9 @@ like the card preview in build.html's results pane / SCRY view, so cards ordered
 [MPC-Autofill](https://github.com/chilli-axe/mpc-autofill) come back pre-marked in the same
 spots the physical Spirit Guide jig would place them on sleeves.
 
-Status: **planned, not implemented**. Part 3 is a ready-to-paste prompt for the
-implementation session. Exact mm offsets will be calibrated after test prints.
+Status: **implemented** — `mpc-stripes.html` + `js/features/mpc-stripes.js` (see Part 2
+for the design it follows). Part 3's prompt was executed and is kept for reference.
+Exact mm offsets still need calibration after test prints (Part 4).
 
 ---
 
@@ -271,10 +272,10 @@ Verify before pushing:
 
 ### One-time setup
 
-1. **No fork. No new repo.** Everything lives in `codwats/prism`.
-2. Open a **new Claude Code session** on the prism repo and paste the Part 3 prompt.
-3. Review + merge the resulting branch, or just run it locally (`npx http-server -p 3456`)
-   if you'd rather not deploy the page to prismmtg.com.
+1. **No fork. No new repo.** Everything lives in `codwats/prism` — already implemented
+   on this branch.
+2. Review + merge the branch, or just run it locally (`npx http-server -p 3456` →
+   `/mpc-stripes.html`) if you'd rather not deploy the page to prismmtg.com.
 
 ### Calibration (first print only)
 

--- a/js/features/mpc-stripes.js
+++ b/js/features/mpc-stripes.js
@@ -331,25 +331,31 @@ async function readCleanFile(entry) {
     const dir = await getOriginalsDir(false);
     const backup = await dir.getFileHandle(entry.name);
     return await backup.getFile();
-  } catch (err) {
+  } catch {
     return entry.handle.getFile();
   }
 }
 
 // Same, but ensures the backup exists first — used by processing so the
-// original bytes are safe before we overwrite the file in place.
+// original bytes are safe before we overwrite the file in place. Only a
+// missing backup may trigger the create-and-copy path: any other failure
+// must propagate rather than overwrite a valid backup with possibly
+// already-striped bytes.
 async function backupAndReadCleanFile(entry, originalsDir) {
+  let backup = null;
   try {
-    const backup = await originalsDir.getFileHandle(entry.name);
-    return await backup.getFile();
+    backup = await originalsDir.getFileHandle(entry.name);
   } catch (err) {
-    const file = await entry.handle.getFile();
-    const backup = await originalsDir.getFileHandle(entry.name, { create: true });
-    const writable = await backup.createWritable();
-    await writable.write(await file.arrayBuffer());
-    await writable.close();
-    return file;
+    if (err.name !== 'NotFoundError') throw err;
   }
+  if (backup) return backup.getFile();
+
+  const file = await entry.handle.getFile();
+  const created = await originalsDir.getFileHandle(entry.name, { create: true });
+  const writable = await created.createWritable();
+  await writable.write(await file.arrayBuffer());
+  await writable.close();
+  return file;
 }
 
 async function compositeEntry(entry, originalsDir, cornerConfig) {

--- a/js/features/mpc-stripes.js
+++ b/js/features/mpc-stripes.js
@@ -55,7 +55,6 @@ const ORIGINALS_DIR = 'originals';
 // ============================================
 
 const state = {
-  prism: null,          // selected prism (local source) or null when using JSON
   sourceLabel: '',      // human description of the active source
   corner: 'top-right',  // stripeStartCorner in effect for the active source
   cards: [],            // [{ name, normalizedName, stripes }] with membership filtered out
@@ -106,6 +105,11 @@ function setCards(cards, sourceLabel, corner) {
   state.cardsByNorm = new Map(cards.map(c => [c.normalizedName, c]));
   rematchEntries();
   renderSourceSummary();
+  refreshEntryViews();
+}
+
+// Re-render everything derived from entries/matches after they change
+function refreshEntryViews() {
   renderMatchTable();
   renderPreviewControls();
   updateProcessButton();
@@ -114,7 +118,6 @@ function setCards(cards, sourceLabel, corner) {
 
 function loadPrismSource(prism) {
   if (!prism) return;
-  state.prism = prism;
   const processed = processCards(prism);
   const cards = processed.map(card => ({
     name: card.name,
@@ -131,7 +134,6 @@ function loadJsonSource(data, filename) {
   if (!prism || !Array.isArray(prism.cards)) {
     throw new Error('Not a PRISM JSON export (missing prism.cards)');
   }
-  state.prism = null;
   const cards = prism.cards.map(card => ({
     name: card.name,
     normalizedName: normalizeCardName(card.name),
@@ -578,10 +580,7 @@ async function handleChooseFolder() {
     : `"${state.dirHandle.name}" — no .png/.jpg images found in this folder`;
   debugLog('MPC: scanned folder', state.dirHandle.name, state.entries.length, 'images');
 
-  renderMatchTable();
-  renderPreviewControls();
-  updateProcessButton();
-  drawPreview();
+  refreshEntryViews();
 }
 
 function handleMatchTableInput(event) {
@@ -590,10 +589,7 @@ function handleMatchTableInput(event) {
   const entry = state.entries[Number(select.dataset.index)];
   if (!entry) return;
   entry.matchNorm = select.value || null;
-  renderMatchTable();
-  renderPreviewControls();
-  updateProcessButton();
-  drawPreview();
+  refreshEntryViews();
 }
 
 function handleSkipToggle(event) {
@@ -602,10 +598,7 @@ function handleSkipToggle(event) {
   const entry = state.entries[Number(checkbox.dataset.index)];
   if (!entry) return;
   entry.skipped = !!checkbox.checked;
-  renderMatchTable();
-  renderPreviewControls();
-  updateProcessButton();
-  drawPreview();
+  refreshEntryViews();
 }
 
 function handleGeometryInput(event) {

--- a/js/features/mpc-stripes.js
+++ b/js/features/mpc-stripes.js
@@ -1,0 +1,757 @@
+// MPC Stripe Compositor — composites PRISM stripe/dot marks onto MakePlayingCards
+// full-bleed card images downloaded by the MPC-Autofill desktop tool.
+//
+// Workflow: the desktop tool downloads order images into a local cards/ folder and
+// skips downloading any file that already exists there. We back each original up to
+// cards/originals/, overwrite the image in place (same filename) with the marks
+// composited on, and the desktop tool then uploads the striped versions untouched.
+// Re-runs always composite from originals/ so images are never double-striped.
+//
+// All geometry constants are millimetres relative to the cut line, mirroring the
+// display-scale preview in card-preview.js. Defaults derive from that preview's
+// proportions and are meant to be calibrated against the Spirit Guide after a
+// test print (values persist in localStorage until then).
+
+import { getAllPrisms, getCurrentPrism, getPreferences } from '../modules/storage.js';
+import { processCards } from '../modules/processor.js';
+import { normalizeCardName } from '../modules/parser.js';
+import { cornerToConfig, getStripeEdge, RULER_ANCHORS } from '../modules/card-preview.js';
+import { showError, showSuccess } from '../core/notifications.js';
+import { debugLog, escapeHtml, slotNumberLabel, countVisibleMarks } from '../core/utils.js';
+
+// ============================================
+// PHYSICAL MODEL (MakePlayingCards full bleed)
+// ============================================
+
+const CARD_FULL_WIDTH_MM = 69.09;   // 2.72" MPC full-bleed width
+const CARD_FULL_HEIGHT_MM = 93.98;  // 3.7"  MPC full-bleed height
+const CARD_CUT_WIDTH_MM = 63;       // 2.48" cut card width
+const CARD_CUT_HEIGHT_MM = 88;      // 3.46" cut card height
+const BLEED_X_MM = (CARD_FULL_WIDTH_MM - CARD_CUT_WIDTH_MM) / 2;   // ≈3.05
+const BLEED_Y_MM = (CARD_FULL_HEIGHT_MM - CARD_CUT_HEIGHT_MM) / 2; // ≈2.99
+const FULL_BLEED_ASPECT = CARD_FULL_HEIGHT_MM / CARD_FULL_WIDTH_MM;
+const ASPECT_TOLERANCE = 0.02; // warn when an image deviates >2% from full-bleed aspect
+const SLOTS_PER_SIDE = 24;
+
+// Calibration defaults, mm relative to the cut line. Derived from the 244×340
+// display preview (340px ↔ 88mm): STRIPE_START_Y 28px ≈ 7.25mm, 12px pitch ≈ 3.1mm,
+// 5px thickness ≈ 1.3mm, dot insetBase 28px ≈ 7.2mm, 10px spacing ≈ 2.6mm.
+export const MPC_GEOMETRY_DEFAULTS = Object.freeze({
+  firstSlotOffsetMm: 7.25,  // top cut line → top edge of slot 1's stripe
+  slotPitchMm: 3.1,         // vertical distance between consecutive slots
+  stripeThicknessMm: 1.3,   // stripe height
+  stripeVisibleMm: 4,       // stripe extent past the cut line onto the visible face
+  dotDiameterMm: 1.6,       // dot-variant dot diameter
+  dotInsetMm: 7.2,          // cut line → first dot centre (inward)
+  dotSpacingMm: 2.6,        // spacing between multiple dots in a group
+});
+
+const GEOMETRY_STORAGE_KEY = 'prism_mpc_geometry';
+const IMAGE_FILE_RE = /\.(png|jpe?g)$/i;
+const ORIGINALS_DIR = 'originals';
+
+// ============================================
+// STATE
+// ============================================
+
+const state = {
+  prism: null,          // selected prism (local source) or null when using JSON
+  sourceLabel: '',      // human description of the active source
+  corner: 'top-right',  // stripeStartCorner in effect for the active source
+  cards: [],            // [{ name, normalizedName, stripes }] with membership filtered out
+  cardsByNorm: new Map(),
+  dirHandle: null,
+  entries: [],          // [{ name, handle, guessedName, matchNorm, skipped }]
+  geometry: { ...MPC_GEOMETRY_DEFAULTS },
+  previewName: null,    // filename currently shown in the preview
+  processing: false,
+};
+
+let els = null;
+
+// ============================================
+// GEOMETRY PERSISTENCE
+// ============================================
+
+function loadGeometry() {
+  try {
+    const raw = localStorage.getItem(GEOMETRY_STORAGE_KEY);
+    const saved = raw ? JSON.parse(raw) : {};
+    const geometry = { ...MPC_GEOMETRY_DEFAULTS };
+    for (const key of Object.keys(MPC_GEOMETRY_DEFAULTS)) {
+      const value = Number(saved[key]);
+      if (Number.isFinite(value) && value >= 0) geometry[key] = value;
+    }
+    return geometry;
+  } catch (err) {
+    console.warn('Failed to load MPC geometry, using defaults:', err);
+    return { ...MPC_GEOMETRY_DEFAULTS };
+  }
+}
+
+function saveGeometry() {
+  localStorage.setItem(GEOMETRY_STORAGE_KEY, JSON.stringify(state.geometry));
+}
+
+// ============================================
+// CARD SOURCE (local prism or imported JSON)
+// ============================================
+
+// Normalize either source into [{ name, normalizedName, stripes }] with
+// invisible 'membership' anchors removed (they carry no physical mark).
+function setCards(cards, sourceLabel, corner) {
+  state.cards = cards;
+  state.sourceLabel = sourceLabel;
+  state.corner = corner;
+  state.cardsByNorm = new Map(cards.map(c => [c.normalizedName, c]));
+  rematchEntries();
+  renderSourceSummary();
+  renderMatchTable();
+  renderPreviewControls();
+  updateProcessButton();
+  drawPreview();
+}
+
+function loadPrismSource(prism) {
+  if (!prism) return;
+  state.prism = prism;
+  const processed = processCards(prism);
+  const cards = processed.map(card => ({
+    name: card.name,
+    normalizedName: card.normalizedName || normalizeCardName(card.name),
+    stripes: card.stripes.filter(s => s.markType !== 'membership'),
+  }));
+  const corner = getPreferences().stripeStartCorner || 'top-right';
+  setCards(cards, `PRISM "${prism.name}"`, corner);
+  debugLog('MPC: loaded prism source', prism.name, cards.length, 'cards');
+}
+
+function loadJsonSource(data, filename) {
+  const prism = data?.prism;
+  if (!prism || !Array.isArray(prism.cards)) {
+    throw new Error('Not a PRISM JSON export (missing prism.cards)');
+  }
+  state.prism = null;
+  const cards = prism.cards.map(card => ({
+    name: card.name,
+    normalizedName: normalizeCardName(card.name),
+    stripes: card.stripes || [],
+  }));
+  // Exports carry the corner preference; older exports fall back to the local one.
+  const corner = prism.preferences?.stripeStartCorner
+    || getPreferences().stripeStartCorner || 'top-right';
+  setCards(cards, `Imported "${filename}" (${prism.name || 'unnamed'})`, corner);
+  debugLog('MPC: loaded JSON source', filename, cards.length, 'cards');
+}
+
+// ============================================
+// FILENAME → CARD MATCHING
+// ============================================
+
+// "Lightning Bolt (1AbC...).png" → "Lightning Bolt"
+// Strips extension, [set]/{artist} decorations, and trailing (…) groups —
+// the desktop tool appends "(driveId)" on filename collisions, and community
+// drives often suffix set/artist in parens. MTG card names contain none of these.
+function cardNameFromFilename(filename) {
+  let base = filename.replace(IMAGE_FILE_RE, '');
+  base = base.replace(/\s*\[[^\]]*\]/g, ' ').replace(/\s*\{[^}]*\}/g, ' ');
+  while (/\s*\([^()]*\)\s*$/.test(base)) {
+    base = base.replace(/\s*\([^()]*\)\s*$/, '');
+  }
+  return base.replace(/\s+/g, ' ').trim();
+}
+
+function rematchEntries() {
+  for (const entry of state.entries) {
+    // Preserve manual assignments that still resolve against the new source
+    if (entry.matchNorm && state.cardsByNorm.has(entry.matchNorm)) continue;
+    const norm = normalizeCardName(entry.guessedName);
+    entry.matchNorm = state.cardsByNorm.has(norm) ? norm : null;
+  }
+}
+
+async function scanFolder(dirHandle) {
+  const entries = [];
+  for await (const [name, handle] of dirHandle.entries()) {
+    if (handle.kind !== 'file' || !IMAGE_FILE_RE.test(name)) continue;
+    const guessedName = cardNameFromFilename(name);
+    const norm = normalizeCardName(guessedName);
+    entries.push({
+      name,
+      handle,
+      guessedName,
+      matchNorm: state.cardsByNorm.has(norm) ? norm : null,
+      skipped: false,
+    });
+  }
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+  return entries;
+}
+
+function matchedEntries() {
+  return state.entries.filter(e => !e.skipped && e.matchNorm);
+}
+
+// ============================================
+// MARK RENDERING (canvas, native image resolution)
+// ============================================
+
+// Per-image pixel layout: everything derives from pxPerMm so any source
+// resolution works. Width drives the scale; aspect deviations get flagged.
+function computeLayout(imgW, imgH) {
+  const pxPerMm = imgW / CARD_FULL_WIDTH_MM;
+  const aspectOff =
+    Math.abs(imgH / imgW - FULL_BLEED_ASPECT) / FULL_BLEED_ASPECT > ASPECT_TOLERANCE;
+  return {
+    pxPerMm,
+    cutLeft: BLEED_X_MM * pxPerMm,
+    cutRight: imgW - BLEED_X_MM * pxPerMm,
+    cutTop: BLEED_Y_MM * pxPerMm,
+    cutBottom: imgH - BLEED_Y_MM * pxPerMm,
+    aspectOff,
+  };
+}
+
+function slotIndex(position) {
+  return position <= SLOTS_PER_SIDE ? position - 1 : position - SLOTS_PER_SIDE - 1;
+}
+
+// Y of a slot's stripe top edge. topDown mirrors around the card centre exactly
+// like the physical jig being flipped (slot 1 measured from the bottom cut line).
+function slotTopY(position, layout, geometry, topDown) {
+  const offsetMm = geometry.firstSlotOffsetMm + slotIndex(position) * geometry.slotPitchMm;
+  return topDown
+    ? layout.cutTop + offsetMm * layout.pxPerMm
+    : layout.cutBottom - offsetMm * layout.pxPerMm - geometry.stripeThicknessMm * layout.pxPerMm;
+}
+
+// Draw a card's marks onto a full-bleed image context. Returns the layout so
+// callers can surface aspect warnings.
+function drawMarks(ctx, imgW, imgH, stripes, geometry, cornerConfig) {
+  const layout = computeLayout(imgW, imgH);
+  const { sideARight, topDown } = cornerConfig;
+  const thicknessPx = geometry.stripeThicknessMm * layout.pxPerMm;
+  // Stripes run from the image edge, through the bleed, onto the visible face.
+  const stripeLenPx = (BLEED_X_MM + geometry.stripeVisibleMm) * layout.pxPerMm;
+
+  // Dot order is computed at render time per group (dotIndex is never stored),
+  // matching createStripeOverlay in card-preview.js.
+  const groupDotCounters = new Map();
+  for (const stripe of stripes) {
+    if (stripe.markType === 'dot' && !groupDotCounters.has(stripe.groupId)) {
+      groupDotCounters.set(stripe.groupId, 0);
+    }
+  }
+
+  for (const stripe of stripes) {
+    if (stripe.markType === 'membership') continue;
+    const { onRight } = getStripeEdge(stripe.position, sideARight);
+    const yTop = slotTopY(stripe.position, layout, geometry, topDown);
+
+    if (stripe.markType === 'dot') {
+      const localIndex = groupDotCounters.get(stripe.groupId);
+      groupDotCounters.set(stripe.groupId, localIndex + 1);
+      const insetMm = geometry.dotInsetMm + localIndex * geometry.dotSpacingMm;
+      const cx = onRight
+        ? layout.cutRight - insetMm * layout.pxPerMm
+        : layout.cutLeft + insetMm * layout.pxPerMm;
+      const cy = yTop + thicknessPx / 2;
+      ctx.beginPath();
+      ctx.arc(cx, cy, (geometry.dotDiameterMm * layout.pxPerMm) / 2, 0, Math.PI * 2);
+      ctx.fillStyle = stripe.color;
+      ctx.fill();
+      continue;
+    }
+
+    ctx.fillStyle = stripe.color;
+    ctx.fillRect(onRight ? imgW - stripeLenPx : 0, yTop, stripeLenPx, thicknessPx);
+  }
+
+  return layout;
+}
+
+// Preview-only overlay: cut line + slot ruler. Never part of processed output.
+function drawGuides(ctx, imgW, imgH, geometry, cornerConfig, { cutLine, ruler }) {
+  const layout = computeLayout(imgW, imgH);
+  const { sideARight, topDown } = cornerConfig;
+
+  if (cutLine) {
+    ctx.save();
+    ctx.strokeStyle = 'rgba(255, 0, 128, 0.9)';
+    ctx.lineWidth = Math.max(1, layout.pxPerMm * 0.15);
+    ctx.setLineDash([layout.pxPerMm * 2, layout.pxPerMm * 1.5]);
+    ctx.strokeRect(
+      layout.cutLeft, layout.cutTop,
+      layout.cutRight - layout.cutLeft, layout.cutBottom - layout.cutTop
+    );
+    ctx.restore();
+  }
+
+  if (ruler) {
+    ctx.save();
+    const tickLenPx = 2.5 * layout.pxPerMm;
+    const fontPx = Math.max(10, 2.4 * layout.pxPerMm);
+    ctx.font = `700 ${fontPx}px system-ui, sans-serif`;
+    ctx.textBaseline = 'middle';
+    for (const pos of RULER_ANCHORS) {
+      const { onRight } = getStripeEdge(pos, sideARight);
+      const y = slotTopY(pos, layout, geometry, topDown)
+        + (geometry.stripeThicknessMm * layout.pxPerMm) / 2;
+      ctx.strokeStyle = 'rgba(255, 255, 255, 0.9)';
+      ctx.lineWidth = Math.max(1, layout.pxPerMm * 0.1);
+      ctx.beginPath();
+      ctx.moveTo(onRight ? imgW - tickLenPx : 0, y);
+      ctx.lineTo(onRight ? imgW : tickLenPx, y);
+      ctx.stroke();
+
+      const label = slotNumberLabel(pos);
+      ctx.fillStyle = 'rgba(255, 255, 255, 0.95)';
+      ctx.shadowColor = 'rgba(0, 0, 0, 0.9)';
+      ctx.shadowBlur = 3;
+      ctx.textAlign = onRight ? 'right' : 'left';
+      const inset = tickLenPx + 1.2 * layout.pxPerMm;
+      ctx.fillText(label, onRight ? imgW - inset : inset, y);
+    }
+    ctx.restore();
+  }
+}
+
+// ============================================
+// FILE ACCESS
+// ============================================
+
+async function getOriginalsDir(create) {
+  return state.dirHandle.getDirectoryHandle(ORIGINALS_DIR, { create });
+}
+
+// Clean source bytes for an entry: the backup in originals/ when present,
+// otherwise the file itself (which is only clean before its first processing).
+async function readCleanFile(entry) {
+  try {
+    const dir = await getOriginalsDir(false);
+    const backup = await dir.getFileHandle(entry.name);
+    return await backup.getFile();
+  } catch (err) {
+    return entry.handle.getFile();
+  }
+}
+
+// Same, but ensures the backup exists first — used by processing so the
+// original bytes are safe before we overwrite the file in place.
+async function backupAndReadCleanFile(entry, originalsDir) {
+  try {
+    const backup = await originalsDir.getFileHandle(entry.name);
+    return await backup.getFile();
+  } catch (err) {
+    const file = await entry.handle.getFile();
+    const backup = await originalsDir.getFileHandle(entry.name, { create: true });
+    const writable = await backup.createWritable();
+    await writable.write(await file.arrayBuffer());
+    await writable.close();
+    return file;
+  }
+}
+
+async function compositeEntry(entry, originalsDir, cornerConfig) {
+  const card = state.cardsByNorm.get(entry.matchNorm);
+  const file = await backupAndReadCleanFile(entry, originalsDir);
+  const bitmap = await createImageBitmap(file, { imageOrientation: 'from-image' });
+
+  const canvas = document.createElement('canvas');
+  canvas.width = bitmap.width;
+  canvas.height = bitmap.height;
+  const ctx = canvas.getContext('2d');
+  ctx.drawImage(bitmap, 0, 0);
+  const layout = drawMarks(ctx, bitmap.width, bitmap.height, card.stripes, state.geometry, cornerConfig);
+  bitmap.close();
+
+  const type = /\.png$/i.test(entry.name) ? 'image/png' : 'image/jpeg';
+  const blob = await new Promise((resolve, reject) => {
+    canvas.toBlob(b => (b ? resolve(b) : reject(new Error('Image encoding failed'))), type, 0.95);
+  });
+
+  // Same filename is load-bearing: the desktop tool skips downloading files
+  // that already exist, which is what makes it upload the striped versions.
+  const writable = await entry.handle.createWritable();
+  await writable.write(blob);
+  await writable.close();
+  return layout.aspectOff;
+}
+
+// ============================================
+// UI — rendering
+// ============================================
+
+function getElements() {
+  const byId = id => document.getElementById(id);
+  return {
+    unsupported: byId('mpc-unsupported'),
+    prismSelect: byId('mpc-prism-select'),
+    importJsonBtn: byId('btn-mpc-import-json'),
+    jsonFileInput: byId('mpc-json-file'),
+    sourceSummary: byId('mpc-source-summary'),
+    chooseFolderBtn: byId('btn-mpc-choose-folder'),
+    folderSummary: byId('mpc-folder-summary'),
+    matchSection: byId('mpc-match-section'),
+    matchSummary: byId('mpc-match-summary'),
+    matchTbody: byId('mpc-match-tbody'),
+    previewSection: byId('mpc-preview-section'),
+    previewSelect: byId('mpc-preview-select'),
+    previewCanvas: byId('mpc-preview-canvas'),
+    previewNote: byId('mpc-preview-note'),
+    guideCut: byId('mpc-guide-cut'),
+    guideRuler: byId('mpc-guide-ruler'),
+    geomInputs: Array.from(document.querySelectorAll('.mpc-geom-input')),
+    geomResetBtn: byId('btn-mpc-geom-reset'),
+    processSection: byId('mpc-process-section'),
+    processBtn: byId('btn-mpc-process'),
+    progress: byId('mpc-progress'),
+    processLog: byId('mpc-process-log'),
+  };
+}
+
+// Web Awesome inputs store values in shadow DOM; fall back when .value is empty
+function readInputValue(el) {
+  const direct = el.value;
+  if (direct !== undefined && direct !== null && direct !== '') return direct;
+  return el.shadowRoot?.querySelector('input, select')?.value ?? '';
+}
+
+// Set a WA form control's value whether or not the element has upgraded yet.
+// Pre-upgrade, a property assignment would shadow the class accessor, so write
+// the attribute (initial value); post-upgrade the property is what updates UI.
+function setInputValue(el, value) {
+  el.setAttribute('value', String(value));
+  if (customElements.get(el.localName)) el.value = String(value);
+}
+
+function renderSourceSummary() {
+  const cardCount = state.cards.length;
+  const markCount = state.cards.reduce((n, c) => n + countVisibleMarks(c.stripes), 0);
+  els.sourceSummary.textContent = cardCount
+    ? `${state.sourceLabel} — ${cardCount} unique cards, ${markCount} marks, corner: ${state.corner}`
+    : 'No decks in this PRISM yet — add decks in the builder first.';
+}
+
+function renderPrismSelect() {
+  const prisms = getAllPrisms();
+  const current = getCurrentPrism();
+  els.prismSelect.innerHTML = prisms
+    .map(p => `<wa-option value="${escapeHtml(p.id)}">${escapeHtml(p.name)} (${(p.decks || []).length} decks)</wa-option>`)
+    .join('');
+  const selected = current || prisms[0];
+  if (selected) setInputValue(els.prismSelect, selected.id);
+}
+
+function renderMatchTable() {
+  if (state.entries.length === 0) {
+    els.matchSection.hidden = true;
+    return;
+  }
+  els.matchSection.hidden = false;
+
+  const matched = matchedEntries().length;
+  const skipped = state.entries.filter(e => e.skipped).length;
+  const unmatched = state.entries.length - matched - skipped;
+  els.matchSummary.textContent =
+    `${state.entries.length} images — ${matched} matched, ${unmatched} unmatched, ${skipped} skipped`;
+
+  const cardOptions = state.cards
+    .slice()
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map(c => `<option value="${escapeHtml(c.normalizedName)}">${escapeHtml(c.name)}</option>`)
+    .join('');
+
+  els.matchTbody.innerHTML = state.entries.map((entry, i) => {
+    const card = entry.matchNorm ? state.cardsByNorm.get(entry.matchNorm) : null;
+    let matchCell;
+    if (card) {
+      matchCell = `<span class="mpc-match-ok">${escapeHtml(card.name)}</span>
+        <span class="mpc-match-marks">${countVisibleMarks(card.stripes)} marks</span>`;
+    } else {
+      // Native select: unmatched rows can number in the dozens and each carries
+      // the full card list — wa-select at that scale is too heavy.
+      matchCell = `<select class="mpc-match-select" data-index="${i}">
+        <option value="">— select card —</option>${cardOptions}</select>`;
+    }
+    return `<tr class="${entry.skipped ? 'mpc-row-skipped' : card ? '' : 'mpc-row-unmatched'}">
+      <td class="mpc-filename">${escapeHtml(entry.name)}</td>
+      <td>${matchCell}</td>
+      <td><wa-checkbox class="mpc-skip-checkbox" data-index="${i}" ${entry.skipped ? 'checked' : ''}>Skip</wa-checkbox></td>
+    </tr>`;
+  }).join('');
+}
+
+function renderPreviewControls() {
+  const matched = matchedEntries();
+  els.previewSection.hidden = matched.length === 0;
+  els.processSection.hidden = matched.length === 0;
+  if (matched.length === 0) return;
+
+  if (!matched.some(e => e.name === state.previewName)) {
+    state.previewName = matched[0].name;
+  }
+  // Option values must not contain spaces (filenames do) — use entry indices
+  els.previewSelect.innerHTML = matched
+    .map(e => `<wa-option value="${state.entries.indexOf(e)}">${escapeHtml(e.name)}</wa-option>`)
+    .join('');
+  const previewEntry = matched.find(e => e.name === state.previewName);
+  setInputValue(els.previewSelect, state.entries.indexOf(previewEntry));
+}
+
+function renderGeometryInputs() {
+  for (const input of els.geomInputs) {
+    const key = input.dataset.key;
+    if (key in state.geometry) setInputValue(input, state.geometry[key]);
+  }
+}
+
+function updateProcessButton() {
+  // Attribute toggle works before and after the WA element upgrades
+  els.processBtn.toggleAttribute('disabled', state.processing || matchedEntries().length === 0);
+}
+
+let previewToken = 0;
+async function drawPreview() {
+  const entry = state.entries.find(e => e.name === state.previewName && !e.skipped && e.matchNorm);
+  if (!entry || !state.dirHandle) return;
+  const token = ++previewToken;
+
+  try {
+    const file = await readCleanFile(entry);
+    const bitmap = await createImageBitmap(file, { imageOrientation: 'from-image' });
+    if (token !== previewToken) { bitmap.close(); return; }
+
+    const canvas = els.previewCanvas;
+    canvas.width = bitmap.width;
+    canvas.height = bitmap.height;
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(bitmap, 0, 0);
+    bitmap.close();
+
+    const card = state.cardsByNorm.get(entry.matchNorm);
+    const cornerConfig = cornerToConfig(state.corner);
+    const layout = drawMarks(ctx, canvas.width, canvas.height, card.stripes, state.geometry, cornerConfig);
+    // Fall back to the attribute while the WA switch hasn't upgraded yet
+    const isOn = el => el.checked ?? el.hasAttribute('checked');
+    drawGuides(ctx, canvas.width, canvas.height, state.geometry, cornerConfig, {
+      cutLine: !!isOn(els.guideCut),
+      ruler: !!isOn(els.guideRuler),
+    });
+
+    els.previewNote.textContent = layout.aspectOff
+      ? `⚠ ${canvas.width}×${canvas.height}px — aspect ratio deviates from MPC full-bleed (2.72″×3.7″); mark placement may be off for this image.`
+      : `${canvas.width}×${canvas.height}px · ${(canvas.width / CARD_FULL_WIDTH_MM * 25.4).toFixed(0)} DPI · guides are preview-only`;
+  } catch (err) {
+    console.error('Preview render failed:', err);
+    els.previewNote.textContent = `Preview failed: ${err.message}`;
+  }
+}
+
+// ============================================
+// UI — event handlers
+// ============================================
+
+async function handleChooseFolder() {
+  try {
+    state.dirHandle = await window.showDirectoryPicker({ mode: 'readwrite' });
+  } catch (err) {
+    if (err.name !== 'AbortError') showError(`Could not open folder: ${err.message}`);
+    return;
+  }
+
+  try {
+    state.entries = await scanFolder(state.dirHandle);
+  } catch (err) {
+    showError(`Could not read folder: ${err.message}`);
+    return;
+  }
+
+  els.folderSummary.textContent = state.entries.length
+    ? `"${state.dirHandle.name}" — ${state.entries.length} image files found`
+    : `"${state.dirHandle.name}" — no .png/.jpg images found in this folder`;
+  debugLog('MPC: scanned folder', state.dirHandle.name, state.entries.length, 'images');
+
+  renderMatchTable();
+  renderPreviewControls();
+  updateProcessButton();
+  drawPreview();
+}
+
+function handleMatchTableInput(event) {
+  const select = event.target.closest('.mpc-match-select');
+  if (!select) return;
+  const entry = state.entries[Number(select.dataset.index)];
+  if (!entry) return;
+  entry.matchNorm = select.value || null;
+  renderMatchTable();
+  renderPreviewControls();
+  updateProcessButton();
+  drawPreview();
+}
+
+function handleSkipToggle(event) {
+  const checkbox = event.target.closest('.mpc-skip-checkbox');
+  if (!checkbox) return;
+  const entry = state.entries[Number(checkbox.dataset.index)];
+  if (!entry) return;
+  entry.skipped = !!checkbox.checked;
+  renderMatchTable();
+  renderPreviewControls();
+  updateProcessButton();
+  drawPreview();
+}
+
+function handleGeometryInput(event) {
+  const input = event.target.closest('.mpc-geom-input');
+  if (!input) return;
+  const key = input.dataset.key;
+  const value = parseFloat(readInputValue(input));
+  if (!(key in state.geometry) || !Number.isFinite(value) || value < 0) return;
+  state.geometry[key] = value;
+  saveGeometry();
+  drawPreview();
+}
+
+function handleGeometryReset() {
+  state.geometry = { ...MPC_GEOMETRY_DEFAULTS };
+  saveGeometry();
+  renderGeometryInputs();
+  drawPreview();
+  showSuccess('Calibration reset to defaults');
+}
+
+async function handleProcessAll() {
+  const entries = matchedEntries();
+  if (entries.length === 0 || state.processing) return;
+
+  state.processing = true;
+  updateProcessButton();
+  els.progress.hidden = false;
+  els.progress.setAttribute('value', '0');
+  els.processLog.innerHTML = '';
+
+  const cornerConfig = cornerToConfig(state.corner);
+  const log = [];
+  let done = 0;
+  let failed = 0;
+  let aspectWarnings = 0;
+
+  let originalsDir;
+  try {
+    originalsDir = await getOriginalsDir(true);
+  } catch (err) {
+    showError(`Could not create originals/ backup folder: ${err.message}`);
+    state.processing = false;
+    updateProcessButton();
+    els.progress.hidden = true;
+    return;
+  }
+
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    try {
+      const aspectOff = await compositeEntry(entry, originalsDir, cornerConfig);
+      done++;
+      if (aspectOff) {
+        aspectWarnings++;
+        log.push(`<li class="mpc-log-warn">⚠ ${escapeHtml(entry.name)} — striped, but aspect ratio deviates from MPC full-bleed</li>`);
+      }
+    } catch (err) {
+      failed++;
+      console.error(`Failed to process ${entry.name}:`, err);
+      log.push(`<li class="mpc-log-error">✕ ${escapeHtml(entry.name)} — ${escapeHtml(err.message)}</li>`);
+    }
+    els.progress.setAttribute('value', String(Math.round(((i + 1) / entries.length) * 100)));
+    // Yield so the progress bar actually repaints between images
+    await new Promise(resolve => setTimeout(resolve, 0));
+  }
+
+  const skipped = state.entries.filter(e => e.skipped).length;
+  const unmatched = state.entries.filter(e => !e.skipped && !e.matchNorm).length;
+  log.unshift(`<li class="mpc-log-summary"><strong>${done} striped</strong>${failed ? `, ${failed} failed` : ''}${aspectWarnings ? `, ${aspectWarnings} aspect warnings` : ''}, ${unmatched} unmatched, ${skipped} skipped. Originals backed up to ${ORIGINALS_DIR}/.</li>`);
+  els.processLog.innerHTML = log.join('');
+
+  state.processing = false;
+  updateProcessButton();
+  if (failed === 0) {
+    showSuccess(`${done} images striped — run the MPC-Autofill desktop tool to upload them`);
+  } else {
+    showError(`${failed} of ${entries.length} images failed — see the log below the progress bar`);
+  }
+  drawPreview();
+}
+
+// ============================================
+// INIT
+// ============================================
+
+export function initMpcStripes() {
+  els = getElements();
+  state.geometry = loadGeometry();
+
+  if (!window.showDirectoryPicker) {
+    els.unsupported.hidden = false;
+    els.chooseFolderBtn.setAttribute('disabled', '');
+  }
+
+  renderPrismSelect();
+  renderGeometryInputs();
+
+  const current = getCurrentPrism() || getAllPrisms()[0] || null;
+  if (current) loadPrismSource(current);
+  else els.sourceSummary.textContent = 'No PRISM found — build one first, or import a PRISM JSON export.';
+
+  // wa-select emits 'wa-change'; native/other WA components emit 'change'.
+  // Listening to both keeps this robust — handlers are idempotent re-renders.
+  const onPrismChange = () => {
+    const prisms = getAllPrisms();
+    const selected = prisms.find(p => p.id === readInputValue(els.prismSelect));
+    if (selected) loadPrismSource(selected);
+  };
+  els.prismSelect.addEventListener('change', onPrismChange);
+  els.prismSelect.addEventListener('wa-change', onPrismChange);
+
+  els.importJsonBtn.addEventListener('click', () => els.jsonFileInput.click());
+  els.jsonFileInput.addEventListener('change', () => {
+    const file = els.jsonFileInput.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        loadJsonSource(JSON.parse(reader.result), file.name);
+        showSuccess(`Imported ${file.name}`);
+      } catch (err) {
+        showError(`Import failed: ${err.message}`);
+      }
+    };
+    reader.readAsText(file);
+    els.jsonFileInput.value = '';
+  });
+
+  els.chooseFolderBtn.addEventListener('click', handleChooseFolder);
+  els.matchTbody.addEventListener('change', handleMatchTableInput);   // native <select>
+  els.matchTbody.addEventListener('change', handleSkipToggle);
+  els.matchTbody.addEventListener('wa-change', handleSkipToggle);     // wa-checkbox
+  const onPreviewChange = () => {
+    const entry = state.entries[Number(readInputValue(els.previewSelect))];
+    if (!entry) return;
+    state.previewName = entry.name;
+    drawPreview();
+  };
+  els.previewSelect.addEventListener('change', onPreviewChange);
+  els.previewSelect.addEventListener('wa-change', onPreviewChange);
+  for (const guide of [els.guideCut, els.guideRuler]) {
+    guide.addEventListener('change', drawPreview);
+    guide.addEventListener('wa-change', drawPreview);
+  }
+  for (const input of els.geomInputs) {
+    input.addEventListener('input', handleGeometryInput);
+    input.addEventListener('wa-input', handleGeometryInput);
+    input.addEventListener('change', handleGeometryInput);
+  }
+  els.geomResetBtn.addEventListener('click', handleGeometryReset);
+  els.processBtn.addEventListener('click', handleProcessAll);
+
+  debugLog('MPC: compositor initialized');
+}

--- a/js/modules/card-preview.js
+++ b/js/modules/card-preview.js
@@ -22,14 +22,20 @@ const STRIPE_SLOT_HEIGHT = 12; // Spacing between stripe positions
 const SLOTS_PER_SIDE = 24;
 const STRIPE_END_Y = STRIPE_START_Y + (SLOTS_PER_SIDE - 1) * STRIPE_SLOT_HEIGHT;
 
-// Parse corner preference into rendering config
-function getCornerConfig() {
-  const prefs = getPreferences();
-  const corner = prefs.stripeStartCorner || 'top-right';
+// Translate a stripeStartCorner value into rendering config.
+// Pure — shared with the MPC stripe compositor, which resolves the corner
+// from an imported JSON export rather than local preferences.
+export function cornerToConfig(corner) {
+  const c = corner || 'top-right';
   return {
-    sideARight: corner.includes('right'),  // Side A stripes on right edge
-    topDown: corner.includes('top'),        // Position 1 at top
+    sideARight: c.includes('right'),  // Side A stripes on right edge
+    topDown: c.includes('top'),        // Position 1 at top
   };
+}
+
+// Parse the local corner preference into rendering config
+function getCornerConfig() {
+  return cornerToConfig(getPreferences().stripeStartCorner);
 }
 
 // Get Y position for a stripe at display scale
@@ -46,7 +52,8 @@ function getStripeY(position, topDown = true) {
 
 // Resolve which edge a slot lives on, purely from position + corner preference.
 // Slots 1-24 live on the primary edge; slots 25-48 live on the opposite edge.
-function getStripeEdge(position, sideARight) {
+// Exported for the MPC stripe compositor, which mirrors this geometry at print scale.
+export function getStripeEdge(position, sideARight) {
   const onPrimaryEdge = position <= SLOTS_PER_SIDE;
   const onRight = onPrimaryEdge ? sideARight : !sideARight;
   return { onRight };
@@ -54,7 +61,7 @@ function getStripeEdge(position, sideARight) {
 
 // Anchor positions (every 5th slot per side) used for the reference ruler.
 // Side A side-relative 5/10/15/20 → positions 5/10/15/20; Side B → 29/34/39/44.
-const RULER_ANCHORS = [5, 10, 15, 20, 29, 34, 39, 44];
+export const RULER_ANCHORS = [5, 10, 15, 20, 29, 34, 39, 44];
 
 // Draw a faint tick + number at every 5th slot down both card edges, regardless
 // of which slots the card actually marks — a permanent ruler so any lone stripe

--- a/js/modules/export.js
+++ b/js/modules/export.js
@@ -136,6 +136,11 @@ export function exportToJSON(prism) {
       name: prism.name,
       exportedAt: new Date().toISOString(),
       deckCount: prism.decks.length,
+      // Corner orientation is a global preference, not prism data — carry it in
+      // the export so consumers (MPC stripe compositor) render the same corners.
+      preferences: {
+        stripeStartCorner: getPreferences().stripeStartCorner || 'top-right'
+      },
       splitGroups: (prism.splitGroups || []).map(group => ({
         id: group.id,
         name: group.name,

--- a/mpc-stripes.html
+++ b/mpc-stripes.html
@@ -16,11 +16,11 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" />
     <!-- Web Awesome, fonts, and app CSS as static tags so the browser preload scanner
          starts them immediately; layout.js injectHeadResources skips tags already present -->
-    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/themes/matter.css" />
-    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/color/palettes/mild.css" />
-    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/native.css" />
-    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/utilities.css" />
-    <script type="module" src="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/webawesome.loader.js"></script>
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.9.0/styles/themes/matter.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.9.0/styles/color/palettes/mild.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.9.0/styles/native.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.9.0/styles/utilities.css" />
+    <script type="module" src="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.9.0/webawesome.loader.js"></script>
     <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Inter:ital,wght@0,100..900;1,100..900&display=swap" />
     <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Geist+Mono:wght@100..900&display=swap" />
     <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Crimson+Pro:ital,wght@0,200..900;1,200..900&display=swap" />

--- a/mpc-stripes.html
+++ b/mpc-stripes.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="en" class="wa-cloak">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Unlisted utility page: not in nav, not for search engines -->
+    <meta name="robots" content="noindex,nofollow" />
+    <title>MPC Stripe Compositor - PRISM</title>
+    <style>.wa-cloak { visibility: hidden; }</style>
+    <style>wa-page:not(:defined) { visibility: hidden; }</style>
+    <!-- Preconnect to CDNs (Supabase SDK on cdn.jsdelivr.net is lazy-loaded for logged-in users) -->
+    <link rel="preconnect" href="https://ka-p.webawesome.com" />
+    <link rel="preconnect" href="https://ka-p.webawesome.com" crossorigin />
+    <link rel="preconnect" href="https://fonts.bunny.net" />
+    <link rel="preconnect" href="https://fonts.bunny.net" crossorigin />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" />
+    <!-- Web Awesome, fonts, and app CSS as static tags so the browser preload scanner
+         starts them immediately; layout.js injectHeadResources skips tags already present -->
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/themes/matter.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/color/palettes/mild.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/native.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/styles/utilities.css" />
+    <script type="module" src="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.8.0/webawesome.loader.js"></script>
+    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Inter:ital,wght@0,100..900;1,100..900&display=swap" />
+    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Geist+Mono:wght@100..900&display=swap" />
+    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Crimson+Pro:ital,wght@0,200..900;1,200..900&display=swap" />
+    <link rel="stylesheet" href="css/custom.css" />
+  </head>
+  <body>
+    <wa-page mobile-breakpoint="768">
+      <main style="max-width: 1000px; margin: 0 auto; padding: var(--wa-space-xl);">
+        <div class="wa-stack wa-gap-xl">
+          <!-- Intro -->
+          <div class="wa-stack wa-gap-s">
+            <h1 class="wa-heading-xl">MPC Stripe Compositor</h1>
+            <p style="color: var(--wa-color-neutral-text-subtle); max-width: 70ch;">
+              Draws your PRISM stripe and dot marks directly onto the full-bleed card images
+              in your MPC-Autofill <code>cards/</code> folder, so printed cards arrive pre-marked.
+              Marks run from the image edge, through the bleed, onto the visible card face.
+              Originals are backed up to <code>cards/originals/</code> and each image is
+              overwritten in place under the same filename — the MPC-Autofill desktop tool
+              then uploads the striped versions automatically (it skips re-downloading files
+              that already exist).
+            </p>
+          </div>
+
+          <wa-callout id="mpc-unsupported" variant="warning" hidden>
+            <wa-icon slot="icon" name="triangle-exclamation"></wa-icon>
+            This tool needs the File System Access API to write images in place.
+            Please use Chrome or Edge on desktop.
+          </wa-callout>
+
+          <!-- Step 1: card source -->
+          <wa-card>
+            <div slot="header" class="wa-cluster wa-gap-s wa-align-items-center">
+              <wa-icon name="layer-group"></wa-icon>
+              <span class="wa-heading-m">1 · PRISM source</span>
+            </div>
+            <div class="wa-stack wa-gap-m">
+              <div class="wa-cluster wa-gap-m wa-align-items-end">
+                <wa-select id="mpc-prism-select" label="PRISM" style="min-width: 280px;"></wa-select>
+                <wa-button id="btn-mpc-import-json" variant="neutral" appearance="outlined">
+                  <wa-icon slot="start" name="file-import"></wa-icon>
+                  Import PRISM JSON
+                </wa-button>
+                <input type="file" id="mpc-json-file" accept=".json,application/json" hidden />
+              </div>
+              <p id="mpc-source-summary" class="wa-caption-m" style="color: var(--wa-color-neutral-text-subtle);"></p>
+            </div>
+          </wa-card>
+
+          <!-- Step 2: cards folder -->
+          <wa-card>
+            <div slot="header" class="wa-cluster wa-gap-s wa-align-items-center">
+              <wa-icon name="folder-open"></wa-icon>
+              <span class="wa-heading-m">2 · MPC-Autofill cards folder</span>
+            </div>
+            <div class="wa-stack wa-gap-m">
+              <p class="wa-caption-m" style="color: var(--wa-color-neutral-text-subtle);">
+                Run the MPC-Autofill desktop tool once so it downloads your order's images,
+                quit before the upload phase, then pick that <code>cards/</code> folder here.
+              </p>
+              <div class="wa-cluster wa-gap-m wa-align-items-center">
+                <wa-button id="btn-mpc-choose-folder" variant="brand">
+                  <wa-icon slot="start" name="folder-open"></wa-icon>
+                  Choose cards folder
+                </wa-button>
+                <span id="mpc-folder-summary" class="wa-caption-m" style="color: var(--wa-color-neutral-text-subtle);"></span>
+              </div>
+            </div>
+          </wa-card>
+
+          <!-- Step 3: match review -->
+          <wa-card id="mpc-match-section" hidden>
+            <div slot="header" class="wa-cluster wa-gap-s wa-align-items-center">
+              <wa-icon name="link"></wa-icon>
+              <span class="wa-heading-m">3 · Match images to cards</span>
+            </div>
+            <div class="wa-stack wa-gap-m">
+              <p id="mpc-match-summary" class="wa-caption-m" style="color: var(--wa-color-neutral-text-subtle);"></p>
+              <div class="mpc-match-table-wrap">
+                <table class="mpc-match-table">
+                  <thead>
+                    <tr><th>Image file</th><th>Card</th><th></th></tr>
+                  </thead>
+                  <tbody id="mpc-match-tbody"></tbody>
+                </table>
+              </div>
+            </div>
+          </wa-card>
+
+          <!-- Step 4: preview + calibration -->
+          <wa-card id="mpc-preview-section" hidden>
+            <div slot="header" class="wa-cluster wa-gap-s wa-align-items-center">
+              <wa-icon name="ruler-combined"></wa-icon>
+              <span class="wa-heading-m">4 · Preview &amp; calibration</span>
+            </div>
+            <div class="mpc-preview-layout">
+              <div class="wa-stack wa-gap-m">
+                <wa-select id="mpc-preview-select" label="Preview card"></wa-select>
+                <canvas id="mpc-preview-canvas" class="mpc-preview-canvas"></canvas>
+                <p id="mpc-preview-note" class="wa-caption-s" style="color: var(--wa-color-neutral-text-subtle);"></p>
+                <div class="wa-cluster wa-gap-m">
+                  <wa-switch id="mpc-guide-cut" checked>Cut line</wa-switch>
+                  <wa-switch id="mpc-guide-ruler">Slot ruler</wa-switch>
+                </div>
+              </div>
+              <div class="wa-stack wa-gap-m">
+                <p class="wa-caption-m" style="color: var(--wa-color-neutral-text-subtle); max-width: 40ch;">
+                  All values are millimetres relative to the cut line. Defaults mirror the
+                  builder's card preview — <strong>calibrate against the Spirit Guide after a
+                  test print</strong>: process one card, order a cheap print, hold it against
+                  the jig, adjust, reprocess. Values persist on this device.
+                </p>
+                <div class="mpc-geom-grid">
+                  <wa-input class="mpc-geom-input" data-key="firstSlotOffsetMm" type="number" step="0.05" min="0" label="First slot offset (mm)"></wa-input>
+                  <wa-input class="mpc-geom-input" data-key="slotPitchMm" type="number" step="0.05" min="0" label="Slot pitch (mm)"></wa-input>
+                  <wa-input class="mpc-geom-input" data-key="stripeThicknessMm" type="number" step="0.05" min="0" label="Stripe thickness (mm)"></wa-input>
+                  <wa-input class="mpc-geom-input" data-key="stripeVisibleMm" type="number" step="0.05" min="0" label="Visible extent past cut (mm)"></wa-input>
+                  <wa-input class="mpc-geom-input" data-key="dotDiameterMm" type="number" step="0.05" min="0" label="Dot diameter (mm)"></wa-input>
+                  <wa-input class="mpc-geom-input" data-key="dotInsetMm" type="number" step="0.05" min="0" label="Dot inset from cut (mm)"></wa-input>
+                  <wa-input class="mpc-geom-input" data-key="dotSpacingMm" type="number" step="0.05" min="0" label="Dot spacing (mm)"></wa-input>
+                </div>
+                <wa-button id="btn-mpc-geom-reset" variant="neutral" appearance="outlined" size="small">
+                  <wa-icon slot="start" name="rotate-left"></wa-icon>
+                  Reset to defaults
+                </wa-button>
+              </div>
+            </div>
+          </wa-card>
+
+          <!-- Step 5: process -->
+          <wa-card id="mpc-process-section" hidden>
+            <div slot="header" class="wa-cluster wa-gap-s wa-align-items-center">
+              <wa-icon name="wand-magic-sparkles"></wa-icon>
+              <span class="wa-heading-m">5 · Process</span>
+            </div>
+            <div class="wa-stack wa-gap-m">
+              <p class="wa-caption-m" style="color: var(--wa-color-neutral-text-subtle);">
+                Backs up each original to <code>originals/</code>, then overwrites the image
+                in place with marks composited on. Safe to re-run — it always starts from the
+                backed-up originals.
+              </p>
+              <div class="wa-cluster wa-gap-m wa-align-items-center">
+                <wa-button id="btn-mpc-process" variant="brand" disabled>
+                  <wa-icon slot="start" name="paintbrush"></wa-icon>
+                  Process all matched images
+                </wa-button>
+              </div>
+              <wa-progress-bar id="mpc-progress" value="0" hidden></wa-progress-bar>
+              <ul id="mpc-process-log" class="mpc-process-log"></ul>
+            </div>
+          </wa-card>
+        </div>
+      </main>
+    </wa-page>
+
+    <!-- Toast notification container -->
+    <wa-toast placement="bottom-end" id="toast-container"></wa-toast>
+
+    <script type="module">
+      import { initLayout } from './js/layout.js';
+      import { initMpcStripes } from './js/features/mpc-stripes.js';
+      initLayout({ activePage: '', headerCta: { href: 'build.html', label: 'Build PRISM', icon: 'wand-magic-sparkles' } });
+      initMpcStripes();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new MPC Stripe Compositor page to review PRISM data, choose an MPC download folder, match card images, and apply stripe/dot marks directly onto the originals for MPC upload readiness.
  * Includes a live preview with optional guides, millimeter-based calibration with reset-to-defaults, per-file reassignment and skip controls, progress/status feedback, and a processing log.
  * Exported PRISM now carries stripe-corner orientation preferences to keep previews and downstream rendering consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->