### PR TITLE
Keep slot numbers fixed when the stripe starting corner changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ Preferences: { colorScheme, defaultColors, stripeStartCorner ('top-right'|'top-l
   - Card in **subset**, stripes-style → child Side B stripe per matching variant
   - Card in **subset**, dots-style, exactly 1 variant → dot in that variant's color
   - Card in **subset**, dots-style, 2+ variants → dot conflict; membership anchors only, parent stripe only
-- **Stripe starting corner** — global preference controlling which card corner stripes originate from. Applying it runs `remapPrismForCorner` (processor.js), which rewrites every stored `stripePosition`/`sideAPosition` so physical mark locations are preserved under the new numbering — slot numbers change and are saved/synced; the marks on sleeves don't move.
+- **Stripe starting corner** — global preference controlling which card corner stripes originate from. Pure presentation: slot numbers never change on corner change; the rendering layer (`cornerToConfig` in card-preview.js and friends) maps slot → physical location using the preference, so Slot 1 always renders at the chosen corner. No prism data is mutated or synced. If any prism has `markedCards`, Apply shows a native `confirm()` warning that physical sleeve marks won't move.
 - **markedCards** tracks which cards the user has physically marked (checkbox state)
 - **removedCards** tracks cards removed from decks that still need physical marks cleared
 - **syncState** is local-only metadata used for Supabase merge reconciliation; it is not part of the PRISM domain model. Baseline shape per prism: `{ updatedAt, deckUpdatedAts, splitGroupUpdatedAts, deletedDecks, deletedSplitGroups, unmarkedCards: { [cardKey]: isoTimestamp } }`

--- a/js/layout.js
+++ b/js/layout.js
@@ -17,8 +17,7 @@ import {
   updatePreferences,
   getStripeNumbersMode,
   STRIPE_NUMBERS_MODES,
-  getCurrentPrism,
-  savePrism,
+  getAllPrisms,
 } from './modules/storage.js';
 import { applyColorScheme } from './modules/theme.js';
 import { initGlobalErrorReporting } from './core/telemetry.js';
@@ -515,7 +514,7 @@ function injectSettingsDrawer() {
             <wa-radio value="bottom-left">Bottom Left</wa-radio>
           </wa-radio-group>
           <wa-button id="stripe-start-corner-apply" appearance="filled" variant="brand" size="small" disabled>Apply</wa-button>
-          <p class="wa-caption-s" style="color: var(--wa-color-neutral-text-subtle); margin: 0;">Applying remaps every deck's slot number so Slot 1 sits at the chosen corner.</p>
+          <p class="wa-caption-s" style="color: var(--wa-color-neutral-text-subtle); margin: 0;">Slot numbers stay the same — stripes move so Slot 1 starts at the chosen corner.</p>
           <wa-slider
             id="stripe-position-numbers-mode"
             label="Position Numbers"
@@ -558,15 +557,19 @@ function injectSettingsDrawer() {
     if (cornerGroup.value !== applied) applyBtn?.removeAttribute('disabled');
     else applyBtn?.setAttribute('disabled', '');
   });
-  applyBtn?.addEventListener('click', async () => {
+  applyBtn?.addEventListener('click', () => {
     const newCorner = cornerGroup?.value;
     if (!newCorner) return;
     const currentCorner = getPreferences().stripeStartCorner || 'top-right';
     if (newCorner !== currentCorner) {
-      const prism = getCurrentPrism();
-      if (prism) {
-        const { remapPrismForCorner } = await import('./modules/processor.js');
-        savePrism(remapPrismForCorner(prism, currentCorner, newCorner));
+      const hasMarks = getAllPrisms().some((p) => (p.markedCards || []).length > 0);
+      // ponytail: native confirm(); upgrade to wa-dialog if UX polish needed
+      if (hasMarks && !window.confirm(
+        "You've already marked cards. Marks you've made on sleeves won't move — stripe positions will now start from the new corner. Continue?"
+      )) {
+        cornerGroup.value = currentCorner;
+        applyBtn.setAttribute('disabled', '');
+        return;
       }
       updatePreferences({ stripeStartCorner: newCorner });
       window.dispatchEvent(new CustomEvent('prism-settings-changed', { detail: { setting: 'stripeStartCorner' } }));

--- a/js/modules/processor.js
+++ b/js/modules/processor.js
@@ -649,55 +649,6 @@ export function getNextVariantPosition(prism) {
 }
 
 /**
- * Remap a slot (1-48) when the starting corner changes.
- * Physical card position of each mark is preserved; the slot *number* shifts
- * so slot 1 always sits at the newly-chosen corner.
- *
- * Model: corner = { R: right-edge primary, T: top-first numbering }.
- * A slot's physical location is (edgeRight, yFromTop): slots 1-24 live on the
- * primary edge from `from`, slots 25-48 on the opposite edge. Index-within-side
- * counts from top under `fromT`, from bottom under `!fromT`.
- */
-export function remapSlot(slot, fromCorner, toCorner) {
-	const fromR = fromCorner.includes('right');
-	const fromT = fromCorner.includes('top');
-	const toR = toCorner.includes('right');
-	const toT = toCorner.includes('top');
-
-	const sideA = slot <= 24;
-	const index = sideA ? slot - 1 : slot - 25; // 0-23 along the edge
-	const physEdgeRight = sideA ? fromR : !fromR;
-	const physY = fromT ? index : 23 - index;
-
-	const newSideA = physEdgeRight === toR;
-	const newIndex = toT ? physY : 23 - physY;
-	return newSideA ? newIndex + 1 : newIndex + 25;
-}
-
-/**
- * Rewrite every stripePosition / sideAPosition in a PRISM so slot 1 sits
- * at the newly-chosen corner while each deck stays at the same physical
- * location on the sleeve.
- */
-export function remapPrismForCorner(prism, fromCorner, toCorner) {
-	if (fromCorner === toCorner) return prism;
-	const now = new Date().toISOString();
-	return {
-		...prism,
-		decks: prism.decks.map((d) => {
-			if (typeof d.stripePosition !== 'number') return d;
-			return { ...d, stripePosition: remapSlot(d.stripePosition, fromCorner, toCorner), updatedAt: now };
-		}),
-		splitGroups: (prism.splitGroups || []).map((g) => ({
-			...g,
-			sideAPosition: remapSlot(g.sideAPosition, fromCorner, toCorner),
-			updatedAt: now,
-		})),
-		updatedAt: now,
-	};
-}
-
-/**
  * Get the next available color from the default palette
  * @param {Object} prism - The PRISM object
  * @returns {string} The next available hex color


### PR DESCRIPTION
## What changed

Changing **Settings → Stripes → Starting Corner** no longer renumbers decks. Slot numbers stay exactly where they are; the stripes move to the newly chosen corner instead.

- `js/layout.js` — the Apply handler no longer imports and calls `remapPrismForCorner`. It only writes the preference and dispatches `prism-settings-changed`. Added a guard: if any PRISM has `markedCards`, Apply shows a `confirm()` first; cancelling resets the radio and re-disables Apply.
- `js/modules/processor.js` — deleted `remapSlot` and `remapPrismForCorner` (49 lines, now dead — `layout.js` was the only caller and there were no tests).
- Drawer caption updated to match the new behaviour.
- `CLAUDE.md` — "Stripe starting corner" bullet rewritten.

## Why

Users import their decks, then discover the corner setting, then start marking. The old behaviour preserved the *physical* location of each mark and shifted the *numbers* — correct for someone who has already marked sleeves, but backwards for the far more common pre-marking case. Deck 1 should sit at Slot 1 wherever Slot 1 is.

No rendering changes were needed. `cornerToConfig` / `getStripeEdge` / `getStripeY` in `card-preview.js` (mirrored in `stripe-reorder-dialog.js` and `mpc-stripes.js`) already derive physical placement from the preference alone, and `formatSlotLabel` is pure arithmetic on the slot number. The fix is deletion.

## Reviewer notes

Two side bugs disappear with the remap:

1. It only remapped `getCurrentPrism()`, but `stripeStartCorner` is a global preference — every *other* PRISM silently kept its old numbers and rendered at flipped physical locations after a corner change.
2. It never remapped `removedCards[].removedStripePosition`, leaving those stale.

Applying a corner change is now a pure preference write: no PRISM mutation, no `updatedAt` bump, nothing to sync.

The confirm is a native `window.confirm()` marked with a `ponytail:` comment — worth upgrading to a `wa-dialog` if it looks out of place next to the rest of the UI.

## Verification

Seeded a PRISM with two standalone decks (Slots 1, 2) and a dots-style split group (Slot 3), then applied `top-right → bottom-left` through the real drawer UI:

| | before (top-right) | after (bottom-left) |
|---|---|---|
| Deck slot labels | Slot 1, 2, 3 | Slot 1, 2, 3 — unchanged |
| Sol Ring stripes | `stripe-mark`, top 28/40/52px | `stripe-mark-left`, top 304/292/280px |
| Dot mark | `right: 28px` | `stripe-dot-mark-right`, `left: 28px` |
| prism + deck `updatedAt` | `14:57:21.187Z` | `14:57:21.187Z` — untouched |
| group `sideAPosition` | 3 | 3 |

Stripes flipped edge and switched to bottom-up ordering; dots followed the parent stripe edge automatically; stored data never moved.

Confirm path, with `markedCards: ['Sol Ring']` — Apply fired the confirm both times. Cancel left the radio at its previous value with the preference unchanged; OK applied the new corner with slot numbers and marks intact.

`npm test` 12/12 pass, `eslint` clean, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated the global “Starting Corner” setting so it changes how slot numbers are displayed without modifying stored prism positions or synced data.
  * Added a confirmation warning when applying a new corner while sleeve marks exist, clarifying that physical marks will not move.
  * Canceling the warning preserves the previous corner selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->