### PR TITLE
feat(build): three-way position numbers slider

### DIFF
--- a/build.html
+++ b/build.html
@@ -148,14 +148,20 @@
                   <p class="wa-caption-s" style="color: var(--wa-color-neutral-text-subtle);">
                     Applying remaps every deck's slot number so Slot 1 sits at the chosen corner.
                   </p>
-                  <wa-switch
-                    id="show-stripe-position-numbers"
-                    size="small"
-                    aria-label="Show stripe position numbers as a counting aid so you can identify a slot without relying on color"
-                  >Show stripe position numbers</wa-switch>
-                  <p class="wa-caption-s" style="color: var(--wa-color-neutral-text-subtle);">
-                    Counting aid — overlays the slot number (5 / 10 / 15 / 20 per side) on stripes so you can find a slot without relying on color.
-                  </p>
+                  <wa-slider
+                    id="stripe-position-numbers-mode"
+                    label="Position Numbers"
+                    name="position-numbers"
+                    min="1"
+                    max="3"
+                    value="1"
+                    with-markers
+                    hint="Counting aid — None hides numbers, Some overlays every 5th slot (5 / 10 / 15 / 20 per side), All numbers every mark."
+                  >
+                    <span slot="reference">None</span>
+                    <span slot="reference">Some</span>
+                    <span slot="reference">All</span>
+                  </wa-slider>
                 </div>
               </wa-details>
 

