### PR TITLE
Add community artwork gallery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,6 +232,17 @@ Preview viewport should be 1280px+ wide to see the desktop layout (sidebar nav).
 - The Stripe Positions reorder card was removed from the Decks tab — use the Move button (⊕) on each deck card to open the visual slot-picker dialog, or use the Export tab's dropdown list for bulk reordering
 - `build.html` has a sync status indicator (`#sync-status`) and a Sync Now button (`#btn-sync-now`) near the PRISM name; both are hidden until the user is logged in. `setupSyncStatus()` in `init.js` wires these to `onSyncStatusChange` / `forceSyncCurrentPrism` from `storage.js`. Storage exports: `onSyncStatusChange(cb)` (returns unsubscribe fn), `forceSyncCurrentPrism()`, `recordUnmarkedCards(prismId, keys)`
 
+### Gallery
+
+`gallery.html` + `js/gallery.js` — community artwork gallery (proxies/tokens/showcase). One page, query-param views: grid (default), `?art=<id>` detail, `?artist=<id>` artist page, `?view=upload|uploads|admin`. Tables `gallery_artists`, `gallery_artworks`, `gallery_likes`, `gallery_admins` in `supabase-schema.sql` (GALLERY section):
+
+- **Public reads** (approved artworks + artists) use plain PostgREST `fetch` with the anon key (`SUPABASE_URL`/`SUPABASE_ANON_KEY` exported from supabase-client.js) so anonymous visitors never load the SDK. Authed actions (likes, uploads, moderation) use the SDK.
+- **Admin role** = row in `gallery_admins`; `is_gallery_admin()` (SECURITY DEFINER) is used in RLS policies and callable via RPC to gate the admin UI. Add admins with `INSERT INTO gallery_admins (user_id) VALUES ('<uuid>')`.
+- **Moderation**: uploads INSERT as `pending` only (RLS WITH CHECK blocks self-approve/highlight/store_url/artist_id). Admins approve/reject via UPDATE; owners may resubmit `rejected → pending` and delete own pending/rejected rows.
+- **Likes**: one row per user per artwork; `likes_count` on artworks is trigger-maintained (SECURITY DEFINER) so most-liked sorting never aggregates. `increment_gallery_download` RPC (authenticated) bumps download counts.
+- **Storage**: single public bucket `gallery-art`, paths `<uid>/<uuid>.<ext>` (10 MB, png/jpg/webp). No SELECT policy on storage.objects → bucket can't be listed; pending art is undiscoverable via table RLS. Download gating is UI-level (soft) by design.
+- **Demo fallback**: if the gallery tables aren't reachable (schema not deployed), gallery.js falls back to read-only `DEMO_*` sample data — remove once real partner art is seeded.
+
 ## Agent skills
 
 ### Issue tracker

--- a/css/custom.css
+++ b/css/custom.css
@@ -1032,3 +1032,434 @@ wa-page[view='desktop'] [data-toggle-nav] {
 .mpc-log-error {
   color: var(--wa-color-danger-text);
 }
+
+/* ============================================================
+   Gallery (gallery.html)
+   ============================================================ */
+
+.gallery-toolbar {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--wa-space-m);
+  flex-wrap: wrap;
+  padding: var(--wa-space-m);
+  border: 1px solid var(--wa-color-surface-border);
+  border-radius: var(--wa-border-radius-m);
+  background: var(--wa-color-surface-lowered);
+  margin-block: var(--wa-space-m);
+}
+
+.gallery-toolbar-search {
+  flex: 1;
+  min-width: 200px;
+}
+
+.gallery-tlabel {
+  display: block;
+  font-size: var(--wa-font-size-2xs);
+  font-weight: var(--wa-font-weight-semibold);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--wa-color-neutral-text-subtle);
+  margin-bottom: var(--wa-space-2xs);
+}
+
+.gallery-eyebrow {
+  display: flex;
+  align-items: center;
+  gap: var(--wa-space-xs);
+  font-size: var(--wa-font-size-2xs);
+  font-weight: var(--wa-font-weight-semibold);
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--wa-color-neutral-text-subtle);
+  margin: var(--wa-space-l) 0 var(--wa-space-s);
+}
+
+.gallery-eyebrow .count {
+  font-weight: var(--wa-font-weight-normal);
+  letter-spacing: 0.02em;
+  text-transform: none;
+}
+
+.gallery-card {
+  border: 1px solid var(--wa-color-surface-border);
+  border-radius: var(--wa-border-radius-m);
+  overflow: hidden;
+  background: var(--wa-color-surface-default);
+  cursor: pointer;
+  transition: box-shadow 0.15s ease;
+}
+
+.gallery-card:hover {
+  box-shadow: var(--wa-shadow-m);
+}
+
+.gallery-card--feat {
+  border-color: var(--wa-color-brand-60);
+  box-shadow: 0 0 0 1px var(--wa-color-brand-70);
+}
+
+.gallery-art {
+  position: relative;
+  aspect-ratio: 1.35;
+  background: var(--wa-color-surface-lowered);
+  display: grid;
+  place-items: center;
+  color: var(--wa-color-neutral-text-subtle);
+  font-size: var(--wa-font-size-xl);
+}
+
+.gallery-art img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.gallery-art--lg {
+  aspect-ratio: 1.3;
+  border-radius: var(--wa-border-radius-m);
+  border: 1px solid var(--wa-color-surface-border);
+  overflow: hidden;
+}
+
+.gallery-flag {
+  position: absolute;
+  top: var(--wa-space-xs);
+  left: var(--wa-space-xs);
+  z-index: 1;
+}
+
+.gallery-cbody {
+  padding: var(--wa-space-xs) var(--wa-space-s) var(--wa-space-s);
+  display: flex;
+  flex-direction: column;
+  gap: var(--wa-space-2xs);
+}
+
+.gallery-ctitle {
+  font-weight: var(--wa-font-weight-semibold);
+  font-size: var(--wa-font-size-s);
+  line-height: 1.25;
+}
+
+.gallery-arow {
+  display: flex;
+  align-items: center;
+  gap: var(--wa-space-2xs);
+  font-size: var(--wa-font-size-xs);
+  color: var(--wa-color-neutral-text-subtle);
+}
+
+.gallery-cfoot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.gallery-likes {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--wa-space-2xs);
+  font-size: var(--wa-font-size-xs);
+  font-weight: var(--wa-font-weight-semibold);
+  color: var(--wa-color-neutral-text-subtle);
+  background: none;
+  border: 0;
+  padding: var(--wa-space-2xs);
+  cursor: pointer;
+  border-radius: var(--wa-border-radius-s);
+}
+
+.gallery-likes:hover {
+  color: var(--wa-color-brand-text);
+}
+
+.gallery-likes.liked {
+  color: var(--wa-color-brand-text);
+}
+
+.gallery-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: var(--wa-space-s);
+  padding: var(--wa-space-3xl) var(--wa-space-l);
+  border: 1px dashed var(--wa-color-surface-border);
+  border-radius: var(--wa-border-radius-m);
+  margin-top: var(--wa-space-m);
+}
+
+.gallery-empty .ic {
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: var(--wa-border-radius-circle);
+  background: var(--wa-color-surface-lowered);
+  display: grid;
+  place-items: center;
+  color: var(--wa-color-neutral-text-subtle);
+  font-size: var(--wa-font-size-l);
+}
+
+/* Detail view */
+.gallery-detail {
+  display: grid;
+  grid-template-columns: 1.15fr 1fr;
+  gap: var(--wa-space-xl);
+  align-items: start;
+}
+
+@media (max-width: 768px) {
+  .gallery-detail {
+    grid-template-columns: 1fr;
+  }
+}
+
+.gallery-orig {
+  display: flex;
+  align-items: center;
+  gap: var(--wa-space-xs);
+  font-size: var(--wa-font-size-s);
+  padding: var(--wa-space-s) var(--wa-space-m);
+  border: 1px solid var(--wa-color-surface-border);
+  border-radius: var(--wa-border-radius-m);
+  background: var(--wa-color-surface-lowered);
+}
+
+.gallery-desc {
+  font-family: var(--wa-font-family-longform);
+  font-size: var(--wa-font-size-m);
+  line-height: 1.6;
+}
+
+.gallery-artist-card {
+  display: flex;
+  gap: var(--wa-space-m);
+  padding: var(--wa-space-m);
+  border: 1px solid var(--wa-color-surface-border);
+  border-radius: var(--wa-border-radius-m);
+}
+
+.gallery-license {
+  display: flex;
+  gap: var(--wa-space-xs);
+  align-items: flex-start;
+  font-size: var(--wa-font-size-xs);
+  color: var(--wa-color-neutral-text-subtle);
+}
+
+/* Artist page */
+.gallery-artist-head {
+  display: flex;
+  gap: var(--wa-space-l);
+  align-items: flex-start;
+  padding: var(--wa-space-l);
+  border-radius: var(--wa-border-radius-l);
+  background: var(--wa-color-brand-fill-quiet);
+  border: 1px solid var(--wa-color-brand-border-quiet);
+}
+
+.gallery-artist-head--community {
+  background: var(--wa-color-surface-lowered);
+  border-color: var(--wa-color-surface-border);
+}
+
+@media (max-width: 600px) {
+  .gallery-artist-head {
+    flex-direction: column;
+  }
+}
+
+.gallery-stats {
+  display: flex;
+  gap: var(--wa-space-xl);
+  margin-top: var(--wa-space-xs);
+}
+
+.gallery-stat b {
+  display: block;
+  font-size: var(--wa-font-size-l);
+}
+
+.gallery-stat span {
+  font-size: var(--wa-font-size-2xs);
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--wa-color-neutral-text-subtle);
+}
+
+/* Upload form */
+.gallery-form {
+  max-width: 40rem;
+  display: flex;
+  flex-direction: column;
+  gap: var(--wa-space-l);
+}
+
+.gallery-drop {
+  border: 1.5px dashed var(--wa-color-neutral-border-normal, var(--wa-color-surface-border));
+  border-radius: var(--wa-border-radius-m);
+  background: var(--wa-color-surface-lowered);
+  padding: var(--wa-space-2xl);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--wa-space-xs);
+  text-align: center;
+  color: var(--wa-color-neutral-text-subtle);
+  cursor: pointer;
+}
+
+.gallery-drop:hover,
+.gallery-drop.dragover {
+  border-color: var(--wa-color-brand-border-loud);
+}
+
+.gallery-drop img {
+  max-width: 100%;
+  max-height: 14rem;
+  border-radius: var(--wa-border-radius-s);
+}
+
+.gallery-ack {
+  border: 1px solid var(--wa-color-surface-border);
+  border-radius: var(--wa-border-radius-m);
+  padding: var(--wa-space-m);
+  background: var(--wa-color-surface-lowered);
+  display: flex;
+  flex-direction: column;
+  gap: var(--wa-space-xs);
+}
+
+.gallery-suggest {
+  position: relative;
+}
+
+.gallery-suggest-list {
+  position: absolute;
+  z-index: 10;
+  inset-inline: 0;
+  background: var(--wa-color-surface-raised);
+  border: 1px solid var(--wa-color-surface-border);
+  border-radius: var(--wa-border-radius-s);
+  box-shadow: var(--wa-shadow-m);
+  max-height: 14rem;
+  overflow-y: auto;
+}
+
+.gallery-suggest-list button {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: 0;
+  padding: var(--wa-space-xs) var(--wa-space-s);
+  font-size: var(--wa-font-size-s);
+  cursor: pointer;
+  color: inherit;
+}
+
+.gallery-suggest-list button:hover {
+  background: var(--wa-color-surface-lowered);
+}
+
+/* Rows (my uploads / moderation queue) */
+.gallery-row {
+  display: flex;
+  gap: var(--wa-space-m);
+  align-items: center;
+  padding: var(--wa-space-s) var(--wa-space-m);
+  border: 1px solid var(--wa-color-surface-border);
+  border-radius: var(--wa-border-radius-m);
+  background: var(--wa-color-surface-default);
+}
+
+.gallery-row--rejected {
+  background: var(--wa-color-danger-fill-quiet);
+}
+
+.gallery-thumb {
+  width: 4.75rem;
+  height: 3.5rem;
+  border-radius: var(--wa-border-radius-s);
+  background: var(--wa-color-surface-lowered);
+  flex: none;
+  display: grid;
+  place-items: center;
+  color: var(--wa-color-neutral-text-subtle);
+  overflow: hidden;
+}
+
+.gallery-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.gallery-rowmeta {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--wa-space-3xs);
+}
+
+.gallery-rowsub {
+  font-size: var(--wa-font-size-xs);
+  color: var(--wa-color-neutral-text-subtle);
+  display: flex;
+  gap: var(--wa-space-s);
+  flex-wrap: wrap;
+}
+
+@media (max-width: 600px) {
+  .gallery-row {
+    flex-wrap: wrap;
+  }
+}
+
+.gallery-queue-card {
+  border: 1px solid var(--wa-color-surface-border);
+  border-radius: var(--wa-border-radius-m);
+  padding: var(--wa-space-m);
+  display: flex;
+  flex-direction: column;
+  gap: var(--wa-space-s);
+}
+
+.gallery-avatar {
+  border-radius: var(--wa-border-radius-circle);
+  background: var(--wa-color-surface-lowered);
+  color: var(--wa-color-neutral-text-subtle);
+  flex: none;
+  display: grid;
+  place-items: center;
+}
+
+.gallery-reject-row {
+  display: none;
+}
+
+.gallery-reject-row.open {
+  display: flex;
+  gap: var(--wa-space-xs);
+  align-items: center;
+}
+
+.gallery-reject-row wa-input {
+  flex: 1;
+  min-width: 14rem;
+}
+
+.gallery-grid {
+  --min-column-size: 220px;
+}
+
+@media (max-width: 768px) {
+  .gallery-grid {
+    --min-column-size: 140px;
+  }
+}

--- a/gallery.html
+++ b/gallery.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en" class="wa-cloak">
+  <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-VHXCWY6VT9"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-VHXCWY6VT9');
+    </script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Gallery - PRISM</title>
+    <meta name="description" content="Partnered and community artwork for MTG proxies, tokens, and showcase treatments. Personal, non-commercial use with artist credit." />
+    <style>.wa-cloak { visibility: hidden; }</style>
+    <style>wa-page:not(:defined) { visibility: hidden; }</style>
+    <!-- Preconnect to CDNs (Supabase SDK on cdn.jsdelivr.net is lazy-loaded for logged-in users) -->
+    <link rel="preconnect" href="https://ka-p.webawesome.com" />
+    <link rel="preconnect" href="https://ka-p.webawesome.com" crossorigin />
+    <link rel="preconnect" href="https://fonts.bunny.net" />
+    <link rel="preconnect" href="https://fonts.bunny.net" crossorigin />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" />
+    <!-- Web Awesome, fonts, and app CSS as static tags so the browser preload scanner
+         starts them immediately; layout.js injectHeadResources skips tags already present -->
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.10.0/styles/themes/matter.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.10.0/styles/color/palettes/mild.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.10.0/styles/native.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.10.0/styles/utilities.css" />
+    <script type="module" src="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.10.0/webawesome.loader.js"></script>
+    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Inter:ital,wght@0,100..900;1,100..900&display=swap" />
+    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Geist+Mono:wght@100..900&display=swap" />
+    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Crimson+Pro:ital,wght@0,200..900;1,200..900&display=swap" />
+    <link rel="stylesheet" href="css/custom.css" />
+  </head>
+  <body>
+    <wa-page mobile-breakpoint="768">
+      <main style="max-width: 1100px; margin: 0 auto;">
+        <div id="gallery-root">
+          <!-- Loading skeleton, replaced by the first render -->
+          <div class="wa-stack wa-gap-m">
+            <wa-skeleton effect="pulse" style="width: 30%; height: 2rem;"></wa-skeleton>
+            <wa-skeleton effect="pulse" style="width: 60%;"></wa-skeleton>
+            <div class="wa-grid wa-gap-m" style="--min-column-size: 220px;">
+              <wa-skeleton effect="pulse" style="height: 14rem;"></wa-skeleton>
+              <wa-skeleton effect="pulse" style="height: 14rem;"></wa-skeleton>
+              <wa-skeleton effect="pulse" style="height: 14rem;"></wa-skeleton>
+              <wa-skeleton effect="pulse" style="height: 14rem;"></wa-skeleton>
+            </div>
+          </div>
+        </div>
+      </main>
+    </wa-page>
+
+    <script type="module" src="js/gallery.js"></script>
+  </body>
+</html>

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -209,6 +209,18 @@ async function toggleLike(artwork) {
 // Shared render helpers
 // ============================================================
 
+// Only allow http/https URLs into href attributes — stored values (artist
+// links, store URLs, scryfall links) must never render a javascript:/data: scheme.
+function safeUrl(url) {
+  if (!url) return '#';
+  try {
+    const u = new URL(url, window.location.origin);
+    return u.protocol === 'http:' || u.protocol === 'https:' ? url : '#';
+  } catch {
+    return '#';
+  }
+}
+
 function typeTagHtml(type, size = 'small') {
   const variant = TYPE_TAG_VARIANTS[type] || 'neutral';
   return `<wa-tag size="${size}" variant="${variant}" appearance="outlined">${TYPE_LABELS[type] || type}</wa-tag>`;
@@ -442,7 +454,7 @@ function renderDetail(root, id) {
         </div>
         <h1 class="wa-heading-xl">${escapeHtml(artwork.title)}</h1>
         ${artwork.originalCard
-          ? `<div class="gallery-orig"><wa-icon name="link" style="color: var(--wa-color-neutral-text-subtle);"></wa-icon><span>Original card: <strong>${escapeHtml(artwork.originalCard.name)}</strong>${artwork.originalCard.set ? ` &middot; ${escapeHtml(artwork.originalCard.set)}` : ''}</span><a href="${escapeHtml(artwork.originalCard.scryfallUrl || 'https://scryfall.com/search?q=' + encodeURIComponent('!"' + artwork.originalCard.name + '"'))}" target="_blank" rel="noopener" style="margin-left: auto; font-size: var(--wa-font-size-xs);">Scryfall <wa-icon name="arrow-up-right-from-square" style="font-size: 0.7em;"></wa-icon></a></div>`
+          ? `<div class="gallery-orig"><wa-icon name="link" style="color: var(--wa-color-neutral-text-subtle);"></wa-icon><span>Original card: <strong>${escapeHtml(artwork.originalCard.name)}</strong>${artwork.originalCard.set ? ` &middot; ${escapeHtml(artwork.originalCard.set)}` : ''}</span><a href="${escapeHtml(safeUrl(artwork.originalCard.scryfallUrl || 'https://scryfall.com/search?q=' + encodeURIComponent('!"' + artwork.originalCard.name + '"')))}" target="_blank" rel="noopener" style="margin-left: auto; font-size: var(--wa-font-size-xs);">Scryfall <wa-icon name="arrow-up-right-from-square" style="font-size: 0.7em;"></wa-icon></a></div>`
           : `<div class="gallery-orig"><wa-icon name="circle-minus" style="color: var(--wa-color-neutral-text-subtle);"></wa-icon><span style="color: var(--wa-color-neutral-text-subtle);">No original card${artwork.type === 'token' ? ' (token)' : ''}</span></div>`}
         ${artwork.description ? `<p class="gallery-desc">${escapeHtml(artwork.description)}</p>` : ''}
         <wa-divider></wa-divider>
@@ -455,7 +467,7 @@ function renderDetail(root, id) {
             </div>
             <p class="wa-caption-m" style="color: var(--wa-color-neutral-text-subtle); margin: var(--wa-space-3xs) 0 var(--wa-space-xs);">${escapeHtml(artist?.bio || 'Community uploader')}</p>
             <div class="wa-cluster wa-gap-m" style="font-size: var(--wa-font-size-s);">
-              ${(artist?.links || []).map(l => `<a href="${escapeHtml(l.href)}" target="_blank" rel="noopener"><wa-icon name="${escapeHtml(l.icon || 'globe')}"${l.family ? ` family="${escapeHtml(l.family)}"` : ''}></wa-icon> ${escapeHtml(l.label)}</a>`).join('')}
+              ${(artist?.links || []).map(l => `<a href="${escapeHtml(safeUrl(l.href))}" target="_blank" rel="noopener"><wa-icon name="${escapeHtml(l.icon || 'globe')}"${l.family ? ` family="${escapeHtml(l.family)}"` : ''}></wa-icon> ${escapeHtml(l.label)}</a>`).join('')}
               ${artist ? `<a href="gallery.html?artist=${encodeURIComponent(artist.id)}">View artist page &rarr;</a>` : ''}
             </div>
           </div>
@@ -465,7 +477,7 @@ function renderDetail(root, id) {
           ${user
             ? '<wa-button variant="brand" id="detail-download"><wa-icon slot="start" name="download"></wa-icon>Download</wa-button>'
             : '<wa-button variant="brand" id="detail-download-gated"><wa-icon slot="start" name="lock"></wa-icon>Sign in to download</wa-button>'}
-          ${artwork.highlighted && artwork.storeUrl ? `<wa-button appearance="outlined" href="${escapeHtml(artwork.storeUrl)}" target="_blank" rel="noopener"><wa-icon slot="start" name="cart-shopping"></wa-icon>Order custom sleeves <wa-icon slot="end" name="arrow-up-right-from-square" style="font-size: 0.7em;"></wa-icon></wa-button>` : ''}
+          ${artwork.highlighted && artwork.storeUrl ? `<wa-button appearance="outlined" href="${escapeHtml(safeUrl(artwork.storeUrl))}" target="_blank" rel="noopener"><wa-icon slot="start" name="cart-shopping"></wa-icon>Order custom sleeves <wa-icon slot="end" name="arrow-up-right-from-square" style="font-size: 0.7em;"></wa-icon></wa-button>` : ''}
         </div>
         ${user ? '' : '<p class="wa-caption-s" style="color: var(--wa-color-neutral-text-subtle); margin: 0;">Downloads need a free account — one print-ready file (2.5&times;3.5&Prime; + bleed).</p>'}
         ${licenseHtml()}
@@ -513,7 +525,7 @@ function renderArtist(root, id) {
           ${artist.isPartner ? '<wa-tag variant="brand"><wa-icon slot="start" name="handshake-angle"></wa-icon>PRISM Partner</wa-tag>' : ''}
         </div>
         <p style="color: var(--wa-color-neutral-text-normal); margin: var(--wa-space-xs) 0 0; max-width: 64ch;">${escapeHtml(artist.bio)}</p>
-        ${artist.links.length ? `<div class="wa-cluster wa-gap-m" style="margin-top: var(--wa-space-s); font-size: var(--wa-font-size-s);">${artist.links.map(l => `<a href="${escapeHtml(l.href)}" target="_blank" rel="noopener"><wa-icon name="${escapeHtml(l.icon || 'globe')}"${l.family ? ` family="${escapeHtml(l.family)}"` : ''}></wa-icon> ${escapeHtml(l.label)}</a>`).join('')}</div>` : ''}
+        ${artist.links.length ? `<div class="wa-cluster wa-gap-m" style="margin-top: var(--wa-space-s); font-size: var(--wa-font-size-s);">${artist.links.map(l => `<a href="${escapeHtml(safeUrl(l.href))}" target="_blank" rel="noopener"><wa-icon name="${escapeHtml(l.icon || 'globe')}"${l.family ? ` family="${escapeHtml(l.family)}"` : ''}></wa-icon> ${escapeHtml(l.label)}</a>`).join('')}</div>` : ''}
         ${artist.isPartner ? `
         <div class="gallery-stats">
           <div class="gallery-stat"><b>${works.length}</b><span>Works</span></div>
@@ -799,7 +811,7 @@ async function renderMyUploads(root) {
 
   root.querySelectorAll('[data-resubmit]').forEach(btn => btn.addEventListener('click', async () => {
     const { error: err } = await sb.from('gallery_artworks')
-      .update({ status: 'pending', reject_reason: null })
+      .update({ status: 'pending', reject_reason: null, reviewed_at: null, reviewed_by: null })
       .eq('id', btn.dataset.resubmit);
     if (err) { showError('Could not resubmit — try again.'); return; }
     showSuccess('Resubmitted for review');

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -1,0 +1,993 @@
+/**
+ * PRISM Gallery — entry point for gallery.html
+ *
+ * One page, deep-linkable views via query params:
+ *   gallery.html                 grid (default)
+ *   gallery.html?art=<id>        artwork detail
+ *   gallery.html?artist=<id>     artist page
+ *   gallery.html?view=upload     community upload form (signed-in)
+ *   gallery.html?view=uploads    my uploads (status tracking)
+ *   gallery.html?view=admin      moderation queue (gallery admins only)
+ *
+ * Backend: Supabase (see the GALLERY section of supabase-schema.sql).
+ * Public reads go through plain PostgREST fetch with the anon key so
+ * logged-out visitors never load the SDK; likes, uploads, and moderation
+ * use the SDK client (user is signed in, so it's already loaded).
+ *
+ * ponytail: if the gallery tables don't exist yet (schema not run), public
+ * reads fail and the page falls back to the DEMO_* sample data below —
+ * remove the demo arrays once real partner art is seeded.
+ */
+
+import { initLayout } from './layout.js';
+import { getCurrentUser, onAuthChange, ensureAuthReady } from './modules/auth.js';
+import { getSupabase, hasStoredSession, SUPABASE_URL, SUPABASE_ANON_KEY } from './modules/supabase-client.js';
+import { showSuccess, showError, showToast } from './core/notifications.js';
+import { escapeHtml } from './core/utils.js';
+
+// ============================================================
+// Demo fallback data (used only when the gallery schema isn't deployed)
+// ============================================================
+
+const DEMO_ARTISTS = [
+  { id: 'reyes', name: 'M. Reyes', isPartner: true, bio: 'Illustrator specializing in artifact and enchantment treatments for Commander. Partnered with PRISM to share proxy and showcase art for personal use.', links: [{ label: 'mreyes.art', icon: 'globe', href: '#' }, { label: '@mreyes', icon: 'instagram', family: 'brands', href: '#' }] },
+  { id: 'vela', name: 'Studio Vela', isPartner: true, bio: 'Two-person studio painting tokens and full-art lands with a storybook feel.', links: [{ label: 'studiovela.com', icon: 'globe', href: '#' }] },
+  { id: 'okafor', name: 'A. Okafor', isPartner: true, bio: 'Showcase treatments with bold linework and saturated color.', links: [{ label: '@aokafor', icon: 'instagram', family: 'brands', href: '#' }] },
+  { id: 'kanae', name: 'kanae_art', isPartner: false, bio: 'Community uploader', links: [] },
+  { id: 'deckbrewer', name: 'deckbrewer', isPartner: false, bio: 'Community uploader', links: [] },
+  { id: 'lindg', name: 'lindg', isPartner: false, bio: 'Community uploader', links: [] },
+];
+
+const DEMO_ARTWORKS = [
+  { id: 'a1', title: 'Sol Ring — Ornate', type: 'proxy', artistId: 'reyes', likes: 412, downloads: 1804, isAI: false, highlighted: true, storeUrl: 'https://example.com/store/sol-ring-ornate', originalCard: { name: 'Sol Ring', set: 'Commander 2021', scryfallUrl: 'https://scryfall.com/search?q=%21%22Sol%20Ring%22' }, description: 'A gilded, art-nouveau take on the format’s most iconic mana rock. Warm brass against deep violet.', createdAt: '2026-05-02' },
+  { id: 'a2', title: 'Treasure Token', type: 'token', artistId: 'vela', likes: 338, downloads: 1512, isAI: false, highlighted: true, storeUrl: 'https://example.com/store/treasure-token', originalCard: null, description: 'An overflowing chest for any deck that makes treasure. Painted in gouache.', createdAt: '2026-04-18' },
+  { id: 'a3', title: 'Command Tower', type: 'showcase', artistId: 'okafor', likes: 291, downloads: 990, isAI: false, highlighted: true, storeUrl: '', originalCard: { name: 'Command Tower', set: 'Commander Legends', scryfallUrl: 'https://scryfall.com/search?q=%21%22Command%20Tower%22' }, description: 'The tower at dusk, five colors of light in its windows.', createdAt: '2026-04-30' },
+  { id: 'a4', title: 'Arcane Signet', type: 'proxy', artistId: 'reyes', likes: 256, downloads: 874, isAI: false, highlighted: true, storeUrl: '', originalCard: { name: 'Arcane Signet', set: 'Throne of Eldraine', scryfallUrl: 'https://scryfall.com/search?q=%21%22Arcane%20Signet%22' }, description: 'Companion piece to Sol Ring — Ornate, same brass-and-violet language.', createdAt: '2026-05-06' },
+  { id: 'a5', title: 'Beast Token', type: 'token', artistId: 'kanae', likes: 84, downloads: 233, isAI: false, highlighted: false, storeUrl: '', originalCard: null, description: 'Green 3/3 beast for go-wide decks. Community upload.', createdAt: '2026-06-01' },
+  { id: 'a6', title: 'Rhystic Study', type: 'proxy', artistId: 'deckbrewer', likes: 63, downloads: 310, isAI: true, highlighted: false, storeUrl: '', originalCard: { name: 'Rhystic Study', set: 'Prophecy', scryfallUrl: 'https://scryfall.com/search?q=%21%22Rhystic%20Study%22' }, description: 'Do you pay the one? Moody library study, AI-assisted and hand-finished.', createdAt: '2026-06-10' },
+  { id: 'a7', title: 'Cultivate', type: 'proxy', artistId: 'lindg', likes: 41, downloads: 122, isAI: false, highlighted: false, storeUrl: '', originalCard: { name: 'Cultivate', set: 'Magic 2011', scryfallUrl: 'https://scryfall.com/search?q=%21%22Cultivate%22' }, description: 'Two lands, one to hand. Soft watercolor greens.', createdAt: '2026-06-14' },
+  { id: 'a8', title: 'Angel Token', type: 'token', artistId: 'vela', likes: 37, downloads: 96, isAI: false, highlighted: false, storeUrl: '', originalCard: null, description: 'A 4/4 vigilance angel in Studio Vela’s storybook style.', createdAt: '2026-06-20' },
+  { id: 'a9', title: 'Mana Crypt', type: 'proxy', artistId: 'reyes', likes: 198, downloads: 701, isAI: false, highlighted: false, storeUrl: '', originalCard: { name: 'Mana Crypt', set: 'Eternal Masters', scryfallUrl: 'https://scryfall.com/search?q=%21%22Mana%20Crypt%22' }, description: 'The crypt rendered as a reliquary.', createdAt: '2026-05-20' },
+  { id: 'a10', title: 'Smothering Tithe', type: 'showcase', artistId: 'reyes', likes: 143, downloads: 402, isAI: false, highlighted: false, storeUrl: '', originalCard: { name: 'Smothering Tithe', set: 'Ravnica Allegiance', scryfallUrl: 'https://scryfall.com/search?q=%21%22Smothering%20Tithe%22' }, description: 'Coins raining through cathedral light.', createdAt: '2026-05-28' },
+  { id: 'a11', title: 'Swords to Plowshares', type: 'proxy', artistId: 'reyes', likes: 121, downloads: 350, isAI: false, highlighted: false, storeUrl: '', originalCard: { name: 'Swords to Plowshares', set: 'Alpha', scryfallUrl: 'https://scryfall.com/search?q=%21%22Swords%20to%20Plowshares%22' }, description: 'The classic answer, reforged.', createdAt: '2026-06-03' },
+  { id: 'a12', title: 'Elf Warrior Token', type: 'token', artistId: 'lindg', likes: 22, downloads: 61, isAI: false, highlighted: false, storeUrl: '', originalCard: null, description: 'A 1/1 elf warrior for the wide boards.', createdAt: '2026-07-01' },
+];
+
+const TYPE_LABELS = { proxy: 'Proxy', token: 'Token', showcase: 'Showcase' };
+const TYPE_TAG_VARIANTS = { proxy: 'neutral', token: 'brand', showcase: 'warning' };
+const LICENSE_HTML = 'Personal, non-commercial use only — credit the artist. <a href="terms.html">Full terms</a>';
+
+// ============================================================
+// Data layer (Supabase)
+// ============================================================
+
+let artworks = [];        // approved artworks, mapped to camelCase
+let artistsDb = [];       // gallery_artists rows, mapped
+let myLikes = new Set();  // artwork ids the current user liked
+let usingDemo = false;    // gallery schema not deployed — read-only sample data
+let publicLoaded = false;
+
+const REST_HEADERS = { apikey: SUPABASE_ANON_KEY, Authorization: `Bearer ${SUPABASE_ANON_KEY}` };
+
+async function restGet(query) {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/${query}`, { headers: REST_HEADERS });
+  if (!res.ok) throw new Error(`Gallery fetch failed: ${res.status}`);
+  return res.json();
+}
+
+function publicImageUrl(path) {
+  return `${SUPABASE_URL}/storage/v1/object/public/gallery-art/${path}`;
+}
+
+function mapArtwork(r) {
+  return {
+    id: r.id,
+    title: r.title,
+    type: r.type,
+    originalCard: r.original_card_name
+      ? { name: r.original_card_name, set: r.original_card_set, scryfallUrl: r.scryfall_url }
+      : null,
+    description: r.description || '',
+    isAI: r.is_ai,
+    artistId: r.artist_id,
+    artistName: r.artist_name,
+    imageUrl: r.image_path ? publicImageUrl(r.image_path) : null,
+    imagePath: r.image_path,
+    likes: r.likes_count || 0,
+    downloads: r.downloads_count || 0,
+    highlighted: r.highlighted,
+    storeUrl: r.store_url,
+    status: r.status,
+    reason: r.reject_reason,
+    createdAt: r.created_at,
+  };
+}
+
+function mapArtist(r) {
+  return {
+    id: r.id,
+    name: r.name,
+    bio: r.bio || '',
+    avatarUrl: r.avatar_url,
+    links: Array.isArray(r.links) ? r.links : [],
+    isPartner: r.is_partner,
+  };
+}
+
+async function loadPublicData() {
+  try {
+    const [artworkRows, artistRows] = await Promise.all([
+      restGet('gallery_artworks?status=eq.approved&select=*&order=likes_count.desc'),
+      restGet('gallery_artists?select=*'),
+    ]);
+    artworks = artworkRows.map(mapArtwork);
+    artistsDb = artistRows.map(mapArtist);
+    usingDemo = false;
+  } catch (err) {
+    console.warn('Gallery: schema not reachable, using demo data.', err);
+    artworks = DEMO_ARTWORKS;
+    artistsDb = DEMO_ARTISTS;
+    usingDemo = true;
+  }
+  publicLoaded = true;
+}
+
+async function loadMyLikes() {
+  const user = getCurrentUser();
+  const sb = getSupabase();
+  if (!user || !sb || usingDemo) {
+    myLikes = new Set();
+    return;
+  }
+  const { data } = await sb.from('gallery_likes').select('artwork_id').eq('user_id', user.id);
+  myLikes = new Set((data || []).map(r => r.artwork_id));
+}
+
+function findArtwork(id) {
+  return artworks.find(a => a.id === id) || null;
+}
+
+function getArtist(id) {
+  return artistsDb.find(a => a.id === id) || null;
+}
+
+function artistName(artwork) {
+  return getArtist(artwork.artistId)?.name || artwork.artistName || 'Unknown';
+}
+
+function isLiked(id) {
+  return myLikes.has(id);
+}
+
+function likeCount(artwork) {
+  return artwork.likes || 0;
+}
+
+async function toggleLike(artwork) {
+  const user = getCurrentUser();
+  if (!user) {
+    showToast('Sign in to like artwork', 'brand', 'heart');
+    promptSignIn();
+    return;
+  }
+  if (usingDemo) {
+    showToast('Demo data — deploy the gallery schema to enable likes', 'neutral', 'database');
+    return;
+  }
+  const sb = getSupabase();
+  if (!sb) return;
+
+  const wasLiked = myLikes.has(artwork.id);
+  // Optimistic update; revert on error
+  if (wasLiked) {
+    myLikes.delete(artwork.id);
+    artwork.likes = Math.max(0, artwork.likes - 1);
+  } else {
+    myLikes.add(artwork.id);
+    artwork.likes += 1;
+  }
+  render();
+
+  const { error } = wasLiked
+    ? await sb.from('gallery_likes').delete().eq('artwork_id', artwork.id).eq('user_id', user.id)
+    : await sb.from('gallery_likes').insert({ artwork_id: artwork.id, user_id: user.id });
+
+  if (error) {
+    if (wasLiked) {
+      myLikes.add(artwork.id);
+      artwork.likes += 1;
+    } else {
+      myLikes.delete(artwork.id);
+      artwork.likes = Math.max(0, artwork.likes - 1);
+    }
+    render();
+    showError('Could not save like — try again.');
+  }
+}
+
+// ============================================================
+// Shared render helpers
+// ============================================================
+
+function typeTagHtml(type, size = 'small') {
+  const variant = TYPE_TAG_VARIANTS[type] || 'neutral';
+  return `<wa-tag size="${size}" variant="${variant}" appearance="outlined">${TYPE_LABELS[type] || type}</wa-tag>`;
+}
+
+function aiTagHtml(size = 'small') {
+  return `<wa-tag size="${size}" variant="neutral" appearance="filled"><wa-icon slot="start" name="robot"></wa-icon>AI-generated</wa-tag>`;
+}
+
+function partnerCheckHtml(artwork) {
+  return getArtist(artwork.artistId)?.isPartner
+    ? ' <wa-icon name="circle-check" style="color: var(--wa-color-brand-text); font-size: 0.75em;" label="Partnered artist"></wa-icon>'
+    : '';
+}
+
+function artPlaceholderHtml(artwork, cls = 'gallery-art') {
+  const img = artwork.imageUrl;
+  return `<div class="${cls}">${img ? `<img src="${escapeHtml(img)}" alt="${escapeHtml(artwork.title)}" loading="lazy" />` : '<wa-icon name="image" label="Artwork placeholder"></wa-icon>'}${artwork.highlighted ? '<wa-tag class="gallery-flag" size="small" variant="brand">Featured</wa-tag>' : artwork.isAI ? '<wa-tag class="gallery-flag" size="small" variant="neutral" appearance="filled"><wa-icon name="robot" label="AI-generated"></wa-icon></wa-tag>' : ''}</div>`;
+}
+
+function avatarHtml(artist, sizeRem, extraStyle = '') {
+  const style = `width: ${sizeRem}rem; height: ${sizeRem}rem;${extraStyle}`;
+  return artist?.avatarUrl
+    ? `<div class="gallery-avatar" style="${style} overflow: hidden;"><img src="${escapeHtml(artist.avatarUrl)}" alt="" style="width: 100%; height: 100%; object-fit: cover;" /></div>`
+    : `<div class="gallery-avatar" style="${style}"><wa-icon name="user"></wa-icon></div>`;
+}
+
+function cardHtml(artwork) {
+  return `
+    <a class="gallery-card${artwork.highlighted ? ' gallery-card--feat' : ''}" href="gallery.html?art=${encodeURIComponent(artwork.id)}" style="text-decoration: none; color: inherit;">
+      ${artPlaceholderHtml(artwork)}
+      <div class="gallery-cbody">
+        <div class="gallery-ctitle">${escapeHtml(artwork.title)}</div>
+        <div class="gallery-arow"><wa-icon name="user" style="font-size: 0.7em;"></wa-icon>${escapeHtml(artistName(artwork))}${partnerCheckHtml(artwork)}</div>
+        <div class="gallery-cfoot">
+          ${typeTagHtml(artwork.type)}
+          <button type="button" class="gallery-likes${isLiked(artwork.id) ? ' liked' : ''}" data-like="${escapeHtml(artwork.id)}" aria-label="Like">
+            <wa-icon name="heart" family="${isLiked(artwork.id) ? 'solid' : 'regular'}"></wa-icon>${likeCount(artwork)}
+          </button>
+        </div>
+      </div>
+    </a>`;
+}
+
+function breadcrumbHtml(items) {
+  return `<wa-breadcrumb style="margin-bottom: var(--wa-space-m);">
+    ${items.map(i => (i.href ? `<wa-breadcrumb-item href="${i.href}">${escapeHtml(i.label)}</wa-breadcrumb-item>` : `<wa-breadcrumb-item>${escapeHtml(i.label)}</wa-breadcrumb-item>`)).join('')}
+  </wa-breadcrumb>`;
+}
+
+function licenseHtml() {
+  return `<div class="gallery-license"><wa-icon name="scale-balanced" style="margin-top: 0.15em; flex: none;"></wa-icon><span>${LICENSE_HTML}</span></div>`;
+}
+
+function loadingHtml() {
+  return `
+    <div class="wa-stack wa-gap-m">
+      <wa-skeleton effect="pulse" style="width: 30%; height: 2rem;"></wa-skeleton>
+      <wa-skeleton effect="pulse" style="width: 60%;"></wa-skeleton>
+      <wa-skeleton effect="pulse" style="width: 100%; height: 8rem;"></wa-skeleton>
+    </div>`;
+}
+
+function promptSignIn() {
+  ensureAuthReady();
+  document.getElementById('auth-dialog')?.setAttribute('open', '');
+}
+
+/** Wire like buttons inside the root after any render. */
+function wireLikeButtons(root) {
+  root.querySelectorAll('[data-like]').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      const artwork = findArtwork(btn.dataset.like);
+      if (artwork) toggleLike(artwork);
+    });
+  });
+}
+
+// ============================================================
+// Grid view
+// ============================================================
+
+const filters = { type: 'all', artist: 'all', q: '', sort: 'liked' };
+
+function sortArtworks(list) {
+  const key = { liked: a => likeCount(a), new: a => Date.parse(a.createdAt) || 0, dl: a => a.downloads || 0 }[filters.sort];
+  return [...list].sort((a, b) => key(b) - key(a));
+}
+
+function filteredArtworks() {
+  const q = filters.q.trim().toLowerCase();
+  return artworks.filter(a => {
+    if (filters.type !== 'all' && a.type !== filters.type) return false;
+    if (filters.artist === 'partnered') {
+      if (!getArtist(a.artistId)?.isPartner) return false;
+    } else if (filters.artist !== 'all' && a.artistId !== filters.artist) return false;
+    if (q && !(a.originalCard?.name || '').toLowerCase().includes(q) && !a.title.toLowerCase().includes(q)) return false;
+    return true;
+  });
+}
+
+function renderGrid(root) {
+  const user = getCurrentUser();
+  const results = sortArtworks(filteredArtworks());
+  const featured = results.filter(a => a.highlighted);
+  const rest = results.filter(a => !a.highlighted);
+  const hasFilter = filters.type !== 'all' || filters.artist !== 'all' || filters.q.trim() !== '';
+
+  const partnered = artistsDb.filter(a => a.isPartner);
+  const community = [...new Set(artworks.map(a => a.artistId).filter(id => id && !getArtist(id)?.isPartner))]
+    .map(id => getArtist(id)).filter(Boolean);
+
+  let gridsHtml;
+  if (results.length === 0) {
+    gridsHtml = hasFilter ? `
+      <div class="gallery-empty">
+        <div class="ic"><wa-icon name="image"></wa-icon></div>
+        <h3 class="wa-heading-s">No artwork matches these filters</h3>
+        <p class="wa-caption-m" style="color: var(--wa-color-neutral-text-subtle); max-width: 32ch;">Try another card name or clear the type filter.</p>
+        <div class="wa-cluster wa-gap-xs">
+          <wa-button size="small" appearance="outlined" id="gallery-clear-filters">Clear filters</wa-button>
+          <wa-button size="small" variant="brand" href="gallery.html?view=upload"><wa-icon slot="start" name="plus"></wa-icon>Upload one</wa-button>
+        </div>
+      </div>` : `
+      <div class="gallery-empty">
+        <div class="ic"><wa-icon name="image"></wa-icon></div>
+        <h3 class="wa-heading-s">No artwork yet</h3>
+        <p class="wa-caption-m" style="color: var(--wa-color-neutral-text-subtle); max-width: 32ch;">Partnered art is on its way. Be the first community upload.</p>
+        <wa-button size="small" variant="brand" href="gallery.html?view=upload"><wa-icon slot="start" name="plus"></wa-icon>Upload artwork</wa-button>
+      </div>`;
+  } else if (hasFilter || filters.sort !== 'liked') {
+    gridsHtml = `
+      <div class="gallery-eyebrow"><wa-icon name="images"></wa-icon>Results <span class="count">&middot; ${results.length} piece${results.length === 1 ? '' : 's'}</span></div>
+      <div class="wa-grid wa-gap-m gallery-grid">${results.map(cardHtml).join('')}</div>`;
+  } else {
+    gridsHtml = `
+      ${featured.length ? `
+        <div class="gallery-eyebrow"><wa-icon name="star" style="color: var(--wa-color-brand-text);"></wa-icon>Featured <span class="count">&middot; partnered work</span></div>
+        <div class="wa-grid wa-gap-m gallery-grid">${featured.map(cardHtml).join('')}</div>` : ''}
+      <div class="gallery-eyebrow"><wa-icon name="images"></wa-icon>All artwork <span class="count">&middot; ${rest.length} piece${rest.length === 1 ? '' : 's'}</span></div>
+      <div class="wa-grid wa-gap-m gallery-grid">${rest.map(cardHtml).join('')}</div>`;
+  }
+
+  root.innerHTML = `
+    <div class="wa-split" style="align-items: flex-start; gap: var(--wa-space-m);">
+      <div>
+        <h1 class="wa-heading-2xl">Gallery</h1>
+        <p style="color: var(--wa-color-neutral-text-subtle); max-width: 60ch; margin-top: var(--wa-space-2xs);">Partnered and community artwork for proxies, tokens, and showcase treatments. Personal, non-commercial use with credit to the artist.</p>
+      </div>
+      <wa-button variant="brand" href="gallery.html?view=upload"><wa-icon slot="start" name="plus"></wa-icon>Upload artwork</wa-button>
+    </div>
+
+    ${user ? '' : `
+    <wa-callout variant="brand" size="small" style="margin-top: var(--wa-space-m);">
+      <wa-icon slot="icon" name="circle-info"></wa-icon>
+      Browsing as a guest. Likes and counts are visible. <a href="#" id="gallery-signin-link">Sign in</a> to like and download.
+    </wa-callout>`}
+
+    <div class="gallery-toolbar">
+      <div class="gallery-toolbar-search">
+        <wa-input id="gallery-search" size="small" label="Card name search" placeholder="Search by card name — e.g. Sol Ring" value="${escapeHtml(filters.q)}">
+          <wa-icon slot="start" name="magnifying-glass"></wa-icon>
+        </wa-input>
+      </div>
+      <div>
+        <span class="gallery-tlabel">Type</span>
+        <wa-button-group label="Filter by type">
+          ${['all', 'proxy', 'token', 'showcase'].map(t => `<wa-button size="small" data-type="${t}"${filters.type === t ? ' variant="brand"' : ' appearance="outlined"'}>${t === 'all' ? 'All' : TYPE_LABELS[t]}</wa-button>`).join('')}
+        </wa-button-group>
+      </div>
+      <wa-select id="gallery-artist" size="small" label="Artist" value="${escapeHtml(filters.artist)}" style="width: 12rem;">
+        <wa-option value="all">All artists</wa-option>
+        <wa-option value="partnered">Partnered artists</wa-option>
+        ${partnered.map(a => `<wa-option value="${a.id}">${escapeHtml(a.name)}</wa-option>`).join('')}
+        ${community.map(a => `<wa-option value="${a.id}">${escapeHtml(a.name)}</wa-option>`).join('')}
+      </wa-select>
+      <wa-select id="gallery-sort" size="small" label="Sort" value="${escapeHtml(filters.sort)}" style="width: 11rem;">
+        <wa-option value="liked">Most liked</wa-option>
+        <wa-option value="new">Newest</wa-option>
+        <wa-option value="dl">Most downloaded</wa-option>
+      </wa-select>
+    </div>
+
+    ${gridsHtml}`;
+
+  wireLikeButtons(root);
+  root.querySelector('#gallery-signin-link')?.addEventListener('click', e => { e.preventDefault(); promptSignIn(); });
+  root.querySelector('#gallery-clear-filters')?.addEventListener('click', () => {
+    filters.type = 'all'; filters.artist = 'all'; filters.q = ''; filters.sort = 'liked';
+    render();
+  });
+  root.querySelectorAll('[data-type]').forEach(btn => btn.addEventListener('click', () => {
+    filters.type = btn.dataset.type;
+    render();
+  }));
+  const search = root.querySelector('#gallery-search');
+  let searchTimer;
+  search?.addEventListener('input', () => {
+    clearTimeout(searchTimer);
+    searchTimer = setTimeout(() => { filters.q = search.value || ''; render(); }, 250);
+  });
+  root.querySelector('#gallery-artist')?.addEventListener('change', e => { filters.artist = e.target.value; render(); });
+  root.querySelector('#gallery-sort')?.addEventListener('change', e => { filters.sort = e.target.value; render(); });
+}
+
+// ============================================================
+// Detail view
+// ============================================================
+
+function renderDetail(root, id) {
+  const artwork = findArtwork(id);
+  if (!artwork) {
+    renderNotFound(root, 'Artwork not found', 'It may still be in review, or the link is wrong.');
+    return;
+  }
+  const user = getCurrentUser();
+  const artist = getArtist(artwork.artistId);
+  const more = artworks.filter(a => a.artistId === artwork.artistId && a.id !== artwork.id && artwork.artistId).slice(0, 4);
+  const liked = isLiked(artwork.id);
+
+  root.innerHTML = `
+    ${breadcrumbHtml([{ label: 'Gallery', href: 'gallery.html' }, { label: artwork.title }])}
+    <div class="gallery-detail">
+      ${artPlaceholderHtml(artwork, 'gallery-art gallery-art--lg')}
+      <div class="wa-stack wa-gap-s">
+        <div class="wa-cluster wa-gap-xs wa-align-items-center">
+          ${typeTagHtml(artwork.type)}
+          ${artwork.isAI ? aiTagHtml() : ''}
+        </div>
+        <h1 class="wa-heading-xl">${escapeHtml(artwork.title)}</h1>
+        ${artwork.originalCard
+          ? `<div class="gallery-orig"><wa-icon name="link" style="color: var(--wa-color-neutral-text-subtle);"></wa-icon><span>Original card: <strong>${escapeHtml(artwork.originalCard.name)}</strong>${artwork.originalCard.set ? ` &middot; ${escapeHtml(artwork.originalCard.set)}` : ''}</span><a href="${escapeHtml(artwork.originalCard.scryfallUrl || 'https://scryfall.com/search?q=' + encodeURIComponent('!"' + artwork.originalCard.name + '"'))}" target="_blank" rel="noopener" style="margin-left: auto; font-size: var(--wa-font-size-xs);">Scryfall <wa-icon name="arrow-up-right-from-square" style="font-size: 0.7em;"></wa-icon></a></div>`
+          : `<div class="gallery-orig"><wa-icon name="circle-minus" style="color: var(--wa-color-neutral-text-subtle);"></wa-icon><span style="color: var(--wa-color-neutral-text-subtle);">No original card${artwork.type === 'token' ? ' (token)' : ''}</span></div>`}
+        ${artwork.description ? `<p class="gallery-desc">${escapeHtml(artwork.description)}</p>` : ''}
+        <wa-divider></wa-divider>
+        <div class="gallery-artist-card">
+          ${avatarHtml(artist, 2.875)}
+          <div style="flex: 1;">
+            <div class="wa-cluster wa-gap-xs wa-align-items-center">
+              <strong>${escapeHtml(artistName(artwork))}</strong>
+              ${artist?.isPartner ? '<wa-tag size="small" variant="brand"><wa-icon slot="start" name="handshake-angle"></wa-icon>Partner</wa-tag>' : ''}
+            </div>
+            <p class="wa-caption-m" style="color: var(--wa-color-neutral-text-subtle); margin: var(--wa-space-3xs) 0 var(--wa-space-xs);">${escapeHtml(artist?.bio || 'Community uploader')}</p>
+            <div class="wa-cluster wa-gap-m" style="font-size: var(--wa-font-size-s);">
+              ${(artist?.links || []).map(l => `<a href="${escapeHtml(l.href)}" target="_blank" rel="noopener"><wa-icon name="${escapeHtml(l.icon || 'globe')}"${l.family ? ` family="${escapeHtml(l.family)}"` : ''}></wa-icon> ${escapeHtml(l.label)}</a>`).join('')}
+              ${artist ? `<a href="gallery.html?artist=${encodeURIComponent(artist.id)}">View artist page &rarr;</a>` : ''}
+            </div>
+          </div>
+        </div>
+        <div class="wa-cluster wa-gap-s wa-align-items-center">
+          <wa-button appearance="outlined" id="detail-like"><wa-icon slot="start" name="heart" family="${liked ? 'solid' : 'regular'}"${liked ? ' style="color: var(--wa-color-brand-text);"' : ''}></wa-icon>Like &middot; ${likeCount(artwork)}</wa-button>
+          ${user
+            ? '<wa-button variant="brand" id="detail-download"><wa-icon slot="start" name="download"></wa-icon>Download</wa-button>'
+            : '<wa-button variant="brand" id="detail-download-gated"><wa-icon slot="start" name="lock"></wa-icon>Sign in to download</wa-button>'}
+          ${artwork.highlighted && artwork.storeUrl ? `<wa-button appearance="outlined" href="${escapeHtml(artwork.storeUrl)}" target="_blank" rel="noopener"><wa-icon slot="start" name="cart-shopping"></wa-icon>Order custom sleeves <wa-icon slot="end" name="arrow-up-right-from-square" style="font-size: 0.7em;"></wa-icon></wa-button>` : ''}
+        </div>
+        ${user ? '' : '<p class="wa-caption-s" style="color: var(--wa-color-neutral-text-subtle); margin: 0;">Downloads need a free account — one print-ready file (2.5&times;3.5&Prime; + bleed).</p>'}
+        ${licenseHtml()}
+      </div>
+    </div>
+    ${more.length ? `
+      <div class="gallery-eyebrow"><wa-icon name="images"></wa-icon>More from ${escapeHtml(artistName(artwork))}</div>
+      <div class="wa-grid wa-gap-m gallery-grid">${more.map(cardHtml).join('')}</div>` : ''}`;
+
+  wireLikeButtons(root);
+  root.querySelector('#detail-like')?.addEventListener('click', () => toggleLike(artwork));
+  root.querySelector('#detail-download')?.addEventListener('click', () => {
+    if (usingDemo || !artwork.imageUrl) {
+      // ponytail: demo pieces have no hosted file — real artworks always do
+      showToast('Print-ready file coming soon for this piece', 'neutral', 'download');
+      return;
+    }
+    getSupabase()?.rpc('increment_gallery_download', { p_artwork_id: artwork.id });
+    window.open(artwork.imageUrl, '_blank', 'noopener');
+  });
+  root.querySelector('#detail-download-gated')?.addEventListener('click', promptSignIn);
+}
+
+// ============================================================
+// Artist view
+// ============================================================
+
+function renderArtist(root, id) {
+  const artist = getArtist(id);
+  if (!artist) {
+    renderNotFound(root, 'Artist not found', 'The link may be wrong.');
+    return;
+  }
+  const works = sortArtworks(artworks.filter(a => a.artistId === artist.id));
+  const totalLikes = works.reduce((sum, a) => sum + likeCount(a), 0);
+  const focus = [...new Set(works.map(w => TYPE_LABELS[w.type]))].join(' &middot; ');
+
+  root.innerHTML = `
+    ${breadcrumbHtml([{ label: 'Gallery', href: 'gallery.html' }, { label: artist.name }])}
+    <div class="gallery-artist-head${artist.isPartner ? '' : ' gallery-artist-head--community'}">
+      ${avatarHtml(artist, 5, ` font-size: var(--wa-font-size-xl);${artist.isPartner && !artist.avatarUrl ? ' background: var(--wa-color-brand-fill-normal); color: var(--wa-color-brand-on-normal);' : ''}`)}
+      <div style="flex: 1;">
+        <div class="wa-cluster wa-gap-s wa-align-items-center">
+          <h1 class="wa-heading-xl">${escapeHtml(artist.name)}</h1>
+          ${artist.isPartner ? '<wa-tag variant="brand"><wa-icon slot="start" name="handshake-angle"></wa-icon>PRISM Partner</wa-tag>' : ''}
+        </div>
+        <p style="color: var(--wa-color-neutral-text-normal); margin: var(--wa-space-xs) 0 0; max-width: 64ch;">${escapeHtml(artist.bio)}</p>
+        ${artist.links.length ? `<div class="wa-cluster wa-gap-m" style="margin-top: var(--wa-space-s); font-size: var(--wa-font-size-s);">${artist.links.map(l => `<a href="${escapeHtml(l.href)}" target="_blank" rel="noopener"><wa-icon name="${escapeHtml(l.icon || 'globe')}"${l.family ? ` family="${escapeHtml(l.family)}"` : ''}></wa-icon> ${escapeHtml(l.label)}</a>`).join('')}</div>` : ''}
+        ${artist.isPartner ? `
+        <div class="gallery-stats">
+          <div class="gallery-stat"><b>${works.length}</b><span>Works</span></div>
+          <div class="gallery-stat"><b>${totalLikes}</b><span>Likes</span></div>
+          ${focus ? `<div class="gallery-stat"><b>${focus}</b><span>Focus</span></div>` : ''}
+        </div>` : ''}
+      </div>
+    </div>
+    <div class="gallery-eyebrow"><wa-icon name="images"></wa-icon>Works <span class="count">&middot; ${works.length}</span></div>
+    ${works.length
+      ? `<div class="wa-grid wa-gap-m gallery-grid">${works.map(cardHtml).join('')}</div>`
+      : '<p style="color: var(--wa-color-neutral-text-subtle);">No public works yet.</p>'}`;
+
+  wireLikeButtons(root);
+}
+
+// ============================================================
+// Upload view
+// ============================================================
+
+function renderUpload(root) {
+  const user = getCurrentUser();
+  if (!user) {
+    if (hasStoredSession()) { root.innerHTML = loadingHtml(); return; } // auth still restoring
+    root.innerHTML = `
+      ${breadcrumbHtml([{ label: 'Gallery', href: 'gallery.html' }, { label: 'Upload artwork' }])}
+      <div class="gallery-empty" style="max-width: 34rem;">
+        <div class="ic"><wa-icon name="lock"></wa-icon></div>
+        <h2 class="wa-heading-m">Sign in to upload artwork</h2>
+        <p class="wa-caption-m" style="color: var(--wa-color-neutral-text-subtle); max-width: 40ch;">Community uploads need a free account. Uploads are reviewed before going public.</p>
+        <wa-button variant="brand" id="upload-signin"><wa-icon slot="start" name="right-to-bracket"></wa-icon>Sign in</wa-button>
+      </div>`;
+    root.querySelector('#upload-signin')?.addEventListener('click', promptSignIn);
+    return;
+  }
+
+  root.innerHTML = `
+    ${breadcrumbHtml([{ label: 'Gallery', href: 'gallery.html' }, { label: 'Upload artwork' }])}
+    <h1 class="wa-heading-2xl">Upload artwork</h1>
+    <p style="color: var(--wa-color-neutral-text-subtle); margin-top: var(--wa-space-2xs);">Uploads are reviewed before going public. You&rsquo;ll see it under <a href="gallery.html?view=uploads">My uploads</a> while it&rsquo;s pending.</p>
+    <form class="gallery-form" id="upload-form" style="margin-top: var(--wa-space-l);">
+      <div>
+        <span class="gallery-tlabel">Image <span style="color: var(--wa-color-danger-text);">*</span></span>
+        <div class="gallery-drop" id="upload-drop" tabindex="0" role="button" aria-label="Choose an image file">
+          <wa-icon name="cloud-arrow-up" style="font-size: var(--wa-font-size-xl);"></wa-icon>
+          <div id="upload-drop-label"><strong>Drop image or browse</strong></div>
+          <div class="wa-caption-s">PNG, JPG, or WebP &middot; up to 10 MB &middot; high-res recommended for print</div>
+        </div>
+        <input type="file" id="upload-file" accept="image/png,image/jpeg,image/webp" hidden />
+      </div>
+      <wa-input id="up-title" label="Title" placeholder="e.g. Sol Ring — Ornate" required></wa-input>
+      <wa-radio-group id="up-type" label="Type" value="proxy" orientation="horizontal">
+        <wa-radio value="proxy">Proxy</wa-radio>
+        <wa-radio value="token">Token</wa-radio>
+        <wa-radio value="showcase">Showcase</wa-radio>
+      </wa-radio-group>
+      <div class="gallery-suggest">
+        <wa-input id="up-card" label="Original card (optional)" placeholder="Start typing a card name" autocomplete="off">
+          <wa-icon slot="start" name="magnifying-glass"></wa-icon>
+          <span slot="hint">Leave blank for tokens or original art with no source card.</span>
+        </wa-input>
+        <div class="gallery-suggest-list" id="up-card-suggest" hidden></div>
+      </div>
+      <wa-textarea id="up-desc" label="Description" placeholder="Tell players about this piece (optional)" rows="3"></wa-textarea>
+      <div>
+        <wa-radio-group id="up-ai" label="AI-generated?" orientation="horizontal">
+          <wa-radio value="no">No</wa-radio>
+          <wa-radio value="yes">Yes</wa-radio>
+        </wa-radio-group>
+        <p class="wa-caption-s" style="color: var(--wa-color-neutral-text-subtle); margin: var(--wa-space-2xs) 0 0;"><wa-icon name="robot"></wa-icon> AI art is allowed but must be labeled.</p>
+      </div>
+      <wa-input id="up-artist" label="Artist attribution" value="${escapeHtml(user.email || 'You')}">
+        <span slot="hint">Crediting someone else? Enter their name — only with their permission.</span>
+      </wa-input>
+      <div class="gallery-ack">
+        <wa-checkbox id="up-ack">I confirm this upload follows the rules:</wa-checkbox>
+        <span class="wa-caption-s" style="color: var(--wa-color-neutral-text-subtle);">MTG-related only &middot; your own work or permission held &middot; no NSFW &middot; AI art is labeled</span>
+      </div>
+      <div class="wa-cluster wa-gap-s">
+        <wa-button type="submit" variant="brand" id="upload-submit"><wa-icon slot="start" name="paper-plane"></wa-icon>Submit for review</wa-button>
+        <wa-button type="button" appearance="plain" href="gallery.html">Cancel</wa-button>
+      </div>
+    </form>`;
+
+  // Image picker (click, keyboard, drag & drop)
+  const drop = root.querySelector('#upload-drop');
+  const fileInput = root.querySelector('#upload-file');
+  let selectedFile = null;
+  const readFile = file => {
+    if (!file || !file.type.startsWith('image/')) return;
+    if (file.size > 10 * 1024 * 1024) {
+      showError('Image too large — keep it under 10 MB.');
+      return;
+    }
+    selectedFile = file;
+    const reader = new FileReader();
+    reader.onload = () => {
+      drop.innerHTML = `<img src="${reader.result}" alt="Selected artwork preview" /><div class="wa-caption-s">${escapeHtml(file.name)} &middot; click to replace</div>`;
+    };
+    reader.readAsDataURL(file);
+  };
+  drop.addEventListener('click', () => fileInput.click());
+  drop.addEventListener('keydown', e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); fileInput.click(); } });
+  fileInput.addEventListener('change', () => readFile(fileInput.files[0]));
+  drop.addEventListener('dragover', e => { e.preventDefault(); drop.classList.add('dragover'); });
+  drop.addEventListener('dragleave', () => drop.classList.remove('dragover'));
+  drop.addEventListener('drop', e => { e.preventDefault(); drop.classList.remove('dragover'); readFile(e.dataTransfer.files[0]); });
+
+  // Scryfall card-name autocomplete
+  const cardInput = root.querySelector('#up-card');
+  const suggest = root.querySelector('#up-card-suggest');
+  let acTimer;
+  cardInput.addEventListener('input', () => {
+    clearTimeout(acTimer);
+    const q = (cardInput.value || '').trim();
+    if (q.length < 2) { suggest.hidden = true; return; }
+    acTimer = setTimeout(async () => {
+      try {
+        const res = await fetch(`https://api.scryfall.com/cards/autocomplete?q=${encodeURIComponent(q)}`);
+        const data = await res.json();
+        const names = (data.data || []).slice(0, 8);
+        suggest.innerHTML = names.map(n => `<button type="button">${escapeHtml(n)}</button>`).join('');
+        suggest.hidden = names.length === 0;
+        suggest.querySelectorAll('button').forEach(b => b.addEventListener('click', () => {
+          cardInput.value = b.textContent;
+          suggest.hidden = true;
+        }));
+      } catch {
+        suggest.hidden = true;
+      }
+    }, 250);
+  });
+  document.addEventListener('click', e => { if (!suggest.contains(e.target) && e.target !== cardInput) suggest.hidden = true; });
+
+  root.querySelector('#upload-form').addEventListener('submit', async e => {
+    e.preventDefault();
+    const title = root.querySelector('#up-title').value?.trim();
+    const ai = root.querySelector('#up-ai').value;
+    const ack = root.querySelector('#up-ack').checked;
+    if (!selectedFile) { showError('Add an image — it’s what the gallery is for.'); return; }
+    if (!title) { showError('Give it a title.'); return; }
+    if (!ai) { showError('Tell us whether it’s AI-generated — AI art is allowed but must be labeled.'); return; }
+    if (!ack) { showError('Please confirm the upload rules.'); return; }
+
+    const sb = getSupabase();
+    if (!sb) { showError('Not connected — try reloading the page.'); return; }
+
+    const submitBtn = root.querySelector('#upload-submit');
+    submitBtn.setAttribute('loading', '');
+    submitBtn.setAttribute('disabled', '');
+
+    try {
+      const ext = { 'image/png': 'png', 'image/jpeg': 'jpg', 'image/webp': 'webp' }[selectedFile.type] || 'png';
+      const path = `${user.id}/${crypto.randomUUID()}.${ext}`;
+      const { error: uploadErr } = await sb.storage.from('gallery-art').upload(path, selectedFile, { contentType: selectedFile.type });
+      if (uploadErr) throw uploadErr;
+
+      const cardName = cardInput.value?.trim();
+      const { error: insertErr } = await sb.from('gallery_artworks').insert({
+        title,
+        type: root.querySelector('#up-type').value || 'proxy',
+        original_card_name: cardName || null,
+        scryfall_url: cardName ? 'https://scryfall.com/search?q=' + encodeURIComponent('!"' + cardName + '"') : null,
+        description: root.querySelector('#up-desc').value?.trim() || '',
+        is_ai: ai === 'yes',
+        artist_name: root.querySelector('#up-artist').value?.trim() || user.email,
+        uploader_id: user.id,
+        image_path: path,
+        status: 'pending',
+      });
+      if (insertErr) {
+        sb.storage.from('gallery-art').remove([path]); // best-effort cleanup
+        throw insertErr;
+      }
+      renderPending(root);
+    } catch (err) {
+      console.error('Gallery upload failed:', err);
+      showError('Upload failed — try again.');
+      submitBtn.removeAttribute('loading');
+      submitBtn.removeAttribute('disabled');
+    }
+  });
+}
+
+function renderPending(root) {
+  root.innerHTML = `
+    <div class="wa-stack wa-gap-m wa-align-items-center" style="text-align: center; padding-block: var(--wa-space-3xl); max-width: 30rem; margin: 0 auto;">
+      <div class="gallery-avatar" style="width: 3.5rem; height: 3.5rem; background: var(--wa-color-warning-fill-quiet); color: var(--wa-color-warning-text); font-size: var(--wa-font-size-l);"><wa-icon name="clock"></wa-icon></div>
+      <h2 class="wa-heading-l">Submitted — pending review</h2>
+      <p style="color: var(--wa-color-neutral-text-subtle);">Thanks. An admin will review it before it goes public. You&rsquo;ll find its status under My uploads.</p>
+      <wa-callout size="small" style="text-align: left;">
+        <wa-icon slot="icon" name="list-check"></wa-icon>
+        We check: MTG-related, your own work or permission, no NSFW, AI labeled.
+      </wa-callout>
+      <div class="wa-cluster wa-gap-xs">
+        <wa-button size="small" variant="brand" href="gallery.html?view=uploads">View My uploads</wa-button>
+        <wa-button size="small" appearance="outlined" href="gallery.html?view=upload">Upload another</wa-button>
+      </div>
+    </div>`;
+}
+
+// ============================================================
+// My uploads view
+// ============================================================
+
+const STATUS_TAGS = {
+  pending: '<wa-tag variant="warning"><wa-icon slot="start" name="clock"></wa-icon>Pending</wa-tag>',
+  approved: '<wa-tag variant="success"><wa-icon slot="start" name="circle-check"></wa-icon>Approved</wa-tag>',
+  rejected: '<wa-tag variant="danger"><wa-icon slot="start" name="circle-xmark"></wa-icon>Rejected</wa-tag>',
+};
+
+function uploadRowHtml(u) {
+  return `
+    <div class="gallery-row${u.status === 'rejected' ? ' gallery-row--rejected' : ''}">
+      <div class="gallery-thumb">${u.imageUrl ? `<img src="${escapeHtml(u.imageUrl)}" alt="" loading="lazy" />` : '<wa-icon name="image"></wa-icon>'}</div>
+      <div class="gallery-rowmeta">
+        <strong>${escapeHtml(u.title)}</strong>
+        <div class="gallery-rowsub">
+          <span><wa-icon name="tag"></wa-icon> ${TYPE_LABELS[u.type] || u.type}</span>
+          ${u.isAI ? '<span><wa-icon name="robot"></wa-icon> AI</span>' : ''}
+          ${u.status === 'approved' ? `<span><wa-icon name="heart"></wa-icon> ${likeCount(u)}</span>` : ''}
+          <span>Submitted <wa-relative-time date="${escapeHtml(u.createdAt)}"></wa-relative-time></span>
+          ${u.status === 'rejected' && u.reason ? `<span style="color: var(--wa-color-danger-text);"><wa-icon name="circle-exclamation"></wa-icon> Reason: ${escapeHtml(u.reason)}</span>` : ''}
+        </div>
+      </div>
+      ${STATUS_TAGS[u.status] || ''}
+      ${u.status === 'approved' ? `<wa-button size="small" appearance="outlined" href="gallery.html?art=${encodeURIComponent(u.id)}">View</wa-button>` : ''}
+      ${u.status === 'rejected' ? `<wa-button size="small" appearance="outlined" data-resubmit="${u.id}">Resubmit</wa-button>` : ''}
+      ${u.status === 'pending' ? `<wa-button size="small" appearance="plain" data-withdraw="${u.id}" aria-label="Withdraw upload"><wa-icon name="trash"></wa-icon></wa-button>` : ''}
+    </div>`;
+}
+
+async function renderMyUploads(root) {
+  const user = getCurrentUser();
+  if (!user) {
+    if (hasStoredSession()) { root.innerHTML = loadingHtml(); return; } // auth still restoring
+    root.innerHTML = `
+      ${breadcrumbHtml([{ label: 'Gallery', href: 'gallery.html' }, { label: 'My uploads' }])}
+      <div class="gallery-empty" style="max-width: 34rem;">
+        <div class="ic"><wa-icon name="lock"></wa-icon></div>
+        <h2 class="wa-heading-m">Sign in to see your uploads</h2>
+        <wa-button variant="brand" id="uploads-signin"><wa-icon slot="start" name="right-to-bracket"></wa-icon>Sign in</wa-button>
+      </div>`;
+    root.querySelector('#uploads-signin')?.addEventListener('click', promptSignIn);
+    return;
+  }
+
+  const sb = getSupabase();
+  root.innerHTML = loadingHtml();
+  const { data, error } = await sb.from('gallery_artworks')
+    .select('*')
+    .eq('uploader_id', user.id)
+    .order('created_at', { ascending: false });
+  if (error) {
+    renderNotFound(root, 'Could not load your uploads', 'Check your connection and reload.');
+    return;
+  }
+  const uploads = (data || []).map(mapArtwork);
+  const by = status => uploads.filter(u => u.status === status);
+  const listHtml = list => (list.length
+    ? `<div class="wa-stack wa-gap-s">${list.map(uploadRowHtml).join('')}</div>`
+    : '<p style="color: var(--wa-color-neutral-text-subtle);">Nothing here yet.</p>');
+
+  root.innerHTML = `
+    ${breadcrumbHtml([{ label: 'Gallery', href: 'gallery.html' }, { label: 'My uploads' }])}
+    <div class="wa-split" style="align-items: flex-start;">
+      <div>
+        <h1 class="wa-heading-2xl">My uploads</h1>
+        <p style="color: var(--wa-color-neutral-text-subtle); margin-top: var(--wa-space-2xs);">Track your submissions through review.</p>
+      </div>
+      <wa-button variant="brand" href="gallery.html?view=upload"><wa-icon slot="start" name="plus"></wa-icon>Upload artwork</wa-button>
+    </div>
+    <wa-tab-group style="margin-top: var(--wa-space-m);">
+      <wa-tab panel="all">All &middot; ${uploads.length}</wa-tab>
+      <wa-tab panel="pending">Pending &middot; ${by('pending').length}</wa-tab>
+      <wa-tab panel="approved">Approved &middot; ${by('approved').length}</wa-tab>
+      <wa-tab panel="rejected">Rejected &middot; ${by('rejected').length}</wa-tab>
+      <wa-tab-panel name="all">${listHtml(uploads)}</wa-tab-panel>
+      <wa-tab-panel name="pending">${listHtml(by('pending'))}</wa-tab-panel>
+      <wa-tab-panel name="approved">${listHtml(by('approved'))}</wa-tab-panel>
+      <wa-tab-panel name="rejected">${listHtml(by('rejected'))}</wa-tab-panel>
+    </wa-tab-group>`;
+
+  root.querySelectorAll('[data-resubmit]').forEach(btn => btn.addEventListener('click', async () => {
+    const { error: err } = await sb.from('gallery_artworks')
+      .update({ status: 'pending', reject_reason: null })
+      .eq('id', btn.dataset.resubmit);
+    if (err) { showError('Could not resubmit — try again.'); return; }
+    showSuccess('Resubmitted for review');
+    render();
+  }));
+  root.querySelectorAll('[data-withdraw]').forEach(btn => btn.addEventListener('click', async () => {
+    const u = uploads.find(x => x.id === btn.dataset.withdraw);
+    const { error: err } = await sb.from('gallery_artworks').delete().eq('id', btn.dataset.withdraw);
+    if (err) { showError('Could not withdraw — try again.'); return; }
+    if (u?.imagePath) sb.storage.from('gallery-art').remove([u.imagePath]); // best-effort
+    showSuccess('Upload withdrawn');
+    render();
+  }));
+}
+
+// ============================================================
+// Admin moderation queue (gallery admins only)
+// ============================================================
+
+async function renderAdmin(root) {
+  const user = getCurrentUser();
+  if (!user) {
+    if (hasStoredSession()) { root.innerHTML = loadingHtml(); return; } // auth still restoring
+    renderNotFound(root, 'Not authorized', 'The moderation queue is for gallery admins. Sign in first.');
+    return;
+  }
+  const sb = getSupabase();
+  root.innerHTML = loadingHtml();
+
+  const { data: adminOk } = await sb.rpc('is_gallery_admin');
+  if (!adminOk) {
+    renderNotFound(root, 'Not authorized', 'The moderation queue is for gallery admins.');
+    return;
+  }
+
+  const { data, error } = await sb.from('gallery_artworks')
+    .select('*')
+    .eq('status', 'pending')
+    .order('created_at', { ascending: true });
+  if (error) {
+    renderNotFound(root, 'Could not load the queue', 'Check your connection and reload.');
+    return;
+  }
+  const pending = (data || []).map(mapArtwork);
+
+  root.innerHTML = `
+    ${breadcrumbHtml([{ label: 'Gallery', href: 'gallery.html' }, { label: 'Moderation queue' }])}
+    <div class="wa-split" style="align-items: flex-start;">
+      <div>
+        <h1 class="wa-heading-2xl">Moderation queue</h1>
+        <p style="color: var(--wa-color-neutral-text-subtle); margin-top: var(--wa-space-2xs);">Review pending uploads. Approve, reject with a reason, set Highlight and a store URL.</p>
+      </div>
+      <wa-tag variant="warning" size="large"><wa-icon slot="start" name="inbox"></wa-icon>${pending.length} pending</wa-tag>
+    </div>
+    ${pending.length === 0 ? `
+      <div class="gallery-empty">
+        <div class="ic"><wa-icon name="inbox"></wa-icon></div>
+        <h3 class="wa-heading-s">Queue is clear</h3>
+        <p class="wa-caption-m" style="color: var(--wa-color-neutral-text-subtle);">New community uploads land here for review.</p>
+      </div>` : `
+      <div class="wa-stack wa-gap-m" style="margin-top: var(--wa-space-m);">
+        ${pending.map(u => `
+        <div class="gallery-queue-card" data-queue="${u.id}">
+          <div class="wa-split" style="align-items: flex-start; gap: var(--wa-space-m);">
+            <div class="wa-cluster wa-gap-m" style="align-items: flex-start; flex: 1;">
+              <div class="gallery-thumb" style="width: 6rem; height: 4.5rem;">${u.imageUrl ? `<img src="${escapeHtml(u.imageUrl)}" alt="" loading="lazy" />` : '<wa-icon name="image"></wa-icon>'}</div>
+              <div class="gallery-rowmeta">
+                <div class="wa-cluster wa-gap-xs wa-align-items-center">
+                  <strong>${escapeHtml(u.title)}</strong>
+                  ${typeTagHtml(u.type)}
+                  ${u.isAI ? '<wa-tag size="small" variant="neutral" appearance="filled"><wa-icon slot="start" name="robot"></wa-icon>AI</wa-tag>' : ''}
+                </div>
+                <div class="gallery-rowsub">
+                  <span><wa-icon name="user"></wa-icon> ${escapeHtml(u.artistName || 'Unknown')}</span>
+                  ${u.originalCard ? `<span><wa-icon name="link"></wa-icon> ${escapeHtml(u.originalCard.name)}</span>` : '<span><wa-icon name="circle-minus"></wa-icon> No source card</span>'}
+                  <span>Submitted <wa-relative-time date="${escapeHtml(u.createdAt)}"></wa-relative-time></span>
+                </div>
+                ${u.description ? `<p class="wa-caption-m" style="color: var(--wa-color-neutral-text-subtle); margin: var(--wa-space-3xs) 0 0; max-width: 60ch;">${escapeHtml(u.description)}</p>` : ''}
+              </div>
+            </div>
+            <div class="wa-cluster wa-gap-xs">
+              <wa-button size="small" variant="success" data-approve="${u.id}"><wa-icon slot="start" name="check"></wa-icon>Approve</wa-button>
+              <wa-button size="small" variant="danger" appearance="outlined" data-reject="${u.id}"><wa-icon slot="start" name="xmark"></wa-icon>Reject&hellip;</wa-button>
+            </div>
+          </div>
+          <wa-divider style="margin: 0;"></wa-divider>
+          <div class="wa-split wa-align-items-center">
+            <div class="wa-cluster wa-gap-l wa-align-items-center">
+              <wa-switch size="small" data-highlight="${u.id}">Highlight</wa-switch>
+              <div class="wa-cluster wa-gap-xs wa-align-items-center">
+                <wa-icon name="cart-shopping" style="color: var(--wa-color-neutral-text-subtle);"></wa-icon>
+                <wa-input size="small" placeholder="Store URL (highlighted only)" data-store-url="${u.id}" style="width: 17.5rem;"></wa-input>
+              </div>
+            </div>
+            <span class="wa-caption-s" style="color: var(--wa-color-neutral-text-subtle);">Highlight &rarr; surfaces in Featured + enables sleeves link</span>
+          </div>
+          <div class="gallery-reject-row" data-reject-row="${u.id}">
+            <wa-input size="small" placeholder="Reason (shown to the uploader)" data-reject-reason="${u.id}"></wa-input>
+            <wa-button size="small" variant="danger" data-reject-confirm="${u.id}">Confirm reject</wa-button>
+          </div>
+        </div>`).join('')}
+      </div>`}
+    <p class="wa-caption-s" style="color: var(--wa-color-neutral-text-subtle); margin-top: var(--wa-space-m);"><wa-icon name="circle-info"></wa-icon> Internal view. Rejection reasons are shown to the uploader. Room is left for a future trusted-uploader tier that skips the queue.</p>`;
+
+  root.querySelectorAll('[data-approve]').forEach(btn => btn.addEventListener('click', async () => {
+    const id = btn.dataset.approve;
+    const storeUrl = root.querySelector(`[data-store-url="${id}"]`)?.value?.trim() || null;
+    const { error: err } = await sb.from('gallery_artworks').update({
+      status: 'approved',
+      highlighted: !!root.querySelector(`[data-highlight="${id}"]`)?.checked,
+      store_url: storeUrl,
+      reviewed_at: new Date().toISOString(),
+      reviewed_by: user.id,
+    }).eq('id', id);
+    if (err) { showError('Could not approve — try again.'); return; }
+    showSuccess('Approved');
+    await loadPublicData(); // approved art is public now
+    render();
+  }));
+  root.querySelectorAll('[data-reject]').forEach(btn => btn.addEventListener('click', () => {
+    root.querySelector(`[data-reject-row="${btn.dataset.reject}"]`)?.classList.toggle('open');
+  }));
+  root.querySelectorAll('[data-reject-confirm]').forEach(btn => btn.addEventListener('click', async () => {
+    const id = btn.dataset.rejectConfirm;
+    const reason = root.querySelector(`[data-reject-reason="${id}"]`)?.value?.trim();
+    if (!reason) { showError('Give the uploader a reason.'); return; }
+    const { error: err } = await sb.from('gallery_artworks').update({
+      status: 'rejected',
+      reject_reason: reason,
+      reviewed_at: new Date().toISOString(),
+      reviewed_by: user.id,
+    }).eq('id', id);
+    if (err) { showError('Could not reject — try again.'); return; }
+    showToast('Rejected', 'danger', 'circle-xmark');
+    render();
+  }));
+}
+
+// ============================================================
+// Router
+// ============================================================
+
+function renderNotFound(root, title, sub) {
+  root.innerHTML = `
+    ${breadcrumbHtml([{ label: 'Gallery', href: 'gallery.html' }, { label: title }])}
+    <div class="gallery-empty">
+      <div class="ic"><wa-icon name="image"></wa-icon></div>
+      <h2 class="wa-heading-m">${escapeHtml(title)}</h2>
+      <p class="wa-caption-m" style="color: var(--wa-color-neutral-text-subtle);">${escapeHtml(sub)}</p>
+      <wa-button appearance="outlined" href="gallery.html">Back to gallery</wa-button>
+    </div>`;
+}
+
+function render() {
+  const root = document.getElementById('gallery-root');
+  if (!root || !publicLoaded) return; // initial skeleton stays until public data arrives
+  const params = new URLSearchParams(window.location.search);
+  const art = params.get('art');
+  const artist = params.get('artist');
+  const view = params.get('view');
+
+  if (art) renderDetail(root, art);
+  else if (artist) renderArtist(root, artist);
+  else if (view === 'upload') renderUpload(root);
+  else if (view === 'uploads') renderMyUploads(root);
+  else if (view === 'admin') renderAdmin(root);
+  else renderGrid(root);
+}
+
+// ============================================================
+// Init
+// ============================================================
+
+initLayout({ activePage: 'gallery' });
+
+loadPublicData().then(async () => {
+  await loadMyLikes(); // no-op unless auth already restored
+  render();
+});
+
+// Re-render when auth state changes (session restore, logout) so gated views
+// and the guest callout stay in sync. Fresh SIGNED_IN reloads the page (auth.js).
+let lastUserId = null;
+onAuthChange(async user => {
+  const id = user?.id || null;
+  if (id !== lastUserId) {
+    lastUserId = id;
+    await loadMyLikes();
+    render();
+  }
+});

--- a/js/layout.js
+++ b/js/layout.js
@@ -33,6 +33,7 @@ const NAV_LINKS = [
   { href: 'index.html', label: 'Home', page: 'home' },
   { href: 'guide.html', label: 'Guide', page: 'guide' },
   { href: 'tools.html', label: 'Tools', page: 'tools' },
+  { href: 'gallery.html', label: 'Gallery', page: 'gallery' },
   { href: 'build.html', label: 'My PRISM', page: 'build' },
 ];
 

--- a/js/modules/supabase-client.js
+++ b/js/modules/supabase-client.js
@@ -1,8 +1,10 @@
 // Supabase client configuration
 // Replace these with your actual Supabase project credentials
 
-const SUPABASE_URL = 'https://clqxysoimlsjfmnjbxsa.supabase.co';
-const SUPABASE_ANON_KEY = 'sb_publishable_EmMs1syywKSfhJuPsO0LvA_GsCzVYFD';
+// Exported for anonymous PostgREST reads (gallery public data) — plain fetch
+// with the anon key keeps the SDK lazy for logged-out visitors.
+export const SUPABASE_URL = 'https://clqxysoimlsjfmnjbxsa.supabase.co';
+export const SUPABASE_ANON_KEY = 'sb_publishable_EmMs1syywKSfhJuPsO0LvA_GsCzVYFD';
 
 // Import Supabase from CDN (loaded in HTML)
 // We'll use the global supabase object

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -410,6 +410,10 @@ CREATE POLICY "Users submit artworks for review"
     AND highlighted = false
     AND store_url IS NULL
     AND artist_id IS NULL
+    AND likes_count = 0
+    AND downloads_count = 0
+    AND reviewed_at IS NULL
+    AND reviewed_by IS NULL
   );
 
 DROP POLICY IF EXISTS "Admins moderate artworks" ON gallery_artworks;
@@ -430,6 +434,10 @@ CREATE POLICY "Owners resubmit rejected artworks"
     AND highlighted = false
     AND store_url IS NULL
     AND artist_id IS NULL
+    AND likes_count = 0
+    AND downloads_count = 0
+    AND reviewed_at IS NULL
+    AND reviewed_by IS NULL
   );
 
 DROP POLICY IF EXISTS "Owners withdraw own artworks" ON gallery_artworks;

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -256,3 +256,230 @@ BEGIN;
     ON app_logs FOR INSERT
     WITH CHECK (auth.uid() = user_id);
 COMMIT;
+
+-- ============================================
+-- GALLERY — artists, artworks, likes, admins
+-- ============================================
+-- Community gallery (gallery.html). Pre-moderated uploads: everything inserts
+-- as 'pending'; only gallery admins can approve/reject, set Highlight, or a
+-- store URL. Approved art is publicly readable (incl. anonymous users).
+
+-- Admins: one row per admin user. Add an admin with
+--   INSERT INTO gallery_admins (user_id) VALUES ('<auth.users uuid>');
+CREATE TABLE IF NOT EXISTS gallery_admins (
+  user_id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- Locked down: no policies. Only the SECURITY DEFINER helper below reads it.
+ALTER TABLE gallery_admins ENABLE ROW LEVEL SECURITY;
+
+-- Helper used by RLS policies and by the client (via /rpc) to toggle admin UI.
+CREATE OR REPLACE FUNCTION is_gallery_admin()
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (SELECT 1 FROM gallery_admins WHERE user_id = auth.uid());
+$$;
+
+GRANT EXECUTE ON FUNCTION is_gallery_admin() TO authenticated;
+
+-- Artists (admin-managed; partners). Community uploads don't get a row —
+-- they carry artist_name text on the artwork instead.
+CREATE TABLE IF NOT EXISTS gallery_artists (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  bio TEXT DEFAULT '',
+  avatar_url TEXT,
+  links JSONB DEFAULT '[]'::jsonb,      -- [{label, icon, family?, href}]
+  is_partner BOOLEAN NOT NULL DEFAULT false,
+  user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS gallery_artworks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  title TEXT NOT NULL,
+  type TEXT NOT NULL CHECK (type IN ('proxy', 'token', 'showcase')),
+  original_card_name TEXT,
+  original_card_set TEXT,
+  scryfall_url TEXT,
+  description TEXT DEFAULT '',
+  is_ai BOOLEAN NOT NULL DEFAULT false,
+  artist_id UUID REFERENCES gallery_artists(id) ON DELETE SET NULL,
+  artist_name TEXT,                     -- community attribution when artist_id is null
+  uploader_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  image_path TEXT NOT NULL,             -- path within the gallery-art bucket
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'approved', 'rejected')),
+  reject_reason TEXT,
+  highlighted BOOLEAN NOT NULL DEFAULT false,
+  store_url TEXT,
+  likes_count INTEGER NOT NULL DEFAULT 0,
+  downloads_count INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  reviewed_at TIMESTAMPTZ,
+  reviewed_by UUID REFERENCES auth.users(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_gallery_artworks_status_likes ON gallery_artworks(status, likes_count DESC);
+CREATE INDEX IF NOT EXISTS idx_gallery_artworks_uploader ON gallery_artworks(uploader_id);
+CREATE INDEX IF NOT EXISTS idx_gallery_artworks_artist ON gallery_artworks(artist_id);
+
+CREATE TABLE IF NOT EXISTS gallery_likes (
+  artwork_id UUID REFERENCES gallery_artworks(id) ON DELETE CASCADE,
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  PRIMARY KEY (artwork_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_gallery_likes_user ON gallery_likes(user_id);
+
+-- Denormalized likes_count so "Most liked" sorting never aggregates.
+-- SECURITY DEFINER because the liking user has no UPDATE right on artworks.
+CREATE OR REPLACE FUNCTION gallery_likes_counter()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    UPDATE gallery_artworks SET likes_count = likes_count + 1 WHERE id = NEW.artwork_id;
+    RETURN NEW;
+  ELSIF TG_OP = 'DELETE' THEN
+    UPDATE gallery_artworks SET likes_count = GREATEST(likes_count - 1, 0) WHERE id = OLD.artwork_id;
+    RETURN OLD;
+  END IF;
+  RETURN NULL;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_gallery_likes_counter ON gallery_likes;
+CREATE TRIGGER trg_gallery_likes_counter
+  AFTER INSERT OR DELETE ON gallery_likes
+  FOR EACH ROW EXECUTE FUNCTION gallery_likes_counter();
+
+-- Download counter, login-gated (authenticated only).
+CREATE OR REPLACE FUNCTION increment_gallery_download(p_artwork_id UUID)
+RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  UPDATE gallery_artworks
+  SET downloads_count = downloads_count + 1
+  WHERE id = p_artwork_id AND status = 'approved';
+$$;
+
+GRANT EXECUTE ON FUNCTION increment_gallery_download(UUID) TO authenticated;
+
+-- ---- RLS ----
+ALTER TABLE gallery_artists ENABLE ROW LEVEL SECURITY;
+ALTER TABLE gallery_artworks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE gallery_likes ENABLE ROW LEVEL SECURITY;
+
+-- Artists: public read, admin write.
+DROP POLICY IF EXISTS "Anyone can view gallery artists" ON gallery_artists;
+CREATE POLICY "Anyone can view gallery artists"
+  ON gallery_artists FOR SELECT
+  USING (true);
+
+DROP POLICY IF EXISTS "Admins manage gallery artists" ON gallery_artists;
+CREATE POLICY "Admins manage gallery artists"
+  ON gallery_artists FOR ALL
+  USING (is_gallery_admin())
+  WITH CHECK (is_gallery_admin());
+
+-- Artworks: approved is public; owners see their own any-status; admins see all.
+DROP POLICY IF EXISTS "Approved artworks are public" ON gallery_artworks;
+CREATE POLICY "Approved artworks are public"
+  ON gallery_artworks FOR SELECT
+  USING (status = 'approved' OR uploader_id = auth.uid() OR is_gallery_admin());
+
+-- Uploads always enter the queue: pending, unhighlighted, no store URL, and
+-- no claiming a partner artist row (admins attach artist_id on approval).
+DROP POLICY IF EXISTS "Users submit artworks for review" ON gallery_artworks;
+CREATE POLICY "Users submit artworks for review"
+  ON gallery_artworks FOR INSERT
+  WITH CHECK (
+    uploader_id = auth.uid()
+    AND status = 'pending'
+    AND highlighted = false
+    AND store_url IS NULL
+    AND artist_id IS NULL
+  );
+
+DROP POLICY IF EXISTS "Admins moderate artworks" ON gallery_artworks;
+CREATE POLICY "Admins moderate artworks"
+  ON gallery_artworks FOR UPDATE
+  USING (is_gallery_admin())
+  WITH CHECK (is_gallery_admin());
+
+-- Owners may resubmit a rejected upload — it must go back to pending and
+-- can't pick up privileges on the way.
+DROP POLICY IF EXISTS "Owners resubmit rejected artworks" ON gallery_artworks;
+CREATE POLICY "Owners resubmit rejected artworks"
+  ON gallery_artworks FOR UPDATE
+  USING (uploader_id = auth.uid() AND status = 'rejected')
+  WITH CHECK (
+    uploader_id = auth.uid()
+    AND status = 'pending'
+    AND highlighted = false
+    AND store_url IS NULL
+    AND artist_id IS NULL
+  );
+
+DROP POLICY IF EXISTS "Owners withdraw own artworks" ON gallery_artworks;
+CREATE POLICY "Owners withdraw own artworks"
+  ON gallery_artworks FOR DELETE
+  USING ((uploader_id = auth.uid() AND status IN ('pending', 'rejected')) OR is_gallery_admin());
+
+-- Likes: users manage their own; counts are read from likes_count.
+DROP POLICY IF EXISTS "Users view own likes" ON gallery_likes;
+CREATE POLICY "Users view own likes"
+  ON gallery_likes FOR SELECT
+  USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "Users like approved artworks" ON gallery_likes;
+CREATE POLICY "Users like approved artworks"
+  ON gallery_likes FOR INSERT
+  WITH CHECK (
+    user_id = auth.uid()
+    AND artwork_id IN (SELECT id FROM gallery_artworks WHERE status = 'approved')
+  );
+
+DROP POLICY IF EXISTS "Users unlike artworks" ON gallery_likes;
+CREATE POLICY "Users unlike artworks"
+  ON gallery_likes FOR DELETE
+  USING (user_id = auth.uid());
+
+-- ---- Storage: public bucket, uuid paths ----
+-- Public-read display bucket. Discovery is controlled by table RLS (pending
+-- art is never listed and paths are unguessable uuids); there is deliberately
+-- NO SELECT policy on storage.objects so the bucket can't be listed via API.
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES ('gallery-art', 'gallery-art', true, 10485760, ARRAY['image/png', 'image/jpeg', 'image/webp'])
+ON CONFLICT (id) DO UPDATE
+  SET public = true,
+      file_size_limit = 10485760,
+      allowed_mime_types = ARRAY['image/png', 'image/jpeg', 'image/webp'];
+
+-- Uploads go to gallery-art/<auth.uid()>/<uuid>.<ext>
+DROP POLICY IF EXISTS "Users upload gallery art to own folder" ON storage.objects;
+CREATE POLICY "Users upload gallery art to own folder"
+  ON storage.objects FOR INSERT TO authenticated
+  WITH CHECK (
+    bucket_id = 'gallery-art'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+DROP POLICY IF EXISTS "Users or admins delete gallery art" ON storage.objects;
+CREATE POLICY "Users or admins delete gallery art"
+  ON storage.objects FOR DELETE TO authenticated
+  USING (
+    bucket_id = 'gallery-art'
+    AND ((storage.foldername(name))[1] = auth.uid()::text OR is_gallery_admin())
+  );


### PR DESCRIPTION
## Summary

- add a public gallery for proxies, tokens, and showcase artwork
- add artwork details, artist pages, filtering, likes, uploads, and moderation views
- add Supabase tables, RLS policies, storage rules, counters, and admin helpers
- add the Gallery navigation entry and document the architecture

## Why

PRISM needs a curated place for partnered and community artwork while keeping anonymous browsing lightweight and authenticated uploads moderated.

## Impact

Visitors can browse approved artwork without loading the Supabase SDK. Signed-in users can like, upload, track submissions, and download artwork; gallery admins can approve or reject submissions.

Deploy the gallery section of `supabase-schema.sql` before enabling live gallery data. Until then, the page uses the read-only demo fallback.

## Validation

- `npm test` — 12/12 passing
- `npm run lint`
- `node --check js/gallery.js`
- `node --check js/layout.js`
- `node --check js/modules/supabase-client.js`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a community artwork **Gallery** page with deep-linkable views (artwork, artist, and grid), including search, filtering, and sorting.
  * Added artwork likes, download tracking (sign-in gated), and user upload workflows with pending confirmation.
  * Added an admin moderation queue to approve/reject submissions, with optional highlight/store updates.
  * Included responsive gallery layouts, upload drag-and-drop with validation, and empty-state/demo fallback behavior.
  * Added a Gallery entry to the site navigation.

* **Documentation**
  * Updated Gallery documentation covering access control, storage conventions, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->