### PR TITLE
docs: agent-skills config + gallery design brief

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,3 +231,13 @@ Preview viewport should be 1280px+ wide to see the desktop layout (sidebar nav).
 - Stripe Settings in the Decks tab is a `<wa-details>` accordion (collapsed by default)
 - The Stripe Positions reorder card was removed from the Decks tab — use the Move button (⊕) on each deck card to open the visual slot-picker dialog, or use the Export tab's dropdown list for bulk reordering
 - `build.html` has a sync status indicator (`#sync-status`) and a Sync Now button (`#btn-sync-now`) near the PRISM name; both are hidden until the user is logged in. `setupSyncStatus()` in `init.js` wires these to `onSyncStatusChange` / `forceSyncCurrentPrism` from `storage.js`. Storage exports: `onSyncStatusChange(cb)` (returns unsubscribe fn), `forceSyncCurrentPrism()`, `recordUnmarkedCards(prismId, keys)`
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues (codwats/prism), via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Domain docs
+
+Single-context layout — `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/gallery-design-brief.md
+++ b/docs/gallery-design-brief.md
@@ -1,0 +1,98 @@
+# PRISM Gallery — Design Brief for Wireframe
+
+**Deliverable requested:** wireframes for a new Gallery section of PRISM (prismmtg.netlify.app). Look at the existing site first — the gallery must feel like the same product.
+
+## Context
+
+PRISM is a tool for MTG Commander players who share cards across decks. Jay has partnered with artists who've agreed to let us share their artwork for proxies, tokens, and showcase treatments. The gallery presents that partnered work, and lets the community upload their own. This brief covers the **full vision** — curated + community — so the design is coherent even though the build may ship curated-first.
+
+### Existing design system (match it)
+
+- **Web Awesome 3.10** components + design tokens (`--wa-color-*`, `--wa-space-*`), loaded via CDN kit. Vanilla JS ES modules, no build step.
+- Shared layout via `js/layout.js`: `<wa-page mobile-breakpoint="768">` — desktop sidebar nav, mobile hamburger. The gallery is a **new nav item** ("Gallery") alongside Build / Guide / Tools.
+- Existing pages for reference: `index.html` (landing), `build.html` (the app), `guide.html`, `tools.html`, `profile.html`.
+- Auth already exists: Supabase email/password, login dialog injected by layout.js.
+- Wireframe both **desktop (1280px+)** and **mobile (<768px)**.
+
+## Screens to wireframe
+
+### 1. Gallery grid (the main page)
+
+- Masonry/grid of artwork cards. Each card in the grid shows: image, title, artist name, type badge, like count. Highlighted (partnered/featured) pieces get a visual distinction and appear first by default.
+- **Filter toolbar:**
+  - Type filter: **Proxy / Token / Showcase**
+  - Artist filter (partnered artists surfaced prominently)
+  - **Card-name search** — "show me all the Sol Rings" (matches the original-card field)
+  - Sort: Most liked (default) / Newest / Most downloaded
+- **States to show:** populated, empty-filter-result, logged-out (likes visible but tap prompts sign-in).
+
+### 2. Artwork detail view
+
+Deep-linkable (each artwork has a shareable URL). Contains:
+
+- Large artwork image
+- Title + **type badge** (proxy/token/showcase) + **AI-generated label** when applicable
+- **Original card**: card name + set, linking to its Scryfall page. Optional — tokens/original art may have no source card.
+- Description (artist-written or uploader-written)
+- **Artist credit block**: name, avatar, short bio line, links to website/socials, link to their artist page
+- **License line** (site-wide, same on every artwork): *"Personal, non-commercial use only — credit the artist."* Links to the full terms.
+- **Like** (heart) — one tap for signed-in users; count visible to everyone; logged-out tap prompts sign-in
+- **Download** button — **requires a free account** (login-gated). Delivers one print-ready file (2.5×3.5" + bleed). Logged-out state shows the button with a sign-in prompt.
+- **"Order custom sleeves"** button — **only on admin-highlighted pieces**. External link to the store, new tab. Most artworks don't have this; design both variants.
+
+### 3. Artist page
+
+- Artist header: name, avatar, bio, website/social links. **Partnered artists** get a richer treatment (partner badge, longer bio) than community uploaders.
+- Grid of that artist's works (same cards as the main grid).
+
+### 4. Community upload flow
+
+Signed-in users only. Form fields:
+
+- Image file
+- Title
+- Type (proxy / token / showcase)
+- Original card (optional; ideally a card-name autocomplete via Scryfall)
+- Description
+- AI-generated? (required yes/no — AI art is allowed but must be labeled)
+- Artist attribution (defaults to uploader; field for crediting someone else with permission)
+- Rules acknowledgment checkbox: *MTG-related only · your own work or permission held · no NSFW · AI art must be labeled*
+
+After submit: **"pending review"** state — uploads are pre-moderated, nothing goes public until approved. Show the user's own pending/approved/rejected submissions somewhere (their profile or a "My uploads" view).
+
+### 5. Admin moderation queue
+
+Internal but wireframed: list of pending uploads with image preview, metadata, uploader, and **Approve / Reject (with reason)** actions. Also where admins set the **Highlight** flag and per-artwork **store URL**.
+
+## Decisions already made (don't reopen in the wireframe)
+
+| Area | Decision |
+|---|---|
+| License | One site-wide license: personal non-commercial use, artist credit required |
+| Moderation | Pre-approval queue; admins approve before anything is public |
+| Content rules | MTG-related only · own work only · AI art labeled · no NSFW |
+| Rating | Hearts/likes from signed-in users; no star ratings |
+| Download | Login-gated; single print-ready file per artwork |
+| Store | Per-artwork external link, admin-flagged, highlighted pieces only |
+| Storage | Supabase Storage (public-read bucket for approved art; auth-gated uploads) |
+| Browse | Filter by type + artist, card-name search |
+
+## Data shape (for the designer's mental model)
+
+```
+Artwork: { id, title, imageUrl, type (proxy|token|showcase), originalCard? { name, scryfallUrl },
+           description, artistId, isAI, likes, downloads, status (pending|approved|rejected),
+           highlighted, storeUrl?, createdAt }
+Artist:  { id, name, avatar, bio, links[], isPartner }
+```
+
+## Out of scope
+
+- In-gallery commerce (cart/checkout) — store is an external link only
+- Per-artwork licenses
+- Color/color-identity filtering (nice-to-have, derivable from Scryfall data later)
+
+## Future (design nothing, break nothing)
+
+- Google Drive shared-folder ingestion for artist batches (the way MPC-autofill integrates Drive) — keep the storage story from assuming manual upload is the only intake path.
+- Trusted-uploader tier (skip the queue after N approvals) — moderation UI shouldn't preclude it.


### PR DESCRIPTION
## What changed

- **`docs/agents/`** — per-repo config for the Matt Pocock engineering skills: `issue-tracker.md` (GitHub Issues via `gh`, PRs-as-request-surface off) and `domain.md` (single-context layout: `CONTEXT.md` + `docs/adr/` at root, read lazily).
- **`CLAUDE.md`** — new `## Agent skills` section pointing at those two docs.
- **`docs/gallery-design-brief.md`** — design brief for the new Gallery section (partnered-artist artwork + community uploads), produced from a planning session. Covers the five screens to wireframe, locked decisions (site-wide license, pre-approval moderation, hearts, login-gated downloads, admin-flagged store links, Supabase Storage), content rules, data shape, and out-of-scope/future notes. Intended as input to a design session that produces wireframes.

## Why

Sets up the skills' expected config files so `to-tickets`/`to-spec`/`qa` know where issues live, and captures the gallery planning output in-repo where the design work can pick it up.

## Notes for review

Docs only — no code changes. The gallery brief records product decisions (licensing, moderation, download gating); worth a skim to confirm they match intent before design starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for using domain documentation, architectural decisions, and the GitHub issue tracker.
  * Documented standard workflows for creating, triaging, labeling, assigning, and resolving issues.
  * Added a design brief for a Gallery experience, including artwork browsing, artist pages, uploads, moderation, and downloads.
  * Captured Gallery design decisions, interface states, and future considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->