--- a/js/core/utils.js
+++ b/js/core/utils.js
@@ -59,7 +59,7 @@ export function slotNumberLabel(position) {
  * Side-relative slot number to overlay at "anchor" positions — every 5th slot
  * within each side (5/10/15/20 on Side A and Side B). Returns null for
  * non-anchor positions. Pure label logic; callers gate on the
- * showStripePositionNumbers preference. Shared by the results table, card
+ * stripeNumbersMode preference. Shared by the results table, card
  * preview, and printable guide so all three surfaces stay in parity.
  * @param {number} position - Stripe position 1-48
  * @returns {string|null} Label string (e.g. "10") or null
@@ -84,7 +84,7 @@ export function countVisibleMarks(stripes) {
 /**
  * Resolve the slot-number label for a stripe given whether the card is sparse.
  * Sparse → exact number on every mark (always-on). Otherwise → anchor label
- * (caller still gates this branch on the showStripePositionNumbers preference).
+ * (caller still gates this branch on the stripeNumbersMode preference).
  * @param {number} position - Stripe position 1-48
  * @param {{ exact: boolean }} opts
  * @returns {string|null}

--- a/js/features/events.js
+++ b/js/features/events.js
@@ -12,7 +12,7 @@ import { renderResults } from './results.js';
 import { openScryMode } from './scry-mode.js';
 import { renderOverlapMatrix } from './analysis.js';
 import { debounce } from '../core/utils.js';
-import { updatePreferences, getPreferences, savePrism, setColorScheme } from '../modules/storage.js';
+import { updatePreferences, getPreferences, savePrism, setColorScheme, STRIPE_NUMBERS_MODES } from '../modules/storage.js';
 import { applyColorScheme } from '../modules/theme.js';
 import { remapPrismForCorner } from '../modules/processor.js';
 import { renderAll } from './init.js';
@@ -257,11 +257,11 @@ export function setupEventListeners() {
     });
   }
 
-  // Show stripe position numbers preference (counting aid overlay).
+  // Position-numbers mode (counting aid overlay): none / some / all.
   // Read at render time + re-render the visible surfaces immediately on change.
-  if (state.elements.showStripePositionNumbers) {
-    state.elements.showStripePositionNumbers.addEventListener('change', (e) => {
-      updatePreferences({ showStripePositionNumbers: e.target.checked });
+  if (state.elements.stripeNumbersMode) {
+    state.elements.stripeNumbersMode.addEventListener('change', (e) => {
+      updatePreferences({ stripeNumbersMode: STRIPE_NUMBERS_MODES[Number(e.target.value) - 1] || 'none' });
       renderResults();
       refreshOpenPreview();
     });

--- a/js/features/init.js
+++ b/js/features/init.js
@@ -5,7 +5,7 @@
 import { state } from '../core/state.js';
 import { getLogicalDeckCount, debugLog } from '../core/utils.js';
 import { createPrism, getUsedPositions, MAX_STRIPE_SLOTS } from '../modules/processor.js';
-import { getCurrentPrism, savePrism, setCurrentPrism, getPreferences, getColorScheme, onSyncStatusChange, forceSyncCurrentPrism } from '../modules/storage.js';
+import { getCurrentPrism, savePrism, setCurrentPrism, getPreferences, getColorScheme, getStripeNumbersMode, STRIPE_NUMBERS_MODES, onSyncStatusChange, forceSyncCurrentPrism } from '../modules/storage.js';
 import { initAuth, setupAuthListeners, getCurrentUser } from '../modules/auth.js';
 import { logToSupabase } from '../modules/supabase-client.js';
 import { initColorSwatches } from './deck-form.js';
@@ -136,7 +136,7 @@ function getElements() {
     // Stripe settings
     stripeStartCorner: document.getElementById('stripe-start-corner'),
     stripeStartCornerApply: document.getElementById('stripe-start-corner-apply'),
-    showStripePositionNumbers: document.getElementById('show-stripe-position-numbers'),
+    stripeNumbersMode: document.getElementById('stripe-position-numbers-mode'),
     colorScheme: document.getElementById('color-scheme'),
 
     // Stripe reorder dialog
@@ -199,8 +199,8 @@ export async function init() {
     const prefs = getPreferences();
     state.elements.stripeStartCorner.value = prefs.stripeStartCorner || 'top-right';
   }
-  if (state.elements.showStripePositionNumbers) {
-    state.elements.showStripePositionNumbers.checked = !!getPreferences().showStripePositionNumbers;
+  if (state.elements.stripeNumbersMode) {
+    state.elements.stripeNumbersMode.value = STRIPE_NUMBERS_MODES.indexOf(getStripeNumbersMode()) + 1;
   }
   if (state.elements.colorScheme) {
     state.elements.colorScheme.value = getColorScheme();

--- a/js/features/results.js
+++ b/js/features/results.js
@@ -4,7 +4,7 @@
 
 import { state } from '../core/state.js';
 import { escapeHtml, stripeNumberLabel, countVisibleMarks, STRIPE_SPARSE_MAX, isCardDone } from '../core/utils.js';
-import { getPreferences } from '../modules/storage.js';
+import { getStripeNumbersMode } from '../modules/storage.js';
 import { processCards, formatSlotLabel } from '../modules/processor.js';
 import { prefetchCards } from '../modules/scryfall.js';
 import { handleMarkToggle, handleClearRemoved, handleClearAllRemoved } from './deck-list.js';
@@ -283,7 +283,8 @@ export function renderResults() {
   if (!state.elements.resultsTbody) return;
 
   const showAllSlots = state.elements.showAllSlots?.checked || false;
-  const showNums = !!getPreferences().showStripePositionNumbers;
+  const numbersMode = getStripeNumbersMode();
+  const showNums = numbersMode !== 'none';
   const totalDecks = state.currentPrism?.decks?.length || 0;
 
   state.elements.resultsTbody.innerHTML = displayCards.map(card => {
@@ -324,8 +325,8 @@ export function renderResults() {
     let stripeIndicators;
 
     // Sparse cards number every mark with its exact slot (always-on); dense
-    // cards fall back to the toggle-gated anchor numbering.
-    const exact = countVisibleMarks(card.stripes) <= STRIPE_SPARSE_MAX;
+    // cards fall back to the anchor numbering unless the pref forces all.
+    const exact = numbersMode === 'all' || countVisibleMarks(card.stripes) <= STRIPE_SPARSE_MAX;
     const opts = { showNums, exact };
 
     if (showAllSlots && totalDecks > 0) {

--- a/js/modules/card-preview.js
+++ b/js/modules/card-preview.js
@@ -1,7 +1,7 @@
 // Card preview with stripe overlay
 
 import { fetchCard } from './scryfall.js';
-import { getPreferences } from './storage.js';
+import { getPreferences, getStripeNumbersMode } from './storage.js';
 import { stripeNumberLabel, countVisibleMarks, STRIPE_SPARSE_MAX } from '../core/utils.js';
 
 // Strip back-face name from DFCs for Scryfall lookup
@@ -65,7 +65,7 @@ export const RULER_ANCHORS = [5, 10, 15, 20, 29, 34, 39, 44];
 
 // Draw a faint tick + number at every 5th slot down both card edges, regardless
 // of which slots the card actually marks — a permanent ruler so any lone stripe
-// can be located by eye. Gated on the showStripePositionNumbers preference.
+// can be located by eye. Gated on the stripeNumbersMode preference.
 function appendRulerGuides(container, sideARight, topDown) {
   for (const pos of RULER_ANCHORS) {
     const { onRight } = getStripeEdge(pos, sideARight);
@@ -91,9 +91,10 @@ function createStripeOverlay(stripes) {
   const container = document.createElement('div');
   container.className = 'card-preview-stripes';
   const { sideARight, topDown } = getCornerConfig();
-  const showNums = !!getPreferences().showStripePositionNumbers;
+  const numbersMode = getStripeNumbersMode();
+  const showNums = numbersMode !== 'none';
   // Sparse cards number every stripe with its exact slot (always-on).
-  const exact = countVisibleMarks(stripes) <= STRIPE_SPARSE_MAX;
+  const exact = numbersMode === 'all' || countVisibleMarks(stripes) <= STRIPE_SPARSE_MAX;
 
   // Permanent reference ruler down both edges when the counting aid is on.
   if (showNums) appendRulerGuides(container, sideARight, topDown);

--- a/js/modules/export.js
+++ b/js/modules/export.js
@@ -5,7 +5,7 @@
 
 import { processCards, getColorName, formatSlotLabel } from './processor.js';
 import { stripeNumberLabel, countVisibleMarks, STRIPE_SPARSE_MAX, escapeHtml, isCardDone } from '../core/utils.js';
-import { getPreferences } from './storage.js';
+import { getPreferences, getStripeNumbersMode } from './storage.js';
 
 /**
  * Escape a value for CSV (handle commas, quotes, newlines)
@@ -249,7 +249,8 @@ export function generatePrintableGuide(prism) {
   const processedCards = processCards(prism);
   const splitGroups = prism.splitGroups || [];
   // Read the counting-aid pref at generation time (no live re-render needed).
-  const showNums = !!getPreferences().showStripePositionNumbers;
+  const numbersMode = getStripeNumbersMode();
+  const showNums = numbersMode !== 'none';
   // Sparse cards (`exact`) number every mark with its exact slot, always-on;
   // dense cards only show the anchor numbers when the pref is on.
   const posNum = (position, exact) => {
@@ -499,7 +500,7 @@ export function generatePrintableGuide(prism) {
 
     // Sparse cards number every mark with its exact slot; only the card's own
     // marked positions get the exact treatment (empty reference slots don't).
-    const cardIsSparse = countVisibleMarks(card.stripes) <= STRIPE_SPARSE_MAX;
+    const cardIsSparse = numbersMode === 'all' || countVisibleMarks(card.stripes) <= STRIPE_SPARSE_MAX;
 
     let stripeIndicators = '';
     for (const pos of allPositions) {

--- a/js/modules/storage.js
+++ b/js/modules/storage.js
@@ -1150,6 +1150,21 @@ export function updatePreferences(updates) {
   saveStorage(storage);
 }
 
+// Slider order for the Position Numbers preference (slider values 1..3).
+export const STRIPE_NUMBERS_MODES = ['none', 'some', 'all'];
+
+/**
+ * Get the stripe position-numbers mode.
+ * Falls back to the legacy showStripePositionNumbers boolean for users who
+ * set the old toggle before the three-way slider existed.
+ * @returns {'none'|'some'|'all'}
+ */
+export function getStripeNumbersMode() {
+  const prefs = getPreferences();
+  if (STRIPE_NUMBERS_MODES.includes(prefs.stripeNumbersMode)) return prefs.stripeNumbersMode;
+  return prefs.showStripePositionNumbers ? 'some' : 'none';
+}
+
 /**
  * Get the color scheme preference
  * @returns {string} 'light', 'dark', or 'auto'


### PR DESCRIPTION
Replace show-numbers toggle with None/Some/All slider. All numbers every mark exactly, not just anchor slots — for users who want full reference without counting.

Stored as stripeNumbersMode pref; legacy showStripePositionNumbers boolean maps to Some so existing users keep their setting.

Closes #132