### PR TITLE
multiple copies of cards and basics rework

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,8 @@ Sync behavior is merge-first, not whole-PRISM last-write-wins:
 
 - On login/session restore, local and cloud PRISMs are merged per prism, per deck, and per split group.
 - `markedCards` merge by union minus any keys with an `unmarkedCards` tombstone newer than the last sync baseline — this ensures intentional un-marks (manual checkbox or auto-unmark when a new deck shares a card) are not reverted by the cloud copy.
-- `removedCards` merge by `(cardName, deckId)` with latest `removedAt`.
+- `removedCards` merge by `(cardName, deckId)` with latest `removedAt`; `previousQuantity` keeps the max of both rows so successive quantity edits never under-report the surplus.
+- `useDedicatedCommanderCopies` merges on its own `useDedicatedCommanderCopiesUpdatedAt` (newer wins, ties local) — explicitly, in `mergePrismVersions`, like `markedCardsUpdatedAt`. The Supabase columns are `use_dedicated_commander_copies` (NOT NULL DEFAULT false) + `use_dedicated_commander_copies_updated_at`; rollout was schema-first.
 - Background saves fetch the latest cloud copy, merge it with local using the stored baseline, then write the merged result back to Supabase.
 - Deck and split-group `updatedAt` timestamps are important for conflict resolution and should be preserved on mutation.
 - Split-group child ordering should be preserved from `group.childDeckIds` during merge; only orphaned child IDs should be dropped, with deck-derived order used as a fallback when the stored ordering is missing.
@@ -112,12 +113,16 @@ Sync behavior is merge-first, not whole-PRISM last-write-wins:
 ### PRISM Data Model
 
 ```
-Prism: { id, name, decks[], splitGroups[], markedCards[], removedCards[], createdAt, updatedAt }
-Deck:  { id, name, commander, bracket (1-5), color (hex), stripePosition (1-48), cards[], splitGroupId? }
+Prism: { id, name, decks[], splitGroups[], markedCards[], removedCards[],
+         useDedicatedCommanderCopies, useDedicatedCommanderCopiesUpdatedAt, createdAt, updatedAt }
+Deck:  { id, name, bracket (1-5), color (hex), stripePosition (1-48), cards[], splitGroupId? }
 SplitGroup: { id, name, sideAPosition, sideAColor, childDeckIds[], splitStyle ('stripes'|'dots'), createdAt?, updatedAt? }
 Card:  { name, quantity, isCommander, isBasicLand }
 Preferences: { colorScheme, defaultColors, stripeStartCorner ('top-right'|'top-left'|'bottom-right'|'bottom-left') }
 ```
+
+- **Commander role** — per-card `isCommander` flags are the only source of truth (#147). There is no `deck.commander` field; read via `commanderNames(deck)` in `processor.js` (alphabetical, derived). The decklist textarea carries N flags losslessly through `Commander`/`Deck` section headers (`cardsToDecklistText`/`rewriteDecklistCommanders` in `parser.js`); the parsed text is the sole save-time authority, with the Add/Edit commander fields kept in sync both ways (`syncCommanderFieldsFromText`/`applyCommanderFieldsToText` in `deck-form.js`). `parseDecklist(text)` takes no commander-name argument. Archidekt import flags only the exact `Commander` category. Legacy scalar-only decks are normalized once at build-page load (`applyCommanderFallback`).
+- **useDedicatedCommanderCopies** (#145/#150) — synced per-PRISM boolean with its own merge timestamp (never rides whole-prism LWW; mark-toggle bumps `prism.updatedAt` too often). Toggle lives on the Decks tab; write path = set flag + its timestamp + `prism.updatedAt` + `savePrism()`. When on, each (commander card, logical deck) pair emits a **dedicated batch** at the deck's full quantity and leaves the shared threshold derivation (replace, not add on top). A split group dedicates as one batch when flagged in ≥1 variant, never per variant. Dedicated-ness is derived at processing time (`isDedicated` on the batch), never stored.
 
 - **Stripe positions** 1–24 (Side A) and 25–48 (Side B) — 48 physical slots, the real capacity limit (`MAX_STRIPE_SLOTS` in `processor.js`). Stripe-only decks/variants each consume one slot (up to 48 decks); dot variants share a Side A slot (up to 96 decks). There is no fixed "logical deck" cap — adding a standalone deck is gated on slot availability (`getUsedPositions(prism).size >= MAX_STRIPE_SLOTS`).
 - **Split groups** let one deck slot have 2–8 (stripes) or exactly 2 (dots) variants sharing a Side A position. The group itself holds `name`, `sideAColor`, and `sideAPosition` — editable via the ✎ button on the group card header (`handleEditGroupClick`/`handleEditGroupConfirm` in `deck-list.js`, `updateSplitGroupInPrism` in `processor.js`).
@@ -127,18 +132,22 @@ Preferences: { colorScheme, defaultColors, stripeStartCorner ('top-right'|'top-l
   - Card in **subset**, dots-style, exactly 1 variant → dot in that variant's color
   - Card in **subset**, dots-style, 2+ variants → dot conflict; membership anchors only, parent stripe only
 - **Stripe starting corner** — global preference controlling which card corner stripes originate from. Pure presentation: slot numbers never change on corner change; the rendering layer (`cornerToConfig` in card-preview.js and friends) maps slot → physical location using the preference, so Slot 1 always renders at the chosen corner. No prism data is mutated or synced. If any prism has `markedCards`, Apply shows a native `confirm()` warning that physical sleeve marks won't move.
-- **markedCards** tracks which cards the user has physically marked (checkbox state)
-- **removedCards** tracks cards removed from decks that still need physical marks cleared
+- **markedCards** tracks which copies the user has physically marked. Three key shapes (#151): plain `<name>` for single-batch cards, `<name>|#b|<sorted deck ids>|<copy count>` per batch of a multi-batch card, and `<name>|<deck name>` for one-mark-at-a-time pass rows. `isCardDone` in `core/utils.js` is the single done gate (plain key for single-batch only; every batch key for multi-batch — legacy plain marks on multi-batch cards deliberately present as undone; every pass key via `passKeysForCard`). Participant/size changes re-key batches so Done retires with no invalidation code; dead keys are never pruned so reverted edits resurrect their marks.
+- **removedCards** tracks cards removed from decks that still need physical marks cleared. Rows carry `previousQuantity`/`newQuantity` — a quantity decrease is a removal of copies (full removal = `newQuantity` 0). Writers upsert by `(cardName, deckId)` via `trackRemovedCard` in `deck-list.js`; `autoClearRemovedCards` only clears once quantity is fully restored; `mergeRemovedCards` keeps `max(previousQuantity)` with the latest row.
 - **syncState** is local-only metadata used for Supabase merge reconciliation; it is not part of the PRISM domain model. Baseline shape per prism: `{ updatedAt, deckUpdatedAts, splitGroupUpdatedAts, deletedDecks, deletedSplitGroups, unmarkedCards: { [cardKey]: isoTimestamp } }`
 
 ### Card Processing
 
-`processCards(prism)` deduplicates cards across all decks and assigns stripe indicators. Basic lands use **max quantity** across decks (not sum). Card names are canonicalized via Scryfall API before storage. Child variant marks for split groups are emitted in a **post-loop pass** — the main loop only emits the group's Side A stripe. The post-loop determines shared vs subset membership for the full group before emitting any child marks (see split styles above). `markType` values: `'stripe'` (rendered Side B stripe), `'dot'` (rendered dot), `'membership'` (not rendered; carries `deckId` for deck-filter matching). `dotIndex` is not stored — renderers compute local dot order from the stripes array at render time. Results table and printable guide both use ö-style rendering (dot row above the stripe square).
+`processCards(prism)` deduplicates cards across all decks and assigns stripe indicators. Card names are canonicalized via Scryfall API before storage. Child variant marks for split groups are emitted in a **post-loop pass** — the main loop only emits the group's Side A stripe. The post-loop determines shared vs subset membership for the full group before emitting any child marks (see split styles above). `markType` values: `'stripe'` (rendered Side B stripe), `'dot'` (rendered dot), `'membership'` (not rendered; carries `deckId` for deck-filter matching). `dotIndex` is not stored — renderers compute local dot order from the stripes array at render time. Results table and printable guide both use ö-style rendering (dot row above the stripe square).
+
+**Marking batches (#146)** — every ProcessedCard carries `batches`: quantity-tier thresholds over the distinct per-deck quantities, each batch `{ copyCount: ti−t(i−1), participantIds (sorted), key, logicalDeckCount, isPool, isDedicated?, stripes }`. Batch marks are **re-derived from the exact participant set** (`marksForParticipants`), never filtered from the card's stripes — `processCards` decides shared-vs-subset over the whole group, so an A5/B2 group emits no child indicator while the 5-tier batch needs one. `totalQuantity` = Σ batch copyCounts (dedicated batches + max across remaining participants; plain max when dedication is off). Results renders multi-batch cards as expandable sub-rows with a derived, non-clickable parent roll-up checkbox; the parent never shows the mark union (over-marking trap). SCRY consumes the flattened `state.resultsView` snapshot — one screen per batch, stating its copy count. "One Mark at a Time" (internal filter value still `basics-by-deck`) is the per-mark projection of batches over every repeated card.
 
 ### Display Counts
 
-- **Decks tab** — Each deck card shows **pool** (cards in 2+ *logical* decks) and **core** (cards unique to one logical deck) counts. Both include full basic land quantities per deck. Computed via `getDeckPoolCoreCounts()` in `deck-list.js`.
-- **Results tab** — Stats cards show **Total Cards** (sum of `totalQuantity` across all processed cards, including basic-land and any-number card copies — `totalQuantity` is the max quantity across decks for every card) and **Pool Cards** (same sum but only cards in 2+ logical decks). These numbers help users plan sleeve purchases and storage.
+Pool/core classification belongs to **batches**, not card names (#146): a pool batch participates in 2+ logical decks, a core batch in exactly one; dedicated batches are core by construction.
+
+- **Decks tab** — Each deck card shows **pool**/**core** counts: Σ copyCount of the pool/core batches the deck participates in (`getDeckPoolCoreCounts()` in `deck-list.js`). Per-deck pool + core equals the deck's trusted decklist quantity per card; per-deck counts are intentionally not additive across decks.
+- **Results tab** — Stats cards show **Total Cards** (Σ `totalQuantity`) and **Pool Cards** (Σ of pool-batch quantities). The Marked progress counts copies: full `totalQuantity` for done cards plus copyCounts of done batches on partially-done cards. Turning dedication on drains commanders out of the pool (Total rises, Pool drops) — correct, not a bug.
 
 ### Logical vs Physical Deck Count
 
@@ -241,7 +250,7 @@ Preview viewport should be 1280px+ wide to see the desktop layout (sidebar nav).
 - 22 paint pen colors in `DEFAULT_COLORS` (processor.js) — matched to real products
 - Bracket values 1–5 represent Commander power level
 - `formatSlotLabel(position, side?)` renders "Side A - Slot 1" style labels
-- Stripe Settings in the Decks tab is a `<wa-details>` accordion (collapsed by default)
+- Stripe display settings (starting corner, position numbers) live in the global settings drawer injected by `layout.js`; the per-PRISM "Dedicated commander copies" `wa-switch` lives on the Decks tab (per-PRISM synced data does not belong in the global drawer)
 - The Stripe Positions reorder card was removed from the Decks tab — use the Move button (⊕) on each deck card to open the visual slot-picker dialog, or use the Export tab's dropdown list for bulk reordering
 - `build.html` has a sync status indicator (`#sync-status`) and a Sync Now button (`#btn-sync-now`) near the PRISM name; both are hidden until the user is logged in. `setupSyncStatus()` in `init.js` wires these to `onSyncStatusChange` / `forceSyncCurrentPrism` from `storage.js`. Storage exports: `onSyncStatusChange(cb)` (returns unsubscribe fn), `forceSyncCurrentPrism()`, `recordUnmarkedCards(prismId, keys)`
 

--- a/build.html
+++ b/build.html
@@ -101,6 +101,14 @@
                 </div>
               </wa-card>
 
+              <!-- Per-PRISM marking settings -->
+              <div class="wa-stack wa-gap-2xs">
+                <wa-switch id="dedicated-commander-copies" size="small">Dedicated commander copies</wa-switch>
+                <p class="wa-caption-s" style="color: var(--wa-color-neutral-text-subtle); margin: 0;">
+                  Sleeve a dedicated copy of each commander instead of sharing it with other decks. Synced with this PRISM.
+                </p>
+              </div>
+
               <!-- Existing Decks List -->
               <section id="decks-list" class="wa-stack wa-gap-m">
                 <!-- Loading skeletons — replaced by the first renderDecksList() -->

--- a/build.html
+++ b/build.html
@@ -345,7 +345,7 @@
                 <wa-radio-group id="results-filter" orientation="horizontal" value="all" size="small">
                   <wa-radio appearance="button" value="all" size="small">All Cards</wa-radio>
                   <wa-radio appearance="button" value="shared" size="small">POOL</wa-radio>
-                  <wa-radio appearance="button" value="basics-by-deck" size="small">Basics by Deck</wa-radio>
+                  <wa-radio appearance="button" value="basics-by-deck" size="small">One Mark at a Time</wa-radio>
                   <wa-radio appearance="button" value="removed" id="removed-filter-btn" size="small">Removed</wa-radio>
                 </wa-radio-group>
                 <!-- Search -->

--- a/build.html
+++ b/build.html
@@ -138,7 +138,16 @@
                       placeholder="e.g., Alania, Divergent Storm"
                       required
                     ></wa-input>
+
+                    <wa-input
+                      id="deck-commander-2"
+                      label="Second Commander"
+                      placeholder="e.g., Partner commander"
+                      hidden
+                    ></wa-input>
                   </div>
+
+                  <wa-switch id="deck-two-commanders" size="small">Two commanders</wa-switch>
 
                   <wa-radio-group
                     id="deck-bracket"
@@ -475,7 +484,15 @@
             label="Commander"
             required
           ></wa-input>
+
+          <wa-input
+            id="edit-deck-commander-2"
+            label="Second Commander"
+            hidden
+          ></wa-input>
         </div>
+
+        <wa-switch id="edit-deck-two-commanders" size="small">Two commanders</wa-switch>
 
         <wa-radio-group
           id="edit-deck-bracket"

--- a/css/custom.css
+++ b/css/custom.css
@@ -136,6 +136,35 @@ wa-page[view='desktop'] [data-toggle-nav] {
   font-size: var(--wa-font-size-s);
 }
 
+/* Marking-batch rows (#149): expandable multi-batch cards */
+.results-table .batch-toggle {
+  background: none;
+  border: none;
+  padding: 0 var(--wa-space-2xs) 0 0;
+  cursor: pointer;
+  color: var(--wa-color-neutral-text-subtle);
+  vertical-align: middle;
+}
+
+.results-table .batch-subrow td {
+  background: var(--wa-color-neutral-fill-quiet);
+}
+
+.results-table .batch-subrow .batch-subrow-label {
+  padding-left: var(--wa-space-xl);
+  color: var(--wa-color-neutral-text-subtle);
+  font-size: var(--wa-font-size-s);
+}
+
+/* Derived roll-up checkbox is informational, not a control */
+.results-table .batch-parent-check {
+  pointer-events: none;
+}
+
+.results-table .copies-cell {
+  text-align: center;
+}
+
 /* ============================================================================
    Stripe Indicators (in results table)
    ============================================================================ */

--- a/js/core/utils.js
+++ b/js/core/utils.js
@@ -94,24 +94,54 @@ export function stripeNumberLabel(position, { exact } = {}) {
 }
 
 /**
- * Whether a processed card is fully marked ("done").
- * Non-basics are done when their plain name key is in markedCards. Basics can
- * also be marked per logical deck from the Basics-by-Deck view (one row per
- * Side A stripe, key "Name|DeckName"), so a basic counts as done when its
- * plain key is marked OR every one of its per-deck keys is marked.
+ * Pass keys for the one-mark-at-a-time view: one `<name>|<deckName>` key per
+ * distinct visible mark across the card's batches (#151). Empty for
+ * non-repeated cards (single physical copy). Shared by the pass-view row
+ * builder and isCardDone so the two can't drift.
+ * @param {Object} card - Processed card ({ name, totalQuantity, batches })
+ * @returns {string[]}
+ */
+export function passKeysForCard(card) {
+  if (!card.batches || card.totalQuantity <= 1) return [];
+  const deckNames = new Set();
+  for (const batch of card.batches) {
+    for (const s of batch.stripes) {
+      if (s.markType === 'membership') continue;
+      deckNames.add(s.deckName);
+    }
+  }
+  return [...deckNames].map(n => `${card.name}|${n}`);
+}
+
+/**
+ * Whether a processed card is fully marked ("done"), per #151:
+ * - single-batch card: plain name key (unchanged legacy path)
+ * - multi-batch card: every batch key marked. A legacy plain-name mark is
+ *   deliberately NOT honored here — the old single checkbox never said which
+ *   copies got which pen, so those cards present as undone.
+ * - OR every pass key marked (one-mark-at-a-time view)
+ * - OR, for basics, every legacy per-deck Side A key marked (pre-batch shape,
+ *   retained so existing Forest|DeckName marks keep counting)
  * Shared by the Marked progress stat and the undone-list exports so all
  * surfaces agree on what "done" means.
- * @param {Object} card - Processed card ({ name, isBasicLand, stripes })
+ * @param {Object} card - Processed card ({ name, isBasicLand, stripes, batches })
  * @param {Set<string>} markedSet - markedCards as a Set
  * @returns {boolean}
  */
 export function isCardDone(card, markedSet) {
-  if (markedSet.has(card.name)) return true;
-  if (!card.isBasicLand) return false;
-  const sideAKeys = (card.stripes || [])
-    .filter(s => s.side === 'a')
-    .map(s => `${card.name}|${s.deckName}`);
-  return sideAKeys.length > 0 && sideAKeys.every(k => markedSet.has(k));
+  const batches = card.batches || [];
+  const multiBatch = batches.length > 1;
+  if (!multiBatch && markedSet.has(card.name)) return true;
+  if (multiBatch && batches.every(b => markedSet.has(b.key))) return true;
+  const passKeys = passKeysForCard(card);
+  if (passKeys.length > 0 && passKeys.every(k => markedSet.has(k))) return true;
+  if (card.isBasicLand) {
+    const sideAKeys = (card.stripes || [])
+      .filter(s => s.side === 'a')
+      .map(s => `${card.name}|${s.deckName}`);
+    if (sideAKeys.length > 0 && sideAKeys.every(k => markedSet.has(k))) return true;
+  }
+  return false;
 }
 
 export function escapeHtml(text) {

--- a/js/features/deck-form.js
+++ b/js/features/deck-form.js
@@ -6,9 +6,10 @@ import { state } from "../core/state.js";
 import { showError, showSuccess } from "../core/notifications.js";
 import { logToSupabase } from "../modules/supabase-client.js";
 import { escapeHtml, debugLog } from "../core/utils.js";
-import { parseDecklist, validateDecklist } from "../modules/parser.js";
+import { parseDecklist, validateDecklist, rewriteDecklistCommanders } from "../modules/parser.js";
 import {
   createDeck,
+  commanderNames,
   getNextStripePosition,
   getNextColor,
   isColorUsed,
@@ -71,6 +72,105 @@ export function updateColorSwatchSelection() {
 }
 
 // ============================================================================
+// Commander field <-> decklist text sync (#147)
+// ============================================================================
+// The parsed decklist text is the sole commander authority; the fields are a
+// text-authoring shortcut kept in sync both ways. All reconciliation happens
+// visibly in the textarea.
+
+// Web Awesome inputs may hold their value in shadow DOM before upgrade
+function getInputValue(element) {
+  if (!element) return "";
+  const shadowInput = element.shadowRoot?.querySelector("input, textarea");
+  if (shadowInput && shadowInput.value) {
+    return String(shadowInput.value).trim();
+  }
+  if (
+    element.value !== undefined &&
+    element.value !== null &&
+    element.value !== ""
+  ) {
+    return String(element.value).trim();
+  }
+  return "";
+}
+
+export function addCommanderRefs() {
+  return {
+    textarea: state.elements.deckList,
+    field1: state.elements.deckCommander,
+    field2: state.elements.deckCommander2,
+    toggle: state.elements.deckTwoCommanders,
+  };
+}
+
+export function editCommanderRefs() {
+  return {
+    textarea: state.elements.editDeckList,
+    field1: state.elements.editDeckCommander,
+    field2: state.elements.editDeckCommander2,
+    toggle: state.elements.editDeckTwoCommanders,
+  };
+}
+
+/**
+ * text → fields: repopulate the commander fields from the parsed decklist.
+ * Toggle auto-enables at ≥2 flags; >2 flags disables the fields (edit the
+ * Commander section directly). With 0 flags the typed field-1 value is kept —
+ * paste-99-then-type is the dominant flow and the save-entry rewrite will
+ * carry it into the text.
+ */
+export function syncCommanderFieldsFromText(refs) {
+  if (!refs.textarea || !refs.field1) return;
+  const names = parseDecklist(refs.textarea.value || "")
+    .cards.filter((c) => c.isCommander)
+    .map((c) => c.name);
+
+  const many = names.length > 2;
+  if (names.length > 0) refs.field1.value = names[0];
+  if (refs.field2) {
+    refs.field2.value = names[1] || "";
+    refs.field2.hidden = names.length < 2;
+  }
+  if (refs.toggle) {
+    refs.toggle.checked = names.length >= 2;
+    refs.toggle.disabled = many;
+  }
+  refs.field1.disabled = many;
+  if (refs.field2) refs.field2.disabled = many;
+  refs.field1.hint = many
+    ? `${names.length} commanders detected — edit the Commander section directly`
+    : "";
+}
+
+/**
+ * fields → text: rewrite the decklist's Commander section to exactly the
+ * field names. Runs on field change and once more at save entry (idempotent)
+ * so a value typed without blurring is not lost. No-op while the fields are
+ * disabled (>2 flags: the text is being edited directly).
+ */
+export function applyCommanderFieldsToText(refs) {
+  if (!refs.textarea || !refs.field1 || refs.field1.disabled) return;
+  const names = [getInputValue(refs.field1)];
+  if (refs.toggle?.checked) names.push(getInputValue(refs.field2));
+  const wanted = names.filter(Boolean);
+  if (wanted.length === 0) return; // nothing to author; save validation catches empty
+  refs.textarea.value = rewriteDecklistCommanders(refs.textarea.value || "", wanted);
+}
+
+/** Toggle switched: show the second field, or collapse the section to field 1. */
+export function handleTwoCommandersToggle(refs) {
+  if (!refs.toggle || !refs.field2) return;
+  if (refs.toggle.checked) {
+    refs.field2.hidden = false;
+  } else {
+    refs.field2.value = "";
+    refs.field2.hidden = true;
+    applyCommanderFieldsToText(refs);
+  }
+}
+
+// ============================================================================
 // Deck Submit
 // ============================================================================
 
@@ -100,22 +200,9 @@ export async function handleDeckSubmit(e) {
       return;
     }
 
-    // Get form values - for web components, access the native input in shadow DOM
-    const getInputValue = (element) => {
-      if (!element) return "";
-      const shadowInput = element.shadowRoot?.querySelector("input, textarea");
-      if (shadowInput && shadowInput.value) {
-        return String(shadowInput.value).trim();
-      }
-      if (
-        element.value !== undefined &&
-        element.value !== null &&
-        element.value !== ""
-      ) {
-        return String(element.value).trim();
-      }
-      return "";
-    };
+    // Fields → text once at save entry (idempotent) so a commander typed
+    // without blurring still lands in the Commander section (#147)
+    applyCommanderFieldsToText(addCommanderRefs());
 
     const name = getInputValue(state.elements.deckName);
     const commander = getInputValue(state.elements.deckCommander);
@@ -145,8 +232,8 @@ export async function handleDeckSubmit(e) {
       return;
     }
 
-    // Parse decklist
-    const parseResult = parseDecklist(decklistText, commander);
+    // Parse decklist — the text is the sole commander authority
+    const parseResult = parseDecklist(decklistText);
     const validation = validateDecklist(parseResult);
 
     debugLog("PRISM: Parse result:", {
@@ -190,7 +277,6 @@ export async function handleDeckSubmit(e) {
     // Create deck
     const deck = createDeck({
       name,
-      commander,
       bracket,
       color,
       stripePosition: getNextStripePosition(state.currentPrism),
@@ -213,7 +299,7 @@ export async function handleDeckSubmit(e) {
     savePrism(state.currentPrism);
 
     debugLog("PRISM: Deck added:", deck.name);
-    logToSupabase('info', 'deck_added', { name: deck.name, commander: deck.commander, bracket: deck.bracket, cardCount: parseResult.uniqueCards });
+    logToSupabase('info', 'deck_added', { name: deck.name, commander: commanderNames(deck).join(' / '), bracket: deck.bracket, cardCount: parseResult.uniqueCards });
 
     // Reset form and re-render
     resetDeckForm();
@@ -241,7 +327,20 @@ export async function handleDeckSubmit(e) {
 export function resetDeckForm() {
   if (state.elements.deckForm) state.elements.deckForm.reset();
   if (state.elements.deckName) state.elements.deckName.value = "";
-  if (state.elements.deckCommander) state.elements.deckCommander.value = "";
+  if (state.elements.deckCommander) {
+    state.elements.deckCommander.value = "";
+    state.elements.deckCommander.disabled = false;
+    state.elements.deckCommander.hint = "";
+  }
+  if (state.elements.deckCommander2) {
+    state.elements.deckCommander2.value = "";
+    state.elements.deckCommander2.hidden = true;
+    state.elements.deckCommander2.disabled = false;
+  }
+  if (state.elements.deckTwoCommanders) {
+    state.elements.deckTwoCommanders.checked = false;
+    state.elements.deckTwoCommanders.disabled = false;
+  }
   if (state.elements.deckBracket) state.elements.deckBracket.value = "2";
   if (state.elements.deckList) state.elements.deckList.value = "";
   resetFileInput(state.elements.deckFileInput);

--- a/js/features/deck-form.js
+++ b/js/features/deck-form.js
@@ -3,10 +3,10 @@
  */
 
 import { state } from "../core/state.js";
-import { showError, showSuccess } from "../core/notifications.js";
+import { showError, showSuccess, showToast } from "../core/notifications.js";
 import { logToSupabase } from "../modules/supabase-client.js";
 import { escapeHtml, debugLog } from "../core/utils.js";
-import { parseDecklist, validateDecklist, rewriteDecklistCommanders } from "../modules/parser.js";
+import { parseDecklist, validateDecklist, rewriteDecklistCommanders, normalizeCardName } from "../modules/parser.js";
 import {
   createDeck,
   commanderNames,
@@ -267,6 +267,27 @@ export async function handleDeckSubmit(e) {
       await canonicalizeCards(parseResult.cards);
     } catch (err) {
       console.warn("Card canonicalization failed, using raw names:", err.message);
+    }
+
+    // Add-time hint (#150): a commander shared by two standalone decks is a
+    // modeling mistake the split group already handles — one non-blocking
+    // nudge toward Split; the save proceeds either way. Add-time only: once
+    // both decks exist the hint has no action behind it.
+    const newCommanderNames = new Set(
+      parseResult.cards.filter((c) => c.isCommander).map((c) => normalizeCardName(c.name)),
+    );
+    for (const existing of state.currentPrism.decks) {
+      const shared = (existing.cards || []).find(
+        (c) => c.isCommander && newCommanderNames.has(normalizeCardName(c.name)),
+      );
+      if (shared) {
+        showToast(
+          `"${shared.name}" already commands "${existing.name}". If these are variants of one physical deck, use Split on that deck instead.`,
+          'warning',
+          'triangle-exclamation',
+        );
+        break;
+      }
     }
 
     // Get card names from the new deck (no processCards call)

--- a/js/features/deck-import.js
+++ b/js/features/deck-import.js
@@ -9,7 +9,12 @@ import { savePrism, setCurrentPrism } from '../modules/storage.js';
 import { buildPrismFromJson } from '../modules/prism-import.js';
 import { importFromMoxfield, toDecklistText, extractMoxfieldId } from '../modules/moxfield.js';
 import { importFromArchidekt, extractArchidektId } from '../modules/archidekt.js';
-import { initColorSwatches } from './deck-form.js';
+import {
+  initColorSwatches,
+  syncCommanderFieldsFromText,
+  addCommanderRefs,
+  editCommanderRefs,
+} from './deck-form.js';
 import { renderAll } from './init.js';
 
 // ============================================================================
@@ -39,6 +44,8 @@ export function handleFileUpload(e) {
   reader.onload = (event) => {
     const content = event.target.result;
     if (state.elements.deckList) state.elements.deckList.value = content;
+    // Programmatic .value writes fire no change event — sync fields explicitly
+    syncCommanderFieldsFromText(addCommanderRefs());
 
     if (state.elements.deckName && !state.elements.deckName.value) {
       const nameWithoutExt = file.name.replace(/\.(txt|dec|dek|mwDeck)$/i, '');
@@ -64,6 +71,7 @@ export function handleEditFileUpload(e) {
   reader.onload = (event) => {
     const content = event.target.result;
     if (state.elements.editDeckList) state.elements.editDeckList.value = content;
+    syncCommanderFieldsFromText(editCommanderRefs());
     showSuccess(`Loaded ${file.name}`);
   };
 
@@ -147,8 +155,9 @@ export async function handleMoxfieldImport() {
     const { serviceName, deckData } = await resolveDeckSource(urlOrId);
 
     if (state.elements.deckName) state.elements.deckName.value = deckData.name || '';
-    if (state.elements.deckCommander) state.elements.deckCommander.value = deckData.commander || '';
     if (state.elements.deckList) state.elements.deckList.value = toDecklistText(deckData);
+    // Commander fields auto-fill from the text's Commander section (#147)
+    syncCommanderFieldsFromText(addCommanderRefs());
 
     logToSupabase('info', 'url_import', { service: serviceName, name: deckData.name, cardCount: deckData.cards.length });
     showMoxfieldSuccess(`Imported "${deckData.name}" from ${serviceName} (${deckData.cards.length} cards). Review the form and click "Add Deck" to save.`);
@@ -181,6 +190,7 @@ export async function handleEditUrlImport() {
     const { serviceName, deckData } = await resolveDeckSource(urlOrId);
 
     if (state.elements.editDeckList) state.elements.editDeckList.value = toDecklistText(deckData);
+    syncCommanderFieldsFromText(editCommanderRefs());
 
     showEditImportSuccess(`Imported "${deckData.name}" from ${serviceName} (${deckData.cards.length} cards). Review and click "Save Changes" to update.`);
 

--- a/js/features/deck-list.js
+++ b/js/features/deck-list.js
@@ -13,7 +13,6 @@ import {
   moveStripeToPosition,
   getColorName,
   calculateRemovedCards,
-  isCardInOtherDecks,
   splitDeck,
   addSplitToGroup,
   unsplitGroup,
@@ -132,16 +131,39 @@ export function unmarkSharedCards(newCardNames) {
 export function autoClearRemovedCards(newCards) {
   if (!state.currentPrism?.removedCards?.length || !newCards?.length) return 0;
 
-  const newCardNames = new Set(
-    newCards.map((c) => c.name.toLowerCase().trim()),
+  const newByName = new Map(
+    newCards.map((c) => [c.name.toLowerCase().trim(), c]),
   );
 
   const before = state.currentPrism.removedCards.length;
-  state.currentPrism.removedCards = state.currentPrism.removedCards.filter(
-    (rc) => !newCardNames.has(rc.cardName.toLowerCase().trim()),
-  );
+  state.currentPrism.removedCards = state.currentPrism.removedCards.filter((rc) => {
+    const newCard = newByName.get(rc.cardName.toLowerCase().trim());
+    if (!newCard) return true; // still absent — keep the row
+    // Quantity-decrease rows (#151) only clear once the quantity is fully
+    // restored — otherwise the very save that created the row would clear it.
+    // Legacy rows without quantity fields keep the present-in-list rule.
+    if (rc.previousQuantity != null) return (newCard.quantity || 1) < rc.previousQuantity;
+    return false; // present again — clear
+  });
 
   return before - state.currentPrism.removedCards.length;
+}
+
+// Upsert a removedCards row by (cardName, deckId): successive quantity edits
+// merge instead of duplicating — previousQuantity keeps its max (5→4→3 must
+// not under-report the surplus), the latest newQuantity/removedAt win.
+// Mirrors mergeRemovedCards in storage.js. Returns true if the row is new.
+function trackRemovedCard(row) {
+  const list = state.currentPrism.removedCards;
+  const idx = list.findIndex(
+    (rc) => rc.cardName.toLowerCase() === row.cardName.toLowerCase() && rc.deckId === row.deckId,
+  );
+  if (idx >= 0) {
+    row.previousQuantity = Math.max(row.previousQuantity || 1, list[idx].previousQuantity || 0);
+    list.splice(idx, 1);
+  }
+  list.push(row);
+  return idx < 0;
 }
 
 // Slot to record in removedCards for a deck's cleared marks. Dot variants own
@@ -208,8 +230,9 @@ export function handleMarkToggle(event) {
   setCardMarked(cardKey, isChecked);
 
   // Full re-render when: undone filter active (marked row must disappear) OR
-  // sort is by "marked" column (row order needs to update).
-  if (state.elements.undoneFilter?.checked || state.sortState?.column === 'marked') {
+  // sort is by "marked" column (row order needs to update) OR a batch sub-row
+  // toggled (the derived parent roll-up checkbox must update).
+  if (state.elements.undoneFilter?.checked || state.sortState?.column === 'marked' || row.classList.contains('batch-subrow')) {
     renderResults();
   } else {
     updateMarkedProgress();
@@ -404,40 +427,17 @@ export async function handleEditConfirm() {
   const removalPosition = getRemovalStripePosition(deck);
 
   for (const removedCard of removedFromDeck) {
-    if (
-      !isCardInOtherDecks(
-        state.currentPrism,
-        removedCard.name,
-        state.deckToEdit,
-      )
-    ) {
-      state.currentPrism.removedCards.push({
-        cardName: removedCard.name,
-        deckId: deck.id,
-        deckName: deck.name,
-        deckColor: deck.color,
-        stripePosition: removalPosition,
-        removedAt: now,
-      });
-      removedCount++;
-    } else {
-      const alreadyTracked = state.currentPrism.removedCards.some(
-        (rc) =>
-          rc.cardName.toLowerCase() === removedCard.name.toLowerCase() &&
-          rc.deckId === deck.id,
-      );
-      if (!alreadyTracked) {
-        state.currentPrism.removedCards.push({
-          cardName: removedCard.name,
-          deckId: deck.id,
-          deckName: deck.name,
-          deckColor: deck.color,
-          stripePosition: removalPosition,
-          removedAt: now,
-        });
-        removedCount++;
-      }
-    }
+    const isNew = trackRemovedCard({
+      cardName: removedCard.name,
+      deckId: deck.id,
+      deckName: deck.name,
+      deckColor: deck.color,
+      stripePosition: removalPosition,
+      removedAt: now,
+      previousQuantity: removedCard.previousQuantity,
+      newQuantity: removedCard.newQuantity,
+    });
+    if (isNew) removedCount++;
   }
 
   const autoClearedCount = autoClearRemovedCards(parseResult.cards);
@@ -489,36 +489,17 @@ export function handleDeleteConfirm() {
   const removalPosition = getRemovalStripePosition(deck);
 
   for (const card of deck.cards) {
-    if (
-      !isCardInOtherDecks(state.currentPrism, card.name, state.deckToDelete)
-    ) {
-      state.currentPrism.removedCards.push({
-        cardName: card.name,
-        deckId: deck.id,
-        deckName: deck.name,
-        deckColor: deck.color,
-        stripePosition: removalPosition,
-        removedAt: now,
-      });
-      removedCount++;
-    } else {
-      const alreadyTracked = state.currentPrism.removedCards.some(
-        (rc) =>
-          rc.cardName.toLowerCase() === card.name.toLowerCase() &&
-          rc.deckId === deck.id,
-      );
-      if (!alreadyTracked) {
-        state.currentPrism.removedCards.push({
-          cardName: card.name,
-          deckId: deck.id,
-          deckName: deck.name,
-          deckColor: deck.color,
-          stripePosition: removalPosition,
-          removedAt: now,
-        });
-        removedCount++;
-      }
-    }
+    const isNew = trackRemovedCard({
+      cardName: card.name,
+      deckId: deck.id,
+      deckName: deck.name,
+      deckColor: deck.color,
+      stripePosition: removalPosition,
+      removedAt: now,
+      previousQuantity: card.quantity || 1,
+      newQuantity: 0,
+    });
+    if (isNew) removedCount++;
   }
 
   const deckName = deck.name;
@@ -719,26 +700,17 @@ export function handlePositionChange(deckId, newPosition) {
 // Pool/Core count helpers
 // ============================================================================
 
-function getDeckPoolCoreCounts(deck, processedCards) {
+export function getDeckPoolCoreCounts(deck, processedCards) {
+  // Batch-based (#146): a deck participates in every batch containing it, so
+  // its pool + core equals its trusted decklist quantity for every card.
   let pool = 0;
   let core = 0;
 
   for (const card of processedCards) {
-    // Check if this card belongs to this deck
-    const inThisDeck = card.stripes.some(s => s.deckId === deck.id);
-    if (!inThisDeck) continue;
-
-    // For basic lands, use this deck's actual quantity
-    let qty = 1;
-    if (card.isBasicLand) {
-      const deckCard = deck.cards.find(c => c.name.toLowerCase() === card.name.toLowerCase());
-      qty = deckCard?.quantity || 1;
-    }
-
-    if (card.logicalDeckCount > 1) {
-      pool += qty;
-    } else {
-      core += qty;
+    for (const batch of card.batches || []) {
+      if (!batch.participantIds.includes(deck.id)) continue;
+      if (batch.isPool) pool += batch.copyCount;
+      else core += batch.copyCount;
     }
   }
 

--- a/js/features/deck-list.js
+++ b/js/features/deck-list.js
@@ -5,7 +5,7 @@
 import { state } from "../core/state.js";
 import { showError, showSuccess } from "../core/notifications.js";
 import { escapeHtml, debugLog } from "../core/utils.js";
-import { parseDecklist, validateDecklist, cardsToDecklistText } from "../modules/parser.js";
+import { parseDecklist, validateDecklist, cardsToDecklistText, normalizeCardName } from "../modules/parser.js";
 import {
   processCards,
   commanderNames,
@@ -131,13 +131,15 @@ export function unmarkSharedCards(newCardNames) {
 export function autoClearRemovedCards(newCards) {
   if (!state.currentPrism?.removedCards?.length || !newCards?.length) return 0;
 
+  // normalizeCardName (not bare toLowerCase) so printing suffixes, back faces
+  // and stray whitespace match the same way processCards dedups cards.
   const newByName = new Map(
-    newCards.map((c) => [c.name.toLowerCase().trim(), c]),
+    newCards.map((c) => [normalizeCardName(c.name), c]),
   );
 
   const before = state.currentPrism.removedCards.length;
   state.currentPrism.removedCards = state.currentPrism.removedCards.filter((rc) => {
-    const newCard = newByName.get(rc.cardName.toLowerCase().trim());
+    const newCard = newByName.get(normalizeCardName(rc.cardName));
     if (!newCard) return true; // still absent — keep the row
     // Quantity-decrease rows (#151) only clear once the quantity is fully
     // restored — otherwise the very save that created the row would clear it.
@@ -155,8 +157,9 @@ export function autoClearRemovedCards(newCards) {
 // Mirrors mergeRemovedCards in storage.js. Returns true if the row is new.
 function trackRemovedCard(row) {
   const list = state.currentPrism.removedCards;
+  const rowName = normalizeCardName(row.cardName);
   const idx = list.findIndex(
-    (rc) => rc.cardName.toLowerCase() === row.cardName.toLowerCase() && rc.deckId === row.deckId,
+    (rc) => normalizeCardName(rc.cardName) === rowName && rc.deckId === row.deckId,
   );
   if (idx >= 0) {
     row.previousQuantity = Math.max(row.previousQuantity || 1, list[idx].previousQuantity || 0);

--- a/js/features/deck-list.js
+++ b/js/features/deck-list.js
@@ -5,9 +5,10 @@
 import { state } from "../core/state.js";
 import { showError, showSuccess } from "../core/notifications.js";
 import { escapeHtml, debugLog } from "../core/utils.js";
-import { parseDecklist, validateDecklist } from "../modules/parser.js";
+import { parseDecklist, validateDecklist, cardsToDecklistText } from "../modules/parser.js";
 import {
   processCards,
+  commanderNames,
   removeDeckFromPrism,
   moveStripeToPosition,
   getColorName,
@@ -26,7 +27,13 @@ import { savePrism, setCurrentPrism, recordUnmarkedCards } from "../modules/stor
 import { trackEvent } from "../modules/supabase-client.js";
 import { canonicalizeCards } from "../modules/scryfall.js";
 import { hideEditImportMessages } from "./deck-import.js";
-import { initColorSwatches, resetDeckForm } from "./deck-form.js";
+import {
+  initColorSwatches,
+  resetDeckForm,
+  syncCommanderFieldsFromText,
+  applyCommanderFieldsToText,
+  editCommanderRefs,
+} from "./deck-form.js";
 import { renderAll } from "./init.js";
 import { openStripeReorderDialog, openGroupReorderDialog } from "./stripe-reorder-dialog.js";
 import { toggleWhatIfAnalysis } from "./analysis.js";
@@ -276,19 +283,16 @@ export function handleEditClick(deckId) {
   if (state.elements.editDeckId) state.elements.editDeckId.value = deck.id;
   if (state.elements.editDeckName)
     state.elements.editDeckName.value = deck.name;
-  if (state.elements.editDeckCommander)
-    state.elements.editDeckCommander.value = deck.commander;
   if (state.elements.editDeckBracket)
     state.elements.editDeckBracket.value = String(deck.bracket);
   if (state.elements.editDeckColor)
     state.elements.editDeckColor.value = deck.color;
 
   if (state.elements.editDeckList) {
-    const decklistText = deck.cards
-      .map((card) => `${card.quantity} ${card.name}`)
-      .join("\n");
-    state.elements.editDeckList.value = decklistText;
+    // Sections carry the commander flags through the textarea round-trip (#147)
+    state.elements.editDeckList.value = cardsToDecklistText(deck.cards);
   }
+  syncCommanderFieldsFromText(editCommanderRefs());
 
   if (state.elements.editDeckListUpdated) {
     const ts = deck.cardsUpdatedAt || deck.createdAt;
@@ -322,6 +326,9 @@ export async function handleEditConfirm() {
   const beforeCounts = getStripeCountMap();
   const oldCards = [...deck.cards];
 
+  // Fields → text once at save entry (idempotent) — see handleDeckSubmit
+  applyCommanderFieldsToText(editCommanderRefs());
+
   const name = (state.elements.editDeckName?.value || "").trim();
   const commander = (state.elements.editDeckCommander?.value || "").trim();
   const bracket = state.elements.editDeckBracket?.value || "2";
@@ -350,7 +357,7 @@ export async function handleEditConfirm() {
     return;
   }
 
-  const parseResult = parseDecklist(decklistText, commander);
+  const parseResult = parseDecklist(decklistText);
 
   // Spinner for the Scryfall round-trip — the only network-bound wait here.
   const saveBtn = state.elements.btnConfirmEdit;
@@ -438,7 +445,6 @@ export async function handleEditConfirm() {
   const cardsChanged = cardListChanged(oldCards, parseResult.cards);
 
   deck.name = name;
-  deck.commander = commander;
   deck.bracket = parseInt(bracket, 10);
   deck.color = color;
   deck.cards = parseResult.cards;
@@ -843,7 +849,7 @@ export function renderDeckCard(deck, showActions = true, processedCards = null) 
               <wa-tag size="small" variant="neutral">Bracket ${deck.bracket}</wa-tag>
             </div>
             <div class="wa-caption-m" style="color: var(--wa-color-neutral-text-subtle);">
-              ${escapeHtml(deck.commander)}${processedCards ? (() => { const { pool, core } = getDeckPoolCoreCounts(deck, processedCards); return ` • ${pool} pool • ${core} core`; })() : ` • ${deck.cards.length} cards`}
+              ${escapeHtml(commanderNames(deck).join(' / '))}${processedCards ? (() => { const { pool, core } = getDeckPoolCoreCounts(deck, processedCards); return ` • ${pool} pool • ${core} core`; })() : ` • ${deck.cards.length} cards`}
             </div>
           </div>
         </div>
@@ -967,7 +973,7 @@ export function renderDecksList() {
                   </wa-tag>
                 </div>
                 <div class="wa-caption-m" style="color: var(--wa-color-neutral-text-subtle);">
-                  ${escapeHtml(children[0]?.commander || "")} • Split deck group
+                  ${escapeHtml(children[0] ? commanderNames(children[0]).join(' / ') : "")} • Split deck group
                 </div>
               </div>
             </div>

--- a/js/features/events.js
+++ b/js/features/events.js
@@ -5,7 +5,18 @@
 import { state } from '../core/state.js';
 import { downloadCSV, downloadJSON, openPrintableGuide, downloadUndoneTxt, copyUndoneToClipboard } from '../modules/export.js';
 import { showPreview, hidePreview, updatePosition, refreshOpenPreview } from '../modules/card-preview.js';
-import { handleDeckSubmit, resetDeckForm, updateColorSwatchSelection, checkColorWarning, handlePrismNameChange } from './deck-form.js';
+import {
+  handleDeckSubmit,
+  resetDeckForm,
+  updateColorSwatchSelection,
+  checkColorWarning,
+  handlePrismNameChange,
+  syncCommanderFieldsFromText,
+  applyCommanderFieldsToText,
+  handleTwoCommandersToggle,
+  addCommanderRefs,
+  editCommanderRefs,
+} from './deck-form.js';
 import { handleFileUpload, handleJsonImport, handleMoxfieldImport, handleEditFileUpload, handleEditUrlImport } from './deck-import.js';
 import { handleDeleteConfirm, handleEditConfirm, handleNewPrism, handleSplitConfirm, handleEditGroupConfirm } from './deck-list.js';
 import { renderResults } from './results.js';
@@ -33,6 +44,14 @@ export function setupEventListeners() {
 
   if (state.elements.btnResetForm) {
     state.elements.btnResetForm.addEventListener('click', resetDeckForm);
+  }
+
+  // Commander fields <-> decklist text sync (#147), Add form and Edit dialog
+  for (const refs of [addCommanderRefs(), editCommanderRefs()]) {
+    refs.textarea?.addEventListener('change', () => syncCommanderFieldsFromText(refs));
+    refs.field1?.addEventListener('change', () => applyCommanderFieldsToText(refs));
+    refs.field2?.addEventListener('change', () => applyCommanderFieldsToText(refs));
+    refs.toggle?.addEventListener('change', () => handleTwoCommandersToggle(refs));
   }
 
   // Color picker change

--- a/js/features/events.js
+++ b/js/features/events.js
@@ -23,7 +23,7 @@ import { renderResults } from './results.js';
 import { openScryMode } from './scry-mode.js';
 import { renderOverlapMatrix } from './analysis.js';
 import { debounce } from '../core/utils.js';
-import { updatePreferences, getCurrentPrism } from '../modules/storage.js';
+import { updatePreferences, getCurrentPrism, savePrism } from '../modules/storage.js';
 import { renderAll } from './init.js';
 import { logToSupabase } from '../modules/supabase-client.js';
 
@@ -52,6 +52,19 @@ export function setupEventListeners() {
     refs.field1?.addEventListener('change', () => applyCommanderFieldsToText(refs));
     refs.field2?.addEventListener('change', () => applyCommanderFieldsToText(refs));
     refs.toggle?.addEventListener('change', () => handleTwoCommandersToggle(refs));
+  }
+
+  // Dedicated commander copies — per-PRISM synced setting; write path per #145
+  // (flag + its own merge timestamp + prism.updatedAt, mirroring mark-toggle)
+  if (state.elements.dedicatedCommanderToggle) {
+    state.elements.dedicatedCommanderToggle.addEventListener('change', (e) => {
+      const now = new Date().toISOString();
+      state.currentPrism.useDedicatedCommanderCopies = !!e.target.checked;
+      state.currentPrism.useDedicatedCommanderCopiesUpdatedAt = now;
+      state.currentPrism.updatedAt = now;
+      savePrism(state.currentPrism);
+      renderAll();
+    });
   }
 
   // Color picker change

--- a/js/features/init.js
+++ b/js/features/init.js
@@ -4,7 +4,7 @@
 
 import { state } from '../core/state.js';
 import { getLogicalDeckCount, debugLog } from '../core/utils.js';
-import { createPrism, getUsedPositions, MAX_STRIPE_SLOTS } from '../modules/processor.js';
+import { createPrism, getUsedPositions, MAX_STRIPE_SLOTS, applyCommanderFallback } from '../modules/processor.js';
 import { getCurrentPrism, savePrism, setCurrentPrism, getPreferences, onSyncStatusChange, forceSyncCurrentPrism } from '../modules/storage.js';
 import { initAuth, setupAuthListeners, getCurrentUser } from '../modules/auth.js';
 import { logToSupabase } from '../modules/supabase-client.js';
@@ -33,6 +33,8 @@ function getElements() {
     deckForm: document.getElementById('deck-form'),
     deckName: document.getElementById('deck-name'),
     deckCommander: document.getElementById('deck-commander'),
+    deckCommander2: document.getElementById('deck-commander-2'),
+    deckTwoCommanders: document.getElementById('deck-two-commanders'),
     deckBracket: document.getElementById('deck-bracket'),
     deckColor: document.getElementById('deck-color'),
     deckList: document.getElementById('deck-list'),
@@ -103,6 +105,8 @@ function getElements() {
     editDeckId: document.getElementById('edit-deck-id'),
     editDeckName: document.getElementById('edit-deck-name'),
     editDeckCommander: document.getElementById('edit-deck-commander'),
+    editDeckCommander2: document.getElementById('edit-deck-commander-2'),
+    editDeckTwoCommanders: document.getElementById('edit-deck-two-commanders'),
     editDeckBracket: document.getElementById('edit-deck-bracket'),
     editDeckColor: document.getElementById('edit-deck-color'),
     editDeckList: document.getElementById('edit-deck-list'),
@@ -189,6 +193,15 @@ export async function init() {
     state.currentPrism = createPrism();
     savePrism(state.currentPrism);
     setCurrentPrism(state.currentPrism.id);
+  } else {
+    // One-time #147 normalization: legacy form-added decks may carry only the
+    // commander scalar with zero card flags. Idempotent, saves only on change;
+    // the stale scalar is left in place, unread, and decays on its own.
+    let normalized = false;
+    for (const deck of state.currentPrism.decks || []) {
+      if (applyCommanderFallback(deck, deck.commander)) normalized = true;
+    }
+    if (normalized) savePrism(state.currentPrism);
   }
 
   if (state.elements.undoneFilter) {

--- a/js/features/init.js
+++ b/js/features/init.js
@@ -39,6 +39,7 @@ function getElements() {
     deckColor: document.getElementById('deck-color'),
     deckList: document.getElementById('deck-list'),
     deckFileInput: document.getElementById('deck-file-input'),
+    dedicatedCommanderToggle: document.getElementById('dedicated-commander-copies'),
     colorSwatches: document.getElementById('color-swatches'),
     colorWarning: document.getElementById('color-warning'),
     parseErrors: document.getElementById('parse-errors'),
@@ -227,6 +228,10 @@ export async function init() {
 
 export function renderAll() {
   renderPrismHeader();
+  // Per-PRISM toggle reflects the loaded/synced prism, not just user clicks
+  if (state.elements.dedicatedCommanderToggle) {
+    state.elements.dedicatedCommanderToggle.checked = !!state.currentPrism?.useDedicatedCommanderCopies;
+  }
   renderDecksList();
   renderResults();
   renderExport();

--- a/js/features/results.js
+++ b/js/features/results.js
@@ -453,7 +453,7 @@ export function renderResults() {
           <td style="text-align: center;">
             <input type="checkbox" class="mark-checkbox" aria-label="Mark ${b.copyCount} ${escapeHtml(card.name)} copies done" ${marked ? 'checked' : ''}>
           </td>
-          <td class="batch-subrow-label" data-card-name="${escapeHtml(card.name)}">${b.copyCount} ${b.copyCount === 1 ? 'copy' : 'copies'} — ${b.isPool ? 'pool' : 'core'}</td>${copiesCell(b.copyCount)}
+          <td class="batch-subrow-label" data-card-name="${escapeHtml(card.name)}">${b.copyCount} ${b.copyCount === 1 ? 'copy' : 'copies'} — ${b.isDedicated ? 'dedicated' : (b.isPool ? 'pool' : 'core')}</td>${copiesCell(b.copyCount)}
           <td><div class="stripe-indicators">${stripeHtml(b.stripes)}</div></td>
         </tr>
       `;

--- a/js/features/results.js
+++ b/js/features/results.js
@@ -75,6 +75,10 @@ function renderSlot(slot, opts) {
   return `<div class="stripe-slot"><div class="slot-dot-row">${dotsHtml}</div>${squareHtml}</div>`;
 }
 
+// Multi-batch cards the user has expanded (by card name). Module-level so the
+// disclosure state survives re-renders within the session.
+const expandedCards = new Set();
+
 // ============================================================================
 // Removed filter badge
 // ============================================================================
@@ -104,9 +108,17 @@ export function updateMarkedProgress() {
   const cards = state.processedCards || [];
   const markedSet = new Set(state.currentPrism?.markedCards || []);
   const totalCount = cards.reduce((sum, c) => sum + c.totalQuantity, 0);
-  // isCardDone also honours per-deck basic marks ("Name|DeckName" keys from the
-  // Basics-by-Deck view) so progress can reach 100% for users of that view.
-  const markedCount = cards.reduce((sum, c) => sum + (isCardDone(c, markedSet) ? c.totalQuantity : 0), 0);
+  // Batch-aware (#151): a fully-done card counts all copies (isCardDone also
+  // honours pass keys); a partially-done multi-batch card counts the copies
+  // of its done batches, so marking 3 of 5 Forests moves the bar.
+  const markedCount = cards.reduce((sum, c) => {
+    if (isCardDone(c, markedSet)) return sum + c.totalQuantity;
+    const batches = c.batches || [];
+    if (batches.length > 1) {
+      return sum + batches.reduce((s, b) => s + (markedSet.has(b.key) ? b.copyCount : 0), 0);
+    }
+    return sum;
+  }, 0);
 
   if (state.elements.statMarked) state.elements.statMarked.textContent = `${markedCount}/${totalCount}`;
   if (state.elements.markedProgress) {
@@ -122,7 +134,12 @@ export function renderResults() {
   const processedCards = processCards(state.currentPrism);
   state.processedCards = processedCards;
   const totalCardCount = processedCards.reduce((sum, c) => sum + c.totalQuantity, 0);
-  const sharedCardCount = processedCards.filter(c => c.logicalDeckCount > 1).reduce((sum, c) => sum + c.totalQuantity, 0);
+  // Pool/core belongs to batches (#146): A5/B3 contributes 3 pool + 2 core,
+  // not 5 pool — so Pool Cards sums pool-batch quantities.
+  const sharedCardCount = processedCards.reduce(
+    (sum, c) => sum + (c.batches || []).reduce((s, b) => s + (b.isPool ? b.copyCount : 0), 0),
+    0,
+  );
 
   // Update stats
   if (state.elements.statTotal) state.elements.statTotal.textContent = totalCardCount;
@@ -158,47 +175,41 @@ export function renderResults() {
     filteredCards = filteredCards.filter(c => c.logicalDeckCount > 1);
     displayCards = filteredCards;
   } else if (filter === 'basics-by-deck') {
-    // Show only basic lands, one row per LOGICAL deck. Standalone decks and
-    // split groups each emit exactly one Side A stripe, so iterating Side A
-    // gives the right row set — split variants share physical cards, so the
-    // group row carries the max quantity across its children. Iterating all
-    // stripes (the old behaviour) leaked invisible membership anchors and
-    // group-level stripes with no deckId, producing bogus rows with qty 1.
-    const findQty = (deck, cardName) =>
-      deck?.cards.find(c => c.name.toLowerCase() === cardName.toLowerCase())?.quantity || 0;
+    // One-mark-at-a-time pass view (#149): the per-deck projection of the
+    // canonical batches (#146), generalized from basics to every repeated
+    // card. One row per distinct physical mark; its quantity is the sum of
+    // the copy counts of the batches carrying that mark — "an A-mark pass
+    // over 5 copies", "a child-indicator pass over the 3 A-only copies".
+    // Row keys stay `<name>|<deckName>` (#151), shared with passKeysForCard.
     displayCards = [];
     for (const card of filteredCards) {
-      if (!card.isBasicLand) continue; // Non-basics are excluded from this view
-      for (const stripe of card.stripes) {
-        if (stripe.side !== 'a') continue;
-
-        let quantity = 1;
-        if (stripe.deckId) {
-          const deck = state.currentPrism.decks.find(d => d.id === stripe.deckId);
-          quantity = findQty(deck, card.name) || 1;
-        } else if (stripe.groupId) {
-          const group = (state.currentPrism.splitGroups || []).find(g => g.id === stripe.groupId);
-          const childQtys = (group?.childDeckIds || [])
-            .map(id => findQty(state.currentPrism.decks.find(d => d.id === id), card.name));
-          quantity = Math.max(1, ...childQtys);
+      if (card.totalQuantity <= 1) continue; // single physical copy — no pass needed
+      const passes = new Map(); // deckName -> { stripe, copies }
+      for (const batch of card.batches || []) {
+        for (const s of batch.stripes) {
+          if (s.markType === 'membership') continue;
+          const entry = passes.get(s.deckName) || { stripe: s, copies: 0 };
+          entry.copies += batch.copyCount;
+          passes.set(s.deckName, entry);
         }
-
+      }
+      for (const [deckName, { stripe, copies }] of passes) {
         displayCards.push({
-          name: `${card.name} (${stripe.deckName})`,
+          name: `${card.name} (${deckName})`,
           displayName: card.name,
-          deckName: stripe.deckName,
-          isBasicLand: true,
-          isBasicByDeck: true,
-          totalQuantity: quantity,
+          deckName,
+          isBasicLand: card.isBasicLand,
+          isPassRow: true,
+          totalQuantity: copies,
           deckCount: 1,
           stripes: [stripe]
         });
       }
     }
-    // Sort by land type first, then by deck name
+    // Sort by card name first, then by deck name
     displayCards.sort((a, b) => {
-      const landCompare = a.displayName.localeCompare(b.displayName);
-      if (landCompare !== 0) return landCompare;
+      const nameCompare = a.displayName.localeCompare(b.displayName);
+      if (nameCompare !== 0) return nameCompare;
       return a.deckName.localeCompare(b.deckName);
     });
   } else if (filter === 'removed') {
@@ -215,6 +226,8 @@ export function renderResults() {
         removedDeckColor: removed.deckColor,
         removedStripePosition: removed.stripePosition,
         removedAt: removed.removedAt,
+        removedPreviousQuantity: removed.previousQuantity,
+        removedNewQuantity: removed.newQuantity,
         deckCount: 0, // Not in any deck now (for this stripe)
         stripes: [{
           position: removed.stripePosition,
@@ -258,11 +271,14 @@ export function renderResults() {
   }
 
   // Persistent undone-only filter: keep cards the user hasn't marked done.
+  // Card rows go through isCardDone so multi-batch cards classify consistently
+  // (a partially-done card stays visible); pass rows keep key equality.
   if (state.elements.undoneFilter?.checked) {
     const markedSet = new Set(state.currentPrism.markedCards || []);
     displayCards = displayCards.filter(card => {
-      const cardKey = card.isBasicByDeck ? `${card.displayName}|${card.deckName}` : card.name;
-      return !markedSet.has(cardKey);
+      if (card.isPassRow) return !markedSet.has(`${card.displayName}|${card.deckName}`);
+      if (card.isRemoved) return true;
+      return !isCardDone(card, markedSet);
     });
   }
 
@@ -273,8 +289,21 @@ export function renderResults() {
   // Apply sorting
   displayCards = sortCards(displayCards, state.sortState.column, state.sortState.direction);
 
-  // Snapshot for SCRY-Mode — reflects exact list visible to user (all filters/sort applied)
-  state.resultsView = displayCards;
+  // Snapshot for SCRY-Mode — reflects exact list visible to user (all
+  // filters/sort applied). Multi-batch cards flatten to one entry per batch
+  // (#149): the parent row is not markable, so it is not a screen.
+  state.resultsView = displayCards.flatMap(card => {
+    const batches = card.batches || [];
+    if (card.isRemoved || card.isPassRow || batches.length <= 1) return [card];
+    return batches.map(b => ({
+      name: card.name,
+      isBasicLand: card.isBasicLand,
+      batchKey: b.key,
+      copyCount: b.copyCount,
+      totalQuantity: b.copyCount,
+      stripes: b.stripes
+    }));
+  });
 
   // Render table header with sort indicators
   renderResultsHeader();
@@ -287,10 +316,59 @@ export function renderResults() {
   const showNums = numbersMode !== 'none';
   const totalDecks = state.currentPrism?.decks?.length || 0;
 
+  // All used positions, for the show-all-slots ruler
+  const allPositions = showAllSlots && totalDecks > 0
+    ? [...new Set([
+        ...state.currentPrism.decks.map(d => d.stripePosition),
+        ...(state.currentPrism.splitGroups || []).map(g => g.sideAPosition)
+      ])].sort((a, b) => a - b)
+    : null;
+
+  // Render a stripe-indicator strip for any stripe set (card row or batch row).
+  // Sparse sets number every mark with its exact slot; dense sets fall back to
+  // anchor numbering unless the pref forces all.
+  const stripeHtml = (stripes) => {
+    const exact = numbersMode === 'all' || countVisibleMarks(stripes) <= STRIPE_SPARSE_MAX;
+    const opts = { showNums, exact };
+    const slotMap = buildSlotMap(stripes);
+    let html = '';
+    if (allPositions) {
+      for (const pos of allPositions) {
+        const slot = slotMap.get(pos);
+        if (slot) {
+          html += renderSlot(slot, opts);
+        } else {
+          // Empty reference slots only ever show the anchor ruler number, never
+          // an "exact" number (they are not this card's marks).
+          html += `<div
+            class="stripe-indicator stripe-empty"
+            title="${formatSlotLabel(pos)}: Empty"
+          >${positionNumHtml(pos, { showNums, exact: false }, true)}</div>`;
+        }
+      }
+    } else {
+      for (const [, slot] of slotMap) html += renderSlot(slot, opts);
+    }
+    return html;
+  };
+
+  const markedSetForRows = new Set(state.currentPrism.markedCards || []);
+  // Copies cell renders only when the quantity exceeds one (#149) — the
+  // common singleton path gains no text at all.
+  const copiesCell = (q) => `<td class="copies-cell">${q > 1 ? q : ''}</td>`;
+
   state.elements.resultsTbody.innerHTML = displayCards.map(card => {
     // Handle removed cards differently
     if (card.isRemoved) {
       const removedKey = `${card.name}|${card.removedDeckId}`;
+      // "clear this mark from N copies" (#151); legacy rows without quantity
+      // fields keep the plain label.
+      const clearCopies = card.removedPreviousQuantity != null
+        ? Math.max(1, (card.removedPreviousQuantity || 1) - (card.removedNewQuantity || 0))
+        : null;
+      const copiesNote = clearCopies != null
+        ? ` — clear ${clearCopies} ${clearCopies === 1 ? 'copy' : 'copies'}`
+        : '';
       return `
         <tr class="removed-row" data-removed-key="${escapeHtml(removedKey)}">
           <td>${escapeHtml(card.name)}</td>
@@ -301,7 +379,7 @@ export function renderResults() {
                 style="background-color: ${card.removedDeckColor};"
                 title="Remove from ${card.removedStripePosition != null ? formatSlotLabel(card.removedStripePosition) : 'this deck’s group slot'}"
               ></div>
-              <span class="removed-deck-label">Remove from ${escapeHtml(card.removedDeckName)}</span>
+              <span class="removed-deck-label">Remove from ${escapeHtml(card.removedDeckName)}${copiesNote}</span>
             </div>
           </td>
           <td style="text-align: center;">
@@ -322,64 +400,78 @@ export function renderResults() {
       `;
     }
 
-    let stripeIndicators;
-
-    // Sparse cards number every mark with its exact slot (always-on); dense
-    // cards fall back to the anchor numbering unless the pref forces all.
-    const exact = numbersMode === 'all' || countVisibleMarks(card.stripes) <= STRIPE_SPARSE_MAX;
-    const opts = { showNums, exact };
-
-    if (showAllSlots && totalDecks > 0) {
-      // Collect all used positions (deck positions + split group Side A positions)
-      const allPositions = [...new Set([
-        ...state.currentPrism.decks.map(d => d.stripePosition),
-        ...(state.currentPrism.splitGroups || []).map(g => g.sideAPosition)
-      ])].sort((a, b) => a - b);
-
-      const slotMap = buildSlotMap(card.stripes);
-      stripeIndicators = '';
-      for (const pos of allPositions) {
-        const slot = slotMap.get(pos);
-        if (slot) {
-          stripeIndicators += renderSlot(slot, opts);
-        } else {
-          // Empty reference slots only ever show the anchor ruler number, never
-          // an "exact" number (they are not this card's marks).
-          stripeIndicators += `<div
-            class="stripe-indicator stripe-empty"
-            title="${formatSlotLabel(pos)}: Empty"
-          >${positionNumHtml(pos, { showNums, exact: false }, true)}</div>`;
-        }
-      }
-    } else {
-      // Show only filled slots (default)
-      const slotMap = buildSlotMap(card.stripes);
-      stripeIndicators = '';
-      for (const [, slot] of slotMap) {
-        stripeIndicators += renderSlot(slot, opts);
-      }
-    }
-
     const rowClass = card.logicalDeckCount > 1 ? 'shared-row' : '';
     const nameClass = card.isBasicLand ? 'basic-land' : '';
-    const basicTag = card.isBasicLand && !card.isBasicByDeck ? ' <span class="basic-tag">(Basic)</span>' : '';
-    const copiesCell = filter === 'basics-by-deck' ? `<td>${card.totalQuantity}</td>` : '';
+    const basicTag = card.isBasicLand && !card.isPassRow ? ' <span class="basic-tag">(Basic)</span>' : '';
+    const batches = card.batches || [];
+    const multiBatch = !card.isPassRow && batches.length > 1;
 
-    // Check if card is marked (use original card name for basics-by-deck entries)
-    const cardKey = card.isBasicByDeck ? `${card.displayName}|${card.deckName}` : card.name;
-    const isMarked = state.currentPrism.markedCards?.includes(cardKey) || false;
-    const markedClass = isMarked ? 'marked-row' : '';
+    if (!multiBatch) {
+      // Singleton path — exactly today's row (#149). Pass rows keep their
+      // `<name>|<deckName>` key.
+      const cardKey = card.isPassRow ? `${card.displayName}|${card.deckName}` : card.name;
+      const isMarked = markedSetForRows.has(cardKey);
+      return `
+        <tr class="${rowClass} ${isMarked ? 'marked-row' : ''}" data-card-key="${escapeHtml(cardKey)}">
+          <td style="text-align: center;">
+            <input type="checkbox" class="mark-checkbox" aria-label="Mark ${escapeHtml(card.name)} done" ${isMarked ? 'checked' : ''}>
+          </td>
+          <td class="${nameClass} card-name-cell" data-card-name="${escapeHtml(card.isPassRow ? card.displayName : card.name)}">${escapeHtml(card.name)}${basicTag}</td>${copiesCell(card.totalQuantity)}
+          <td><div class="stripe-indicators">${stripeHtml(card.stripes)}</div></td>
+        </tr>
+      `;
+    }
 
-    return `
-      <tr class="${rowClass} ${markedClass}" data-card-key="${escapeHtml(cardKey)}">
+    // Multi-batch card: parent row with derived (non-clickable) checkbox and
+    // no mark union — the union is the over-marking trap (#149). Marking
+    // requires expanding and checking each batch.
+    const doneCount = batches.filter(b => markedSetForRows.has(b.key)).length;
+    const allDone = doneCount === batches.length;
+    const isExpanded = expandedCards.has(card.name);
+    const parentRow = `
+      <tr class="${rowClass} ${allDone ? 'marked-row' : ''} batch-parent">
         <td style="text-align: center;">
-          <input type="checkbox" class="mark-checkbox" aria-label="Mark ${escapeHtml(card.name)} done" ${isMarked ? 'checked' : ''}>
+          <input type="checkbox" class="batch-parent-check" disabled
+            aria-label="${escapeHtml(card.name)} roll-up: ${doneCount} of ${batches.length} batches done"
+            ${allDone ? 'checked' : ''} ${doneCount > 0 && !allDone ? 'data-indeterminate="1"' : ''}>
         </td>
-        <td class="${nameClass} card-name-cell" data-card-name="${escapeHtml(card.name)}">${escapeHtml(card.name)}${basicTag}</td>${copiesCell}
-        <td><div class="stripe-indicators">${stripeIndicators}</div></td>
+        <td class="${nameClass} card-name-cell" data-card-name="${escapeHtml(card.name)}">
+          <button type="button" class="batch-toggle" data-card-name="${escapeHtml(card.name)}" aria-expanded="${isExpanded}" title="${isExpanded ? 'Collapse' : 'Expand'} batches">
+            <wa-icon name="${isExpanded ? 'chevron-down' : 'chevron-right'}"></wa-icon>
+          </button>
+          ${escapeHtml(card.name)}${basicTag}
+        </td>${copiesCell(card.totalQuantity)}
+        <td><span class="basic-tag">${batches.length} different markings</span></td>
       </tr>
     `;
+    if (!isExpanded) return parentRow;
+
+    return parentRow + batches.map(b => {
+      const marked = markedSetForRows.has(b.key);
+      return `
+        <tr class="batch-subrow ${marked ? 'marked-row' : ''}" data-card-key="${escapeHtml(b.key)}">
+          <td style="text-align: center;">
+            <input type="checkbox" class="mark-checkbox" aria-label="Mark ${b.copyCount} ${escapeHtml(card.name)} copies done" ${marked ? 'checked' : ''}>
+          </td>
+          <td class="batch-subrow-label" data-card-name="${escapeHtml(card.name)}">${b.copyCount} ${b.copyCount === 1 ? 'copy' : 'copies'} — ${b.isPool ? 'pool' : 'core'}</td>${copiesCell(b.copyCount)}
+          <td><div class="stripe-indicators">${stripeHtml(b.stripes)}</div></td>
+        </tr>
+      `;
+    }).join('');
   }).join('');
+
+  // Batch expand/collapse + derived parent checkbox states
+  state.elements.resultsTbody.querySelectorAll('.batch-toggle').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const name = btn.dataset.cardName;
+      if (expandedCards.has(name)) expandedCards.delete(name);
+      else expandedCards.add(name);
+      renderResults();
+    });
+  });
+  state.elements.resultsTbody.querySelectorAll('.batch-parent-check[data-indeterminate="1"]').forEach(cb => {
+    cb.indeterminate = true;
+  });
 
   // Add event listeners for checkboxes
   state.elements.resultsTbody.querySelectorAll('.mark-checkbox').forEach(checkbox => {
@@ -401,7 +493,7 @@ export function renderResults() {
     clearAllBtn.addEventListener('click', handleClearAllRemoved);
   }
 
-  const colspan = filter === 'basics-by-deck' ? 4 : 3;
+  const colspan = 4;
 
   // Handle empty states
   if (displayCards.length === 0) {
@@ -426,7 +518,7 @@ export function renderResults() {
   // Prefetch card images for visible cards (first 20 to avoid rate limiting)
   const cardNames = displayCards
     .slice(0, 20)
-    .map(c => c.isBasicByDeck ? c.displayName : c.name)
+    .map(c => c.isPassRow ? c.displayName : c.name)
     .filter(Boolean);
   if (cardNames.length > 0) {
     prefetchCards(cardNames).catch(() => {
@@ -467,11 +559,12 @@ function sortCards(cards, column, direction) {
         }
         break;
       case 'marked': {
-        const aKey = a.isBasicByDeck ? `${a.displayName}|${a.deckName}` : a.name;
-        const bKey = b.isBasicByDeck ? `${b.displayName}|${b.deckName}` : b.name;
-        const aMarked = markedSet.has(aKey) ? 1 : 0;
-        const bMarked = markedSet.has(bKey) ? 1 : 0;
-        comparison = aMarked - bMarked;
+        // Card rows classify through isCardDone (batch-aware); pass rows keep
+        // their key equality.
+        const doneOf = (c) => c.isPassRow
+          ? (markedSet.has(`${c.displayName}|${c.deckName}`) ? 1 : 0)
+          : (isCardDone(c, markedSet) ? 1 : 0);
+        comparison = doneOf(a) - doneOf(b);
         if (comparison === 0) {
           comparison = a.name.localeCompare(b.name);
         }
@@ -494,7 +587,7 @@ function renderResultsHeader() {
   if (!thead) return;
 
   const filter = state.elements.resultsFilter?.value || 'all';
-  const showCopies = filter === 'basics-by-deck';
+  const showCopies = true; // Copies column always present; cells are empty at qty 1 (#149)
   const isRemovedFilter = filter === 'removed';
 
   const getSortIcon = (column) => {

--- a/js/features/results.js
+++ b/js/features/results.js
@@ -316,12 +316,14 @@ export function renderResults() {
   const showNums = numbersMode !== 'none';
   const totalDecks = state.currentPrism?.decks?.length || 0;
 
-  // All used positions, for the show-all-slots ruler
+  // All used positions, for the show-all-slots ruler. Dot-style split variants
+  // have stripePosition === null (they share the group's Side A slot), so drop
+  // nulls before building the ruler — same as generatePrintableGuide.
   const allPositions = showAllSlots && totalDecks > 0
     ? [...new Set([
         ...state.currentPrism.decks.map(d => d.stripePosition),
         ...(state.currentPrism.splitGroups || []).map(g => g.sideAPosition)
-      ])].sort((a, b) => a - b)
+      ])].filter(p => p != null).sort((a, b) => a - b)
     : null;
 
   // Render a stripe-indicator strip for any stripe set (card row or batch row).
@@ -448,12 +450,14 @@ export function renderResults() {
 
     return parentRow + batches.map(b => {
       const marked = markedSetForRows.has(b.key);
+      // Two batches can share a copy count, so the class disambiguates the label.
+      const batchClass = b.isDedicated ? 'dedicated' : (b.isPool ? 'pool' : 'core');
       return `
         <tr class="batch-subrow ${marked ? 'marked-row' : ''}" data-card-key="${escapeHtml(b.key)}">
           <td style="text-align: center;">
-            <input type="checkbox" class="mark-checkbox" aria-label="Mark ${b.copyCount} ${escapeHtml(card.name)} copies done" ${marked ? 'checked' : ''}>
+            <input type="checkbox" class="mark-checkbox" aria-label="Mark ${b.copyCount} ${batchClass} ${escapeHtml(card.name)} copies done" ${marked ? 'checked' : ''}>
           </td>
-          <td class="batch-subrow-label" data-card-name="${escapeHtml(card.name)}">${b.copyCount} ${b.copyCount === 1 ? 'copy' : 'copies'} — ${b.isDedicated ? 'dedicated' : (b.isPool ? 'pool' : 'core')}</td>${copiesCell(b.copyCount)}
+          <td class="batch-subrow-label" data-card-name="${escapeHtml(card.name)}">${b.copyCount} ${b.copyCount === 1 ? 'copy' : 'copies'} — ${batchClass}</td>${copiesCell(b.copyCount)}
           <td><div class="stripe-indicators">${stripeHtml(b.stripes)}</div></td>
         </tr>
       `;

--- a/js/features/scry-mode.js
+++ b/js/features/scry-mode.js
@@ -13,7 +13,8 @@ let scrySnapshot = [];
 let scryIndex = 0;
 
 function getScryCardKey(card) {
-  return card.isBasicByDeck ? `${card.displayName}|${card.deckName}` : card.name;
+  if (card.batchKey) return card.batchKey; // one screen per batch (#149/#151)
+  return card.isPassRow ? `${card.displayName}|${card.deckName}` : card.name;
 }
 
 function computeScale() {
@@ -53,8 +54,12 @@ async function renderCurrentScryCard() {
   }
 
   const card = scrySnapshot[scryIndex];
-  const displayName = card.isBasicByDeck ? card.displayName : card.name;
-  scryProgress.textContent = `${scryIndex + 1} / ${scrySnapshot.length} — ${displayName}`;
+  const displayName = card.isPassRow ? card.displayName : card.name;
+  // Each screen states its quantity — "mark 2 copies" — rather than implying
+  // one copy per card (#149). Pass rows and batch screens both carry one.
+  const copies = card.copyCount || card.totalQuantity || 1;
+  const copiesNote = copies > 1 ? ` — mark ${copies} copies` : '';
+  scryProgress.textContent = `${scryIndex + 1} / ${scrySnapshot.length} — ${displayName}${copiesNote}`;
 
   const scale = computeScale();
   scryContent.innerHTML = '';
@@ -68,7 +73,7 @@ async function renderCurrentScryCard() {
   const capturedIndex = scryIndex;
 
   try {
-    const cardName = card.isBasicByDeck ? card.displayName : card.name;
+    const cardName = card.isPassRow ? card.displayName : card.name;
     const stripes = card.stripes || [];
     const el = await buildCardWithStripes(cardName, stripes);
 
@@ -79,7 +84,7 @@ async function renderCurrentScryCard() {
     inner.appendChild(el);
     scryContent.appendChild(outer);
   } catch (err) {
-    console.warn(`SCRY: failed to load card image for "${card.isBasicByDeck ? card.displayName : card.name}":`, err);
+    console.warn(`SCRY: failed to load card image for "${card.isPassRow ? card.displayName : card.name}":`, err);
     if (scryIndex !== capturedIndex) return;
 
     scryContent.innerHTML = '';
@@ -91,7 +96,7 @@ async function renderCurrentScryCard() {
   // Prefetch next few cards so advance is snappy
   const nextNames = scrySnapshot
     .slice(scryIndex + 1, scryIndex + 4)
-    .map(c => c.isBasicByDeck ? c.displayName : c.name)
+    .map(c => c.isPassRow ? c.displayName : c.name)
     .filter(Boolean);
   if (nextNames.length > 0) prefetchCards(nextNames).catch(() => {});
 }

--- a/js/features/scry-mode.js
+++ b/js/features/scry-mode.js
@@ -73,9 +73,8 @@ async function renderCurrentScryCard() {
   const capturedIndex = scryIndex;
 
   try {
-    const cardName = card.isPassRow ? card.displayName : card.name;
     const stripes = card.stripes || [];
-    const el = await buildCardWithStripes(cardName, stripes);
+    const el = await buildCardWithStripes(displayName, stripes);
 
     if (scryIndex !== capturedIndex) return;
 
@@ -84,7 +83,7 @@ async function renderCurrentScryCard() {
     inner.appendChild(el);
     scryContent.appendChild(outer);
   } catch (err) {
-    console.warn(`SCRY: failed to load card image for "${card.isPassRow ? card.displayName : card.name}":`, err);
+    console.warn(`SCRY: failed to load card image for "${displayName}":`, err);
     if (scryIndex !== capturedIndex) return;
 
     scryContent.innerHTML = '';

--- a/js/modules/archidekt.js
+++ b/js/modules/archidekt.js
@@ -52,7 +52,6 @@ export async function fetchArchidektDeck(deckId) {
  */
 export function transformArchidektDeck(archidektDeck) {
   const cards = [];
-  let commander = null;
 
   // Process cards from the deck
   if (archidektDeck.cards && Array.isArray(archidektDeck.cards)) {
@@ -61,15 +60,12 @@ export function transformArchidektDeck(archidektDeck) {
       const quantity = cardEntry.quantity || 1;
       const categories = cardEntry.categories || [];
 
-      // Check if commander
+      // Exact `Commander` category only (#148): loose substring matching
+      // flagged user-authored categories like "Commander Damage" or
+      // "Partner Package" and produced false commander flags.
       const isCommander = categories.some(cat =>
-        cat.toLowerCase().includes('commander') ||
-        cat.toLowerCase().includes('partner')
+        cat.trim().toLowerCase() === 'commander'
       );
-
-      if (isCommander && !commander) {
-        commander = card.oracleCard?.name || card.name;
-      }
 
       const isBasicLand = isBasicLandCard(card);
 
@@ -84,7 +80,6 @@ export function transformArchidektDeck(archidektDeck) {
 
   return {
     name: archidektDeck.name || 'Imported Deck',
-    commander,
     format: archidektDeck.format?.name || 'commander',
     cards,
     source: 'archidekt',

--- a/js/modules/export.js
+++ b/js/modules/export.js
@@ -524,22 +524,23 @@ export function generatePrintableGuide(prism) {
   // Add card rows. Multi-batch cards print one row per batch — the union of a
   // card's marks on paper is the same over-marking trap #149 closed on screen.
   for (const card of processedCards) {
-    const rowClass = card.logicalDeckCount > 1 ? 'shared' : '';
     const nameClass = card.isBasicLand ? 'basic-land' : '';
     const basicTag = card.isBasicLand ? ' (Basic)' : '';
     const batches = card.batches || [];
 
     if (batches.length > 1) {
+      // Pool/core is a per-batch property (#146), so each printed row is shaded
+      // by its own batch — not by the card's overall logical deck count.
       for (const b of batches) {
         html += `
-      <tr class="${rowClass}">
+      <tr class="${b.isPool ? 'shared' : ''}">
         <td class="${nameClass}">${escapeHtml(card.name)}${basicTag} — ${b.copyCount} ${b.copyCount === 1 ? 'copy' : 'copies'}</td>
         <td><div class="stripe-indicator">${stripeStripHtml(b.stripes)}</div></td>
       </tr>`;
       }
     } else {
       html += `
-      <tr class="${rowClass}">
+      <tr class="${card.logicalDeckCount > 1 ? 'shared' : ''}">
         <td class="${nameClass}">${escapeHtml(card.name)}${basicTag}</td>
         <td><div class="stripe-indicator">${stripeStripHtml(card.stripes)}</div></td>
       </tr>`;

--- a/js/modules/export.js
+++ b/js/modules/export.js
@@ -3,7 +3,7 @@
  * Handles CSV and JSON export generation
  */
 
-import { processCards, getColorName, formatSlotLabel } from './processor.js';
+import { processCards, getColorName, formatSlotLabel, commanderNames } from './processor.js';
 import { stripeNumberLabel, countVisibleMarks, STRIPE_SPARSE_MAX, escapeHtml, isCardDone } from '../core/utils.js';
 import { getPreferences, getStripeNumbersMode } from './storage.js';
 
@@ -155,7 +155,8 @@ export function exportToJSON(prism) {
       decks: prism.decks.map(deck => ({
         id: deck.id,
         name: deck.name,
-        commander: deck.commander,
+        // Derived at export time so existing backup consumers keep reading a string
+        commander: commanderNames(deck).join(' / '),
         bracket: deck.bracket,
         color: deck.color,
         colorName: getColorName(deck.color),

--- a/js/modules/export.js
+++ b/js/modules/export.js
@@ -187,6 +187,7 @@ export function exportToJSON(prism) {
       })),
       markedCards: prism.markedCards || [],
       removedCards: prism.removedCards || [],
+      useDedicatedCommanderCopies: prism.useDedicatedCommanderCopies || false,
       statistics: {
         totalUniqueCards: processedCards.length,
         sharedCards: processedCards.filter(c => c.logicalDeckCount > 1).length,

--- a/js/modules/export.js
+++ b/js/modules/export.js
@@ -486,23 +486,20 @@ export function generatePrintableGuide(prism) {
     ...splitGroups.map(g => g.sideAPosition)
   ])].filter(p => p != null).sort((a, b) => a - b);
 
-  // Add card rows
-  for (const card of processedCards) {
-    const rowClass = card.logicalDeckCount > 1 ? 'shared' : '';
-    const nameClass = card.isBasicLand ? 'basic-land' : '';
-
+  // Render one stripe strip for a mark set (whole card or one batch).
+  const stripeStripHtml = (stripes) => {
     // Non-dot stripes by position
-    const stripeMap = new Map(card.stripes.filter(s => s.markType !== 'dot' && s.markType !== 'membership').map(s => [s.position, s]));
+    const stripeMap = new Map(stripes.filter(s => s.markType !== 'dot' && s.markType !== 'membership').map(s => [s.position, s]));
     // Dots grouped by position
     const dotsByPos = new Map();
-    for (const s of card.stripes.filter(s => s.markType === 'dot')) {
+    for (const s of stripes.filter(s => s.markType === 'dot')) {
       if (!dotsByPos.has(s.position)) dotsByPos.set(s.position, []);
       dotsByPos.get(s.position).push(s);
     }
 
     // Sparse cards number every mark with its exact slot; only the card's own
     // marked positions get the exact treatment (empty reference slots don't).
-    const cardIsSparse = numbersMode === 'all' || countVisibleMarks(card.stripes) <= STRIPE_SPARSE_MAX;
+    const cardIsSparse = numbersMode === 'all' || countVisibleMarks(stripes) <= STRIPE_SPARSE_MAX;
 
     let stripeIndicators = '';
     for (const pos of allPositions) {
@@ -521,12 +518,32 @@ export function generatePrintableGuide(prism) {
       const isCardMark = !!stripe || dots.length > 0;
       stripeIndicators += `<div class="stripe-slot">${dotRow}${squareHtml}${posNum(pos, cardIsSparse && isCardMark)}</div>`;
     }
+    return stripeIndicators;
+  };
 
-    html += `
+  // Add card rows. Multi-batch cards print one row per batch — the union of a
+  // card's marks on paper is the same over-marking trap #149 closed on screen.
+  for (const card of processedCards) {
+    const rowClass = card.logicalDeckCount > 1 ? 'shared' : '';
+    const nameClass = card.isBasicLand ? 'basic-land' : '';
+    const basicTag = card.isBasicLand ? ' (Basic)' : '';
+    const batches = card.batches || [];
+
+    if (batches.length > 1) {
+      for (const b of batches) {
+        html += `
       <tr class="${rowClass}">
-        <td class="${nameClass}">${escapeHtml(card.name)}${card.isBasicLand ? ' (Basic)' : ''}</td>
-        <td><div class="stripe-indicator">${stripeIndicators}</div></td>
+        <td class="${nameClass}">${escapeHtml(card.name)}${basicTag} — ${b.copyCount} ${b.copyCount === 1 ? 'copy' : 'copies'}</td>
+        <td><div class="stripe-indicator">${stripeStripHtml(b.stripes)}</div></td>
       </tr>`;
+      }
+    } else {
+      html += `
+      <tr class="${rowClass}">
+        <td class="${nameClass}">${escapeHtml(card.name)}${basicTag}</td>
+        <td><div class="stripe-indicator">${stripeStripHtml(card.stripes)}</div></td>
+      </tr>`;
+    }
   }
 
   html += `
@@ -567,11 +584,18 @@ export function exportUndoneTxt(prism) {
   const processedCards = processCards(prism);
   const markedSet = new Set(prism.markedCards || []);
 
-  // isCardDone also honours per-deck basic marks ("Name|DeckName" keys from
-  // the Basics-by-Deck view) so fully-marked basics drop off the undone list.
-  const lines = processedCards
-    .filter(card => !isCardDone(card, markedSet))
-    .map(card => `${card.totalQuantity} ${card.name}`);
+  // Batch-aware (#151): emit the sum of the UNDONE batch quantities — "5
+  // Forest", not "8 Forest" — so nobody re-pulls copies they already marked.
+  // isCardDone also honours pass keys so fully-marked cards drop off entirely.
+  const lines = [];
+  for (const card of processedCards) {
+    if (isCardDone(card, markedSet)) continue;
+    const batches = card.batches || [];
+    const undoneQty = batches.length > 1
+      ? batches.reduce((s, b) => s + (markedSet.has(b.key) ? 0 : b.copyCount), 0)
+      : card.totalQuantity;
+    if (undoneQty > 0) lines.push(`${undoneQty} ${card.name}`);
+  }
 
   return lines.join('\n');
 }

--- a/js/modules/moxfield.js
+++ b/js/modules/moxfield.js
@@ -3,6 +3,8 @@
  * Handles importing decks from Moxfield URLs
  */
 
+import { cardsToDecklistText } from './parser.js';
+
 /**
  * Extract deck ID from a Moxfield URL or raw ID
  * @param {string} input - Moxfield URL or deck ID
@@ -52,15 +54,10 @@ export async function fetchMoxfieldDeck(publicId) {
  */
 export function transformMoxfieldDeck(moxfieldDeck) {
   const cards = [];
-  let commander = null;
 
-  // Process commanders first
+  // Process commanders first — every command-zone card keeps its flag (#148)
   if (moxfieldDeck.boards?.commanders?.cards) {
     for (const cardData of Object.values(moxfieldDeck.boards.commanders.cards)) {
-      // Use first commander as the deck's commander
-      if (!commander) {
-        commander = cardData.card.name;
-      }
       cards.push({
         name: cardData.card.name,
         quantity: cardData.quantity || 1,
@@ -99,7 +96,6 @@ export function transformMoxfieldDeck(moxfieldDeck) {
 
   return {
     name: moxfieldDeck.name || 'Imported Deck',
-    commander,
     format: moxfieldDeck.format || 'commander',
     cards,
     source: 'moxfield',
@@ -148,12 +144,11 @@ export async function importFromMoxfield(urlOrId) {
 }
 
 /**
- * Convert PRISM deck data to decklist text format
+ * Convert PRISM deck data to decklist text format with Commander/Deck
+ * sections so commander flags survive the textarea round-trip (#147).
  * @param {Object} deckData - Transformed deck data
  * @returns {string} Decklist in text format
  */
 export function toDecklistText(deckData) {
-  return deckData.cards
-    .map(card => `${card.quantity} ${card.name}`)
-    .join('\n');
+  return cardsToDecklistText(deckData.cards);
 }

--- a/js/modules/parser.js
+++ b/js/modules/parser.js
@@ -68,16 +68,18 @@ export function parseLine(line) {
  *   Commander
  *   commander card
  * Only includes cards from maindeck and commander sections.
+ * Cards under a `Commander` header are flagged isCommander (unbounded count) —
+ * the parsed text is the sole commander authority (#147).
  * @param {string} decklist - The full decklist text
- * @param {string} commanderName - The commander's name for flagging
- * @returns {Object} Result with cards array and any errors
+ * @returns {Object} Result with cards array, errors, and excludedLines
+ *   (verbatim lines of non-included sections, headers included, so rewrites
+ *   can preserve sideboard/maybeboard text)
  */
-export function parseDecklist(decklist, commanderName = '') {
+export function parseDecklist(decklist) {
   const lines = decklist.split('\n');
   const cards = [];
   const errors = [];
-
-  const normalizedCommander = commanderName.toLowerCase().trim();
+  const excludedLines = [];
 
   // Track which section we're in: 'main', 'sideboard', 'commander', 'companion', 'maybeboard'
   let currentSection = 'main';
@@ -93,6 +95,7 @@ export function parseDecklist(decklist, commanderName = '') {
     // Check for section headers
     if (upperLine.startsWith('SIDEBOARD') || upperLine === 'SB:' || upperLine.startsWith('SB:')) {
       currentSection = 'sideboard';
+      excludedLines.push(trimmedLine);
       continue;
     }
     if (upperLine.startsWith('COMMANDER')) {
@@ -105,6 +108,7 @@ export function parseDecklist(decklist, commanderName = '') {
     }
     if (upperLine.startsWith('MAYBEBOARD') || upperLine.startsWith('CONSIDERING')) {
       currentSection = 'maybeboard';
+      excludedLines.push(trimmedLine);
       continue;
     }
     if (upperLine.startsWith('DECK') || upperLine === 'MAINBOARD' || upperLine === 'MAINBOARD:') {
@@ -112,8 +116,10 @@ export function parseDecklist(decklist, commanderName = '') {
       continue;
     }
 
-    // Skip cards in sections we don't want
+    // Keep cards from sections we don't want out of the deck, but preserve
+    // their text verbatim so a rewrite can re-emit them.
     if (!includeSections.has(currentSection)) {
+      if (trimmedLine) excludedLines.push(trimmedLine);
       continue;
     }
 
@@ -132,10 +138,8 @@ export function parseDecklist(decklist, commanderName = '') {
       continue;
     }
 
-    // Flag if this is the commander (either by name match or by being in commander section)
+    // Flag if this card is in the commander section
     if (currentSection === 'commander') {
-      result.isCommander = true;
-    } else if (normalizedCommander && result.name.toLowerCase().trim() === normalizedCommander) {
       result.isCommander = true;
     }
 
@@ -156,9 +160,70 @@ export function parseDecklist(decklist, commanderName = '') {
   return {
     cards,
     errors,
+    excludedLines,
     totalCards: cards.reduce((sum, card) => sum + card.quantity, 0),
     uniqueCards: cards.length
   };
+}
+
+/**
+ * Serialize cards to decklist text with a Commander/Deck section structure.
+ * The Commander section is the lossless carrier for N commander flags (#147);
+ * it is omitted when no card is flagged.
+ * @param {Array} cards - Card objects ({ name, quantity, isCommander })
+ * @returns {string}
+ */
+export function cardsToDecklistText(cards) {
+  const line = (c) => `${c.quantity} ${c.name}`;
+  const commanders = (cards || []).filter(c => c.isCommander);
+  const rest = (cards || []).filter(c => !c.isCommander);
+  if (commanders.length === 0) return rest.map(line).join('\n');
+  return [
+    'Commander',
+    ...commanders.map(line),
+    '',
+    'Deck',
+    ...rest.map(line)
+  ].join('\n');
+}
+
+/**
+ * Rewrite a decklist's Commander section so the flagged set is exactly
+ * `names` (#147 field→text sync). A name matching an existing line keeps its
+ * quantity and moves into the section, never duplicated; an unmatched name is
+ * added as a qty-1 card; every other card is unflagged. Unparseable lines and
+ * excluded-section blocks (sideboard/maybeboard) are re-emitted verbatim.
+ * ponytail: comments and formatting are normalized away — same as the Edit
+ * re-open flatten has always done; preserve-in-place line surgery if it hurts.
+ * @param {string} text - Current decklist text
+ * @param {string[]} names - Commander names (order preserved in the section)
+ * @returns {string}
+ */
+export function rewriteDecklistCommanders(text, names) {
+  const parsed = parseDecklist(text);
+  const wanted = names.map(n => n.trim()).filter(Boolean);
+  const cards = parsed.cards.map(c => ({ ...c, isCommander: false }));
+
+  const commanders = [];
+  for (const name of wanted) {
+    const norm = normalizeCardName(name);
+    const idx = cards.findIndex(c => normalizeCardName(c.name) === norm);
+    if (idx >= 0) {
+      const [hit] = cards.splice(idx, 1);
+      commanders.push({ ...hit, isCommander: true });
+    } else {
+      commanders.push({ name, quantity: 1, isCommander: true, isBasicLand: isBasicLand(name) });
+    }
+  }
+
+  const parts = [cardsToDecklistText([...commanders, ...cards])];
+  if (parsed.errors.length > 0) {
+    parts.push(parsed.errors.map(e => e.content).join('\n'));
+  }
+  if (parsed.excludedLines.length > 0) {
+    parts.push(parsed.excludedLines.join('\n'));
+  }
+  return parts.join('\n\n');
 }
 
 /**

--- a/js/modules/parser.js
+++ b/js/modules/parser.js
@@ -178,13 +178,9 @@ export function cardsToDecklistText(cards) {
   const commanders = (cards || []).filter(c => c.isCommander);
   const rest = (cards || []).filter(c => !c.isCommander);
   if (commanders.length === 0) return rest.map(line).join('\n');
-  return [
-    'Commander',
-    ...commanders.map(line),
-    '',
-    'Deck',
-    ...rest.map(line)
-  ].join('\n');
+  const head = ['Commander', ...commanders.map(line)];
+  if (rest.length === 0) return head.join('\n');
+  return [...head, '', 'Deck', ...rest.map(line)].join('\n');
 }
 
 /**

--- a/js/modules/prism-import.js
+++ b/js/modules/prism-import.js
@@ -4,7 +4,7 @@
  * page's Restore from backup dialog (imports as a new PRISM).
  */
 
-import { createPrism, createDeck } from './processor.js';
+import { createPrism, createDeck, applyCommanderFallback } from './processor.js';
 
 /**
  * Validate and construct a PRISM object from parsed backup JSON.
@@ -52,7 +52,6 @@ export function buildPrismFromJson(jsonData, { preserveId = true } = {}) {
     const newDeck = createDeck({
       id: deck.id,
       name: deck.name,
-      commander: deck.commander,
       bracket: deck.bracket,
       color: validHex(deck.color),
       stripePosition: deck.stripePosition,
@@ -62,6 +61,8 @@ export function buildPrismFromJson(jsonData, { preserveId = true } = {}) {
       updatedAt: deck.updatedAt,
       cardsUpdatedAt: deck.cardsUpdatedAt
     });
+    // Backup flags win; a pre-#147 backup's commander scalar is the fallback
+    applyCommanderFallback(newDeck, deck.commander);
     newPrism.decks.push(newDeck);
   }
 

--- a/js/modules/prism-import.js
+++ b/js/modules/prism-import.js
@@ -39,6 +39,9 @@ export function buildPrismFromJson(jsonData, { preserveId = true } = {}) {
   newPrism.createdAt = prismData.createdAt || newPrism.createdAt;
   newPrism.updatedAt = new Date().toISOString();
   newPrism.markedCards = prismData.markedCards || [];
+  // Timestamp stays createPrism()'s `now`: restore is a user act happening
+  // now, so the restored value wins the next cloud merge (#145).
+  newPrism.useDedicatedCommanderCopies = prismData.useDedicatedCommanderCopies || false;
   newPrism.removedCards = (prismData.removedCards || []).map(removed => ({
     ...removed,
     deckColor: validHex(removed.deckColor),

--- a/js/modules/processor.js
+++ b/js/modules/processor.js
@@ -94,7 +94,6 @@ export function generateId() {
  */
 export function createDeck({
 	name,
-	commander,
 	bracket,
 	color,
 	stripePosition,
@@ -109,7 +108,6 @@ export function createDeck({
 	return {
 		id: id || generateId(),
 		name,
-		commander,
 		bracket: parseInt(bracket, 10),
 		color: color.toUpperCase(),
 		stripePosition,
@@ -119,6 +117,40 @@ export function createDeck({
 		updatedAt: updatedAt || now,
 		cardsUpdatedAt: cardsUpdatedAt || createdAt || now,
 	};
+}
+
+/**
+ * Derive a deck's commander names from its card flags — the only commander
+ * source of truth (#147). Alphabetical so the label is stable across syncs
+ * (deck_cards has no ORDER BY; paste order does not survive a round-trip).
+ * @param {Object} deck
+ * @returns {string[]}
+ */
+export function commanderNames(deck) {
+	return (deck.cards || []).filter(c => c.isCommander).map(c => c.name).sort();
+}
+
+/**
+ * One-time normalization for decks that carry only the legacy commander
+ * scalar (form-added, typed name absent from the pasted list). Flags the
+ * matching card, or inserts the name as a qty-1 card. No-op when any flag
+ * already exists, so it is idempotent across loads.
+ * @param {Object} deck - Deck object (mutated)
+ * @param {string|null} commanderName - Legacy scalar (or backup fallback)
+ * @returns {boolean} Whether the deck changed
+ */
+export function applyCommanderFallback(deck, commanderName) {
+	if (!commanderName) return false;
+	const cards = deck.cards || [];
+	if (cards.some(c => c.isCommander)) return false;
+	const norm = normalizeCardName(commanderName);
+	const hit = cards.find(c => normalizeCardName(c.name) === norm);
+	if (hit) {
+		hit.isCommander = true;
+	} else {
+		cards.unshift({ name: commanderName, quantity: 1, isCommander: true, isBasicLand: false });
+	}
+	return true;
 }
 
 /**
@@ -907,7 +939,6 @@ export function splitDeck(prism, deckId, splitCount, splitStyle = 'stripes') {
 				const childColor = getNextColor(tempPrism);
 				const child = createDeck({
 					name: `${deck.name} (${i})`,
-					commander: deck.commander,
 					bracket: deck.bracket,
 					color: childColor,
 					stripePosition: childPosition,
@@ -975,7 +1006,6 @@ export function addSplitToGroup(prism, groupId) {
 
 	const newChild = createDeck({
 		name: `${group.name} (${splitNumber})`,
-		commander: templateDeck.commander,
 		bracket: templateDeck.bracket,
 		color: childColor,
 		stripePosition: childPosition,

--- a/js/modules/processor.js
+++ b/js/modules/processor.js
@@ -140,7 +140,9 @@ export function commanderNames(deck) {
  * @returns {boolean} Whether the deck changed
  */
 export function applyCommanderFallback(deck, commanderName) {
-	if (!commanderName) return false;
+	// Type-check, not just truthiness: the scalar can come from an untrusted
+	// backup file, where a number/object would throw inside normalizeCardName.
+	if (typeof commanderName !== 'string' || !commanderName) return false;
 	const cards = deck.cards || [];
 	if (cards.some(c => c.isCommander)) return false;
 	const norm = normalizeCardName(commanderName);

--- a/js/modules/processor.js
+++ b/js/modules/processor.js
@@ -289,6 +289,7 @@ export function processCards(prism) {
 					stripes: [],
 					sideAGroups: new Set(), // Track which split groups already have a Side A stripe
 					deckIds: new Set(), // Track unique deck IDs for deckCount
+					commanderDeckIds: new Set(), // Decks where this card is isCommander-flagged (#150)
 				});
 			}
 
@@ -297,6 +298,7 @@ export function processCards(prism) {
 			// Track quantity per deck (for basics)
 			cardData.quantities.set(deck.id, card.quantity);
 			cardData.deckIds.add(deck.id);
+			if (card.isCommander) cardData.commanderDeckIds.add(deck.id);
 
 			if (group) {
 				// Split deck: add Side A stripe (deduplicated per group)
@@ -419,11 +421,6 @@ export function processCards(prism) {
 	const processedCards = [];
 
 	for (const [normalizedName, cardData] of cardMap) {
-		// Calculate total quantity needed: max across decks. For singleton cards
-		// every quantity is 1, so this stays 1; basics and "any number" cards
-		// (Rat Colony, Shadowborn Apostle, …) report the real sleeve count.
-		const totalQuantity = Math.max(1, ...[...cardData.quantities.values()].map(q => q || 1));
-
 		// Sort stripes: Side A first (by position), then Side B (by position)
 		const sortedStripes = cardData.stripes.sort((a, b) => {
 			if (a.side !== b.side) return a.side === "a" ? -1 : 1;
@@ -447,12 +444,51 @@ export function processCards(prism) {
 		// quantities ascending; each batch is the gap to the previous threshold
 		// with everyone at >= that tier participating. Participant sets strictly
 		// shrink as tiers rise, so Σ copyCount === totalQuantity.
-		const parts = [...cardData.quantities.entries()].map(([deckId, qty]) => ({
+		let parts = [...cardData.quantities.entries()].map(([deckId, qty]) => ({
 			deckId,
 			qty: qty || 1,
 		}));
-		const tiers = [...new Set(parts.map((p) => p.qty))].sort((a, b) => a - b);
 		const batches = [];
+
+		// Dedicated commander copies (#150): one rule per (commander card,
+		// logical deck) — emit a dedicated batch at the logical deck's full
+		// quantity carrying its normal marks, and REMOVE that logical deck from
+		// the remaining threshold derivation (replace, not add on top: a
+		// commander with no other home still costs exactly one copy). A group
+		// dedicates when the card is flagged in at least one child variant, and
+		// emits ONE batch for the whole group, never one per variant.
+		if (prism.useDedicatedCommanderCopies && cardData.commanderDeckIds.size > 0) {
+			const logicalIdOf = (deckId) => {
+				const deck = decks.find((d) => d.id === deckId);
+				return (deck?.splitGroupId && groupMap.has(deck.splitGroupId)) ? deck.splitGroupId : deckId;
+			};
+			const byLogical = new Map(); // logicalId -> parts[]
+			for (const p of parts) {
+				const lid = logicalIdOf(p.deckId);
+				if (!byLogical.has(lid)) byLogical.set(lid, []);
+				byLogical.get(lid).push(p);
+			}
+			const dedicatedDeckIds = new Set();
+			for (const [, logicalParts] of byLogical) {
+				const flagged = logicalParts.some((p) => cardData.commanderDeckIds.has(p.deckId));
+				if (!flagged) continue;
+				const participantIds = logicalParts.map((p) => p.deckId).sort();
+				const copyCount = Math.max(...logicalParts.map((p) => p.qty));
+				batches.push({
+					copyCount,
+					participantIds,
+					key: `${cardData.name}|#b|${participantIds.join(",")}|${copyCount}`,
+					logicalDeckCount: 1, // dedicated batches are core by construction
+					isPool: false,
+					isDedicated: true,
+					stripes: marksForParticipants(decks, splitGroups, new Set(participantIds), cardData.quantities),
+				});
+				logicalParts.forEach((p) => dedicatedDeckIds.add(p.deckId));
+			}
+			parts = parts.filter((p) => !dedicatedDeckIds.has(p.deckId));
+		}
+
+		const tiers = [...new Set(parts.map((p) => p.qty))].sort((a, b) => a - b);
 		let prevTier = 0;
 		for (const tier of tiers) {
 			const participantIds = parts
@@ -476,6 +512,12 @@ export function processCards(prism) {
 			});
 			prevTier = tier;
 		}
+
+		// Physical total (#146 as amended by #150): the sum of batch quantities —
+		// dedicated batches plus the maximum across the remaining participants.
+		// With dedication off this equals the plain max across decks. Singleton
+		// cards stay 1; basics and "any number" cards report the real count.
+		const totalQuantity = Math.max(1, batches.reduce((s, b) => s + b.copyCount, 0));
 
 		processedCards.push({
 			name: cardData.name,

--- a/js/modules/processor.js
+++ b/js/modules/processor.js
@@ -135,6 +135,8 @@ export function createPrism(name = "") {
 		splitGroups: [], // Split group definitions for deck variants
 		markedCards: [], // Track which cards have been physically marked
 		markedCardsUpdatedAt: now,
+		useDedicatedCommanderCopies: false, // Synced per-PRISM setting (#145)
+		useDedicatedCommanderCopiesUpdatedAt: now,
 		removedCards: [], // Track cards removed from decks that need marks removed
 		createdAt: now,
 		updatedAt: now,

--- a/js/modules/processor.js
+++ b/js/modules/processor.js
@@ -180,6 +180,88 @@ export function createPrism(name = "") {
  * @param {Object} prism - The PRISM object containing decks
  * @returns {Array} Array of ProcessedCard objects sorted by deck count (descending) then name
  */
+/**
+ * Re-derive the marks for one batch's exact participant set (#146/#149).
+ * Cannot be a filter over the card's processed stripes: processCards decides
+ * shared-vs-subset over the WHOLE split group, so a group at A5/B2 emits no
+ * child indicator at all, while the 5-copy tier (A only) requires one.
+ * Emits the same stripe entry shapes as processCards, including 'membership'
+ * anchors so deck-filtering keeps working on batch rows.
+ * @param {Array} decks - prism.decks
+ * @param {Array} splitGroups - prism.splitGroups
+ * @param {Set} participantIds - deck ids participating in this batch
+ * @param {Map} quantities - deckId -> quantity for this card
+ * @returns {Array} stripes, Side A first then by position
+ */
+function marksForParticipants(decks, splitGroups, participantIds, quantities) {
+	const stripes = [];
+
+	for (const deck of decks) {
+		if (!deck.splitGroupId && participantIds.has(deck.id)) {
+			stripes.push({
+				position: deck.stripePosition,
+				color: deck.color,
+				side: "a",
+				deckName: deck.name,
+				deckId: deck.id,
+				groupId: null,
+				bracket: deck.bracket,
+				quantity: quantities.get(deck.id),
+			});
+		}
+	}
+
+	for (const group of splitGroups) {
+		const variantDecks = group.childDeckIds
+			.map((id) => decks.find((d) => d.id === id))
+			.filter(Boolean);
+		const inBatch = variantDecks.filter((d) => participantIds.has(d.id));
+		if (inBatch.length === 0) continue;
+
+		stripes.push({
+			position: group.sideAPosition,
+			color: group.sideAColor,
+			side: "a",
+			deckName: group.name,
+			deckId: null,
+			groupId: group.id,
+			bracket: null,
+			quantity: null,
+		});
+
+		const isShared = inBatch.length === variantDecks.length;
+		const isDotStyle = (group.splitStyle || "stripes") === "dots";
+		const anchor = (variantDeck, markType, position) => ({
+			position,
+			color: variantDeck.color,
+			side: "b",
+			deckName: variantDeck.name,
+			deckId: variantDeck.id,
+			groupId: group.id,
+			bracket: variantDeck.bracket,
+			quantity: quantities.get(variantDeck.id),
+			markType,
+		});
+
+		if (isShared) {
+			inBatch.forEach((d) => stripes.push(anchor(d, "membership", group.sideAPosition)));
+		} else if (isDotStyle) {
+			if (inBatch.length === 1) {
+				stripes.push(anchor(inBatch[0], "dot", group.sideAPosition));
+			} else {
+				inBatch.forEach((d) => stripes.push(anchor(d, "membership", group.sideAPosition)));
+			}
+		} else {
+			inBatch.forEach((d) => stripes.push(anchor(d, "stripe", d.stripePosition)));
+		}
+	}
+
+	return stripes.sort((a, b) => {
+		if (a.side !== b.side) return a.side === "a" ? -1 : 1;
+		return a.position - b.position;
+	});
+}
+
 export function processCards(prism) {
 	const { decks, splitGroups = [] } = prism;
 
@@ -361,6 +443,40 @@ export function processCards(prism) {
 		}
 		const logicalDeckCount = standaloneIds.size + splitGroupIds.size;
 
+		// Quantity-tier marking batches (#146): thresholds are the distinct
+		// quantities ascending; each batch is the gap to the previous threshold
+		// with everyone at >= that tier participating. Participant sets strictly
+		// shrink as tiers rise, so Σ copyCount === totalQuantity.
+		const parts = [...cardData.quantities.entries()].map(([deckId, qty]) => ({
+			deckId,
+			qty: qty || 1,
+		}));
+		const tiers = [...new Set(parts.map((p) => p.qty))].sort((a, b) => a - b);
+		const batches = [];
+		let prevTier = 0;
+		for (const tier of tiers) {
+			const participantIds = parts
+				.filter((p) => p.qty >= tier)
+				.map((p) => p.deckId)
+				.sort();
+			const logical = new Set(
+				participantIds.map((id) => {
+					const deck = decks.find((d) => d.id === id);
+					return (deck?.splitGroupId && groupMap.has(deck.splitGroupId)) ? deck.splitGroupId : id;
+				}),
+			);
+			const copyCount = tier - prevTier;
+			batches.push({
+				copyCount,
+				participantIds,
+				key: `${cardData.name}|#b|${participantIds.join(",")}|${copyCount}`,
+				logicalDeckCount: logical.size,
+				isPool: logical.size > 1,
+				stripes: marksForParticipants(decks, splitGroups, new Set(participantIds), cardData.quantities),
+			});
+			prevTier = tier;
+		}
+
 		processedCards.push({
 			name: cardData.name,
 			normalizedName,
@@ -369,6 +485,7 @@ export function processCards(prism) {
 			deckCount: cardData.deckIds.size, // Number of actual decks, not stripe count
 			logicalDeckCount, // Standalone decks + split groups (variants of same group = 1)
 			stripes: sortedStripes,
+			batches,
 		});
 	}
 
@@ -781,16 +898,23 @@ export function updateDeckInPrism(prism, deckId, updates) {
  * @returns {Array} Array of removed card names
  */
 export function calculateRemovedCards(oldCards, newCards) {
-	const newCardNames = new Set(newCards.map((c) => normalizeCardName(c.name)));
+	const newByName = new Map(newCards.map((c) => [normalizeCardName(c.name), c]));
 	const removedCards = [];
 
 	for (const card of oldCards) {
 		const normalizedName = normalizeCardName(card.name);
-		if (!newCardNames.has(normalizedName)) {
+		const newCard = newByName.get(normalizedName);
+		const previousQuantity = card.quantity || 1;
+		const newQuantity = newCard ? (newCard.quantity || 1) : 0;
+		// A quantity decrease is a removal of copies; full removal is the
+		// newQuantity === 0 special case (#151).
+		if (newQuantity < previousQuantity) {
 			removedCards.push({
 				name: card.name,
 				normalizedName,
 				isBasicLand: card.isBasicLand,
+				previousQuantity,
+				newQuantity,
 			});
 		}
 	}

--- a/js/modules/storage.js
+++ b/js/modules/storage.js
@@ -327,6 +327,8 @@ function buildPrismFromRow(prism) {
     updatedAt: prism.updated_at,
     markedCards: prism.marked_cards || [],
     markedCardsUpdatedAt: prism.marked_cards_updated_at || null,
+    useDedicatedCommanderCopies: prism.use_dedicated_commander_copies || false,
+    useDedicatedCommanderCopiesUpdatedAt: prism.use_dedicated_commander_copies_updated_at || null,
     removedCards: prism.removed_cards || [],
     splitGroups: (prism.split_groups || []).map(group => ({
       ...group,
@@ -353,7 +355,7 @@ function buildPrismFromRow(prism) {
   };
 }
 
-function mergePrismVersions(localPrism, cloudPrism, prismBaseline) {
+export function mergePrismVersions(localPrism, cloudPrism, prismBaseline) {
   const baseline = prismBaseline || {
     updatedAt: null,
     deckUpdatedAts: {},
@@ -393,6 +395,12 @@ function mergePrismVersions(localPrism, cloudPrism, prismBaseline) {
   const localMCTime = getTimestampMs(localPrism.markedCardsUpdatedAt);
   const cloudMCTime = getTimestampMs(cloudPrism.markedCardsUpdatedAt);
 
+  // Merged on its own timestamp, not via basePrism: prism.updatedAt is bumped
+  // by mark-toggle (high frequency), so whole-prism LWW would silently revert
+  // a toggle made on another device (#145).
+  const localDCTime = getTimestampMs(localPrism.useDedicatedCommanderCopiesUpdatedAt);
+  const cloudDCTime = getTimestampMs(cloudPrism.useDedicatedCommanderCopiesUpdatedAt);
+
   return {
     ...basePrism,
     markedCards: mergeMarkedCards(
@@ -404,6 +412,12 @@ function mergePrismVersions(localPrism, cloudPrism, prismBaseline) {
     markedCardsUpdatedAt: localMCTime >= cloudMCTime
       ? localPrism.markedCardsUpdatedAt
       : cloudPrism.markedCardsUpdatedAt,
+    useDedicatedCommanderCopies: localDCTime >= cloudDCTime
+      ? localPrism.useDedicatedCommanderCopies || false
+      : cloudPrism.useDedicatedCommanderCopies || false,
+    useDedicatedCommanderCopiesUpdatedAt: localDCTime >= cloudDCTime
+      ? localPrism.useDedicatedCommanderCopiesUpdatedAt || null
+      : cloudPrism.useDedicatedCommanderCopiesUpdatedAt || null,
     removedCards: mergeRemovedCards(
       localPrism.removedCards || [],
       cloudPrism.removedCards || []
@@ -422,6 +436,8 @@ const PRISM_SELECT = `
   split_groups,
   marked_cards,
   marked_cards_updated_at,
+  use_dedicated_commander_copies,
+  use_dedicated_commander_copies_updated_at,
   removed_cards,
   created_at,
   updated_at,
@@ -555,6 +571,8 @@ async function savePrismToSupabase(prism) {
         split_groups: prism.splitGroups || [],
         marked_cards: prism.markedCards || [],
         marked_cards_updated_at: prism.markedCardsUpdatedAt || null,
+        use_dedicated_commander_copies: prism.useDedicatedCommanderCopies || false,
+        use_dedicated_commander_copies_updated_at: prism.useDedicatedCommanderCopiesUpdatedAt || null,
         removed_cards: prism.removedCards || [],
         created_at: prism.createdAt || prismUpdatedAt,
         updated_at: prismUpdatedAt

--- a/js/modules/storage.js
+++ b/js/modules/storage.js
@@ -4,6 +4,7 @@
  */
 
 import { DEFAULT_COLORS } from './processor.js';
+import { normalizeCardName } from './parser.js';
 import { getSupabase, isConfigured } from './supabase-client.js';
 import { getCurrentUser } from './auth.js';
 import { showToast } from '../core/notifications.js';
@@ -816,14 +817,14 @@ export function mergeRemovedCards(localArr, cloudArr) {
   // bad row from the cloud or an imported backup must not abort the whole
   // prism merge for the session.
   for (const entry of localArr) {
-    if (!entry?.cardName) continue;
-    const key = `${entry.cardName.toLowerCase()}|${entry.deckId}`;
+    if (typeof entry?.cardName !== 'string' || !entry.cardName) continue;
+    const key = `${normalizeCardName(entry.cardName)}|${entry.deckId}`;
     map.set(key, entry);
   }
 
   for (const entry of cloudArr) {
-    if (!entry?.cardName) continue;
-    const key = `${entry.cardName.toLowerCase()}|${entry.deckId}`;
+    if (typeof entry?.cardName !== 'string' || !entry.cardName) continue;
+    const key = `${normalizeCardName(entry.cardName)}|${entry.deckId}`;
     const existing = map.get(key);
     if (!existing) {
       map.set(key, entry);

--- a/js/modules/storage.js
+++ b/js/modules/storage.js
@@ -809,7 +809,7 @@ function mergeMarkedCards(localArr, cloudArr, unmarkedTombstones, baselineUpdate
  * Merge removedCards arrays via union, deduplicated by (cardName, deckId).
  * When both contain the same entry, keep the one with the later removedAt.
  */
-function mergeRemovedCards(localArr, cloudArr) {
+export function mergeRemovedCards(localArr, cloudArr) {
   const map = new Map();
 
   // Skip malformed entries (missing cardName) instead of throwing — a single
@@ -825,8 +825,15 @@ function mergeRemovedCards(localArr, cloudArr) {
     if (!entry?.cardName) continue;
     const key = `${entry.cardName.toLowerCase()}|${entry.deckId}`;
     const existing = map.get(key);
-    if (!existing || new Date(entry.removedAt) > new Date(existing.removedAt)) {
+    if (!existing) {
       map.set(key, entry);
+    } else {
+      // Latest row wins, but previousQuantity keeps the max of both (#151):
+      // successive edits (5→4→3) and cross-device edits must not collapse to
+      // the last delta and under-report the surplus copies to clear.
+      const newer = new Date(entry.removedAt) > new Date(existing.removedAt) ? entry : existing;
+      const maxPrev = Math.max(entry.previousQuantity || 0, existing.previousQuantity || 0);
+      map.set(key, maxPrev > 0 ? { ...newer, previousQuantity: maxPrev } : newer);
     }
   }
 

--- a/js/modules/storage.js
+++ b/js/modules/storage.js
@@ -341,7 +341,6 @@ function buildPrismFromRow(prism) {
       bracket: deck.bracket,
       stripePosition: deck.stripe_position,
       splitGroupId: deck.split_group_id || null,
-      commander: deck.deck_cards?.find(c => c.is_commander)?.card_name || null,
       createdAt: deck.created_at,
       updatedAt: deck.updated_at,
       cardsUpdatedAt: deck.cards_updated_at || null,

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -231,6 +231,18 @@ BEGIN;
 COMMIT;
 
 -- ============================================
+-- MIGRATION: Add dedicated commander-copy setting (#145)
+-- ============================================
+-- Synced per-PRISM boolean with its own merge timestamp so the setting is
+-- merged independently rather than riding whole-prism last-write-wins.
+-- NOT NULL DEFAULT false backfills existing rows. Safe to re-run (IF NOT EXISTS).
+BEGIN;
+  ALTER TABLE prisms
+    ADD COLUMN IF NOT EXISTS use_dedicated_commander_copies BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS use_dedicated_commander_copies_updated_at TIMESTAMPTZ DEFAULT NULL;
+COMMIT;
+
+-- ============================================
 -- MIGRATION: Remove server-side updated_at triggers
 -- ============================================
 -- The client always supplies updated_at on upsert. A trigger that overwrites

--- a/tests/commander-role.test.js
+++ b/tests/commander-role.test.js
@@ -1,0 +1,131 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+	parseDecklist,
+	cardsToDecklistText,
+	rewriteDecklistCommanders,
+} from '../js/modules/parser.js';
+import {
+	commanderNames,
+	applyCommanderFallback,
+	createDeck,
+} from '../js/modules/processor.js';
+import { transformArchidektDeck } from '../js/modules/archidekt.js';
+
+test('parseDecklist flags every Commander-section line at stated quantity, no name union', () => {
+	const text = [
+		'Commander',
+		'1 Krark, the Thumbless',
+		'2 Sakashima of a Thousand Faces',
+		'',
+		'Deck',
+		'1 Sol Ring',
+		'1 Krark, the Thumbless', // duplicate — merges into the flagged entry
+	].join('\n');
+
+	const result = parseDecklist(text);
+	const flagged = result.cards.filter((c) => c.isCommander);
+	assert.equal(flagged.length, 2);
+	assert.equal(flagged.find((c) => c.name.startsWith('Sakashima')).quantity, 2);
+	assert.equal(result.cards.filter((c) => c.name === 'Sol Ring')[0].isCommander, false);
+	// no second parameter: a name outside the section is never flagged
+	assert.equal(result.cards.length, 3);
+});
+
+test('cardsToDecklistText round-trips N commander flags through parseDecklist', () => {
+	const cards = [
+		{ name: 'Krark, the Thumbless', quantity: 1, isCommander: true, isBasicLand: false },
+		{ name: 'Sakashima of a Thousand Faces', quantity: 1, isCommander: true, isBasicLand: false },
+		{ name: 'Sol Ring', quantity: 1, isCommander: false, isBasicLand: false },
+		{ name: 'Island', quantity: 12, isCommander: false, isBasicLand: true },
+	];
+
+	const reparsed = parseDecklist(cardsToDecklistText(cards));
+	assert.deepEqual(
+		reparsed.cards.filter((c) => c.isCommander).map((c) => c.name).sort(),
+		['Krark, the Thumbless', 'Sakashima of a Thousand Faces']
+	);
+	assert.equal(reparsed.cards.find((c) => c.name === 'Island').quantity, 12);
+	// no flags → no Commander header
+	assert.ok(!cardsToDecklistText(cards.slice(2)).includes('Commander'));
+});
+
+test('rewriteDecklistCommanders: add unmatched, move matched at quantity, unflag others', () => {
+	const text = [
+		'Commander',
+		'1 Old Commander',
+		'',
+		'Deck',
+		'3 Rat Colony',
+		'1 Sol Ring',
+	].join('\n');
+
+	const out = rewriteDecklistCommanders(text, ['Rat Colony', 'Brand New Cmdr']);
+	const reparsed = parseDecklist(out);
+	const flagged = reparsed.cards.filter((c) => c.isCommander);
+
+	assert.deepEqual(flagged.map((c) => c.name).sort(), ['Brand New Cmdr', 'Rat Colony']);
+	assert.equal(flagged.find((c) => c.name === 'Rat Colony').quantity, 3, 'moved at existing quantity');
+	assert.equal(flagged.find((c) => c.name === 'Brand New Cmdr').quantity, 1, 'unmatched added as qty 1');
+	assert.equal(reparsed.cards.find((c) => c.name === 'Old Commander').isCommander, false, 'unflagged');
+	assert.equal(reparsed.cards.filter((c) => c.name === 'Rat Colony').length, 1, 'never duplicated');
+});
+
+test('rewriteDecklistCommanders preserves unparseable lines and sideboard blocks', () => {
+	const text = [
+		'1 Sol Ring',
+		'not a valid line',
+		'Sideboard',
+		'1 Swords to Plowshares',
+	].join('\n');
+
+	const out = rewriteDecklistCommanders(text, ['Sol Ring']);
+	assert.ok(out.includes('not a valid line'), 'error line survives');
+	assert.ok(out.includes('Sideboard'), 'sideboard header survives');
+	assert.ok(out.includes('1 Swords to Plowshares'), 'sideboard card survives');
+	// idempotent: rewriting again changes nothing
+	assert.equal(rewriteDecklistCommanders(out, ['Sol Ring']), out);
+});
+
+test('commanderNames derives alphabetically from flags', () => {
+	const deck = createDeck({
+		name: 'D', bracket: 3, color: '#FF0000', stripePosition: 1,
+		cards: [
+			{ name: 'Zndrsplt, Eye of Wisdom', quantity: 1, isCommander: true, isBasicLand: false },
+			{ name: 'Okaun, Eye of Chaos', quantity: 1, isCommander: true, isBasicLand: false },
+			{ name: 'Sol Ring', quantity: 1, isCommander: false, isBasicLand: false },
+		],
+	});
+	assert.deepEqual(commanderNames(deck), ['Okaun, Eye of Chaos', 'Zndrsplt, Eye of Wisdom']);
+	assert.equal(deck.commander, undefined, 'createDeck no longer stores a scalar');
+});
+
+test('applyCommanderFallback flags a match, inserts a miss, no-ops when flagged', () => {
+	const flagIt = { cards: [{ name: 'Krark, the Thumbless', quantity: 1, isCommander: false, isBasicLand: false }] };
+	assert.equal(applyCommanderFallback(flagIt, 'krark, the thumbless'), true);
+	assert.equal(flagIt.cards[0].isCommander, true);
+
+	const insertIt = { cards: [{ name: 'Sol Ring', quantity: 1, isCommander: false, isBasicLand: false }] };
+	assert.equal(applyCommanderFallback(insertIt, 'Krark, the Thumbless'), true);
+	assert.deepEqual(insertIt.cards[0], { name: 'Krark, the Thumbless', quantity: 1, isCommander: true, isBasicLand: false });
+
+	assert.equal(applyCommanderFallback(insertIt, 'Krark, the Thumbless'), false, 'idempotent');
+	assert.equal(applyCommanderFallback(insertIt, null), false);
+});
+
+test('transformArchidektDeck flags only the exact Commander category', () => {
+	const raw = {
+		id: 1,
+		name: 'Test',
+		cards: [
+			{ card: { name: 'Krark, the Thumbless' }, quantity: 1, categories: ['Commander'] },
+			{ card: { name: 'Fiery Emancipation' }, quantity: 1, categories: ['Commander Damage'] },
+			{ card: { name: 'Sakashima of a Thousand Faces' }, quantity: 1, categories: [' commander '] },
+			{ card: { name: 'Thrasios, Triton Hero' }, quantity: 1, categories: ['Partner Package'] },
+			{ card: { name: 'Sol Ring' }, quantity: 1, categories: ['Non-Commander'] },
+		],
+	};
+	const flagged = transformArchidektDeck(raw).cards.filter((c) => c.isCommander).map((c) => c.name);
+	assert.deepEqual(flagged.sort(), ['Krark, the Thumbless', 'Sakashima of a Thousand Faces']);
+});

--- a/tests/dedicated-batches.test.js
+++ b/tests/dedicated-batches.test.js
@@ -1,0 +1,152 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createPrism, createDeck, createSplitGroup, processCards } from '../js/modules/processor.js';
+
+function card(name, quantity = 1, isCommander = false) {
+	return { name, quantity, isCommander, isBasicLand: false };
+}
+
+function standalone(name, pos, cards) {
+	return createDeck({ name, bracket: 3, color: '#FF0000', stripePosition: pos, cards });
+}
+
+function visible(stripes) {
+	return stripes.filter((s) => s.markType !== 'membership');
+}
+
+function findCard(prism, name) {
+	return processCards(prism).find((c) => c.name === name);
+}
+
+const KRARK = 'Krark, the Thumbless';
+
+test('commander of A, also regular in B and C: dedicated A + shared B+C', () => {
+	const prism = createPrism('T');
+	prism.decks = [
+		standalone('A', 1, [card(KRARK, 1, true)]),
+		standalone('B', 2, [card(KRARK)]),
+		standalone('C', 3, [card(KRARK)]),
+	];
+
+	// off: one shared batch, total 1
+	const off = findCard(prism, KRARK);
+	assert.equal(off.batches.length, 1);
+	assert.equal(off.totalQuantity, 1);
+
+	// on: replace, not add on top
+	prism.useDedicatedCommanderCopies = true;
+	const on = findCard(prism, KRARK);
+	assert.equal(on.batches.length, 2);
+	const [ded, sharedBatch] = on.batches;
+	assert.equal(ded.isDedicated, true);
+	assert.equal(ded.isPool, false);
+	assert.deepEqual(visible(ded.stripes).map((s) => s.deckName), ['A']);
+	assert.equal(sharedBatch.isDedicated, undefined);
+	assert.deepEqual(visible(sharedBatch.stripes).map((s) => s.deckName).sort(), ['B', 'C']);
+	assert.equal(on.totalQuantity, 2);
+	// pool 1 (B+C batch), core 1 (dedicated)
+	assert.equal(on.batches.reduce((s, b) => s + (b.isPool ? b.copyCount : 0), 0), 1);
+});
+
+test('commander of A only: still exactly one copy (replace removes the double-count)', () => {
+	const prism = createPrism('T');
+	prism.decks = [standalone('A', 1, [card(KRARK, 1, true), card('Sol Ring')])];
+	prism.useDedicatedCommanderCopies = true;
+
+	const krark = findCard(prism, KRARK);
+	assert.equal(krark.batches.length, 1);
+	assert.equal(krark.batches[0].isDedicated, true);
+	assert.equal(krark.totalQuantity, 1);
+});
+
+test('commands two standalone decks: two dedicated copies, both core', () => {
+	const prism = createPrism('T');
+	prism.decks = [
+		standalone('A', 1, [card(KRARK, 1, true)]),
+		standalone('B', 2, [card(KRARK, 1, true)]),
+	];
+	prism.useDedicatedCommanderCopies = true;
+
+	const krark = findCard(prism, KRARK);
+	assert.equal(krark.batches.length, 2);
+	assert.ok(krark.batches.every((b) => b.isDedicated && !b.isPool));
+	assert.equal(krark.totalQuantity, 2);
+	// distinct keys, distinct single participants
+	assert.notEqual(krark.batches[0].key, krark.batches[1].key);
+});
+
+function groupPrism({ flagInBoth }) {
+	const prism = createPrism('T');
+	const group = createSplitGroup({ name: 'G', sideAPosition: 1, sideAColor: '#00FF00', splitStyle: 'stripes' });
+	const v1 = createDeck({ name: 'G (1)', bracket: 3, color: '#111111', stripePosition: 48, splitGroupId: group.id, cards: [card(KRARK, 1, true)] });
+	const v2 = createDeck({ name: 'G (2)', bracket: 3, color: '#222222', stripePosition: 47, splitGroupId: group.id, cards: [card(KRARK, 1, flagInBoth)] });
+	group.childDeckIds = [v1.id, v2.id];
+	prism.decks = [v1, v2];
+	prism.splitGroups = [group];
+	prism.useDedicatedCommanderCopies = true;
+	return prism;
+}
+
+test('2-variant group, flagged in both children: ONE dedicated batch, parent marks, total 1', () => {
+	const krark = findCard(groupPrism({ flagInBoth: true }), KRARK);
+	assert.equal(krark.batches.length, 1);
+	const [b] = krark.batches;
+	assert.equal(b.isDedicated, true);
+	assert.equal(b.copyCount, 1);
+	// shared by every child at this quantity → parent Side A mark only
+	assert.deepEqual(visible(b.stripes).map((s) => s.deckName), ['G']);
+	assert.equal(krark.totalQuantity, 1);
+});
+
+test('at-least-one rule: flagged in a single child variant still dedicates the whole group', () => {
+	const krark = findCard(groupPrism({ flagInBoth: false }), KRARK);
+	assert.equal(krark.batches.length, 1);
+	assert.equal(krark.batches[0].isDedicated, true);
+	assert.equal(krark.totalQuantity, 1);
+});
+
+test('multi-commander deck: one dedicated batch per flagged card, each marked A alone', () => {
+	const prism = createPrism('T');
+	prism.decks = [
+		standalone('A', 1, [card('Okaun, Eye of Chaos', 1, true), card('Zndrsplt, Eye of Wisdom', 1, true), card('Sol Ring')]),
+	];
+	prism.useDedicatedCommanderCopies = true;
+
+	const cards = processCards(prism);
+	for (const name of ['Okaun, Eye of Chaos', 'Zndrsplt, Eye of Wisdom']) {
+		const c = cards.find((x) => x.name === name);
+		assert.equal(c.batches.length, 1);
+		assert.equal(c.batches[0].isDedicated, true);
+		assert.deepEqual(visible(c.batches[0].stripes).map((s) => s.deckName), ['A']);
+		assert.equal(c.totalQuantity, 1);
+	}
+});
+
+test('dedicated batch takes the full decklist quantity, not a fixed 1', () => {
+	const prism = createPrism('T');
+	prism.decks = [
+		standalone('A', 1, [card(KRARK, 2, true)]),
+		standalone('B', 2, [card(KRARK, 1)]),
+	];
+	prism.useDedicatedCommanderCopies = true;
+
+	const krark = findCard(prism, KRARK);
+	assert.deepEqual(
+		krark.batches.map((b) => [b.copyCount, !!b.isDedicated]),
+		[[2, true], [1, false]]
+	);
+	assert.equal(krark.totalQuantity, 3); // dedicated 2 + max of remaining 1
+});
+
+test('flag off leaves derivation untouched (slice-3 behavior)', () => {
+	const prism = createPrism('T');
+	prism.decks = [
+		standalone('A', 1, [card(KRARK, 1, true)]),
+		standalone('B', 2, [card(KRARK)]),
+	];
+	const krark = findCard(prism, KRARK);
+	assert.equal(krark.batches.length, 1);
+	assert.equal(krark.batches[0].isDedicated, undefined);
+	assert.equal(krark.totalQuantity, 1);
+});

--- a/tests/dedicated-commander-copies.test.js
+++ b/tests/dedicated-commander-copies.test.js
@@ -1,0 +1,92 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// storage.js touches localStorage inside functions; shim it like audit-fixes.test.js
+const store = new Map();
+globalThis.localStorage = {
+	getItem: (k) => (store.has(k) ? store.get(k) : null),
+	setItem: (k, v) => store.set(k, String(v)),
+	removeItem: (k) => store.delete(k),
+	clear: () => store.clear(),
+};
+
+const { mergePrismVersions } = await import('../js/modules/storage.js');
+const { createPrism } = await import('../js/modules/processor.js');
+const { buildPrismFromJson } = await import('../js/modules/prism-import.js');
+
+function prism(overrides = {}) {
+	return {
+		id: 'p1',
+		name: 'P',
+		createdAt: '2026-01-01T00:00:00Z',
+		updatedAt: '2026-01-01T00:00:00Z',
+		decks: [],
+		splitGroups: [],
+		markedCards: [],
+		removedCards: [],
+		markedCardsUpdatedAt: null,
+		useDedicatedCommanderCopies: false,
+		useDedicatedCommanderCopiesUpdatedAt: null,
+		...overrides,
+	};
+}
+
+test('local toggle survives merge when cloud prism.updatedAt is newer', () => {
+	// Desktop toggled the setting offline; phone marked cards after, so the
+	// phone (cloud) copy has the newer prism.updatedAt and is basePrism.
+	const local = prism({
+		useDedicatedCommanderCopies: true,
+		useDedicatedCommanderCopiesUpdatedAt: '2026-02-01T00:00:00Z',
+		updatedAt: '2026-01-15T00:00:00Z',
+	});
+	const cloud = prism({
+		updatedAt: '2026-02-02T00:00:00Z', // mark-toggle bumped it
+	});
+
+	const merged = mergePrismVersions(local, cloud, null);
+	assert.equal(merged.useDedicatedCommanderCopies, true);
+	assert.equal(merged.useDedicatedCommanderCopiesUpdatedAt, '2026-02-01T00:00:00Z');
+});
+
+test('newer cloud timestamp wins (stale tab self-heals)', () => {
+	const local = prism(); // stale: flag false, timestamp null
+	const cloud = prism({
+		useDedicatedCommanderCopies: true,
+		useDedicatedCommanderCopiesUpdatedAt: '2026-02-01T00:00:00Z',
+	});
+
+	const merged = mergePrismVersions(local, cloud, null);
+	assert.equal(merged.useDedicatedCommanderCopies, true);
+});
+
+test('legacy null timestamps: first device to toggle wins', () => {
+	const local = prism({
+		useDedicatedCommanderCopies: true,
+		useDedicatedCommanderCopiesUpdatedAt: '2026-02-01T00:00:00Z',
+	});
+	const cloud = prism(); // legacy row: false, null timestamp
+
+	const merged = mergePrismVersions(local, cloud, null);
+	assert.equal(merged.useDedicatedCommanderCopies, true);
+
+	// and the field never rides basePrism: tie (both null) resolves local
+	const tie = mergePrismVersions(prism({ useDedicatedCommanderCopies: true }), prism(), null);
+	assert.equal(tie.useDedicatedCommanderCopies, true);
+});
+
+test('createPrism seeds false plus a timestamp', () => {
+	const p = createPrism('T');
+	assert.equal(p.useDedicatedCommanderCopies, false);
+	assert.ok(p.useDedicatedCommanderCopiesUpdatedAt);
+});
+
+test('backup round-trip: flag restored, pre-feature backup restores as off', () => {
+	const deck = { id: 'd1', name: 'D', bracket: 3, color: '#FF0000', stripePosition: 1, cards: [] };
+
+	const restored = buildPrismFromJson({ prism: { name: 'B', decks: [deck], useDedicatedCommanderCopies: true } });
+	assert.equal(restored.useDedicatedCommanderCopies, true);
+	assert.ok(restored.useDedicatedCommanderCopiesUpdatedAt, 'restore stamps a fresh timestamp');
+
+	const legacy = buildPrismFromJson({ prism: { name: 'B', decks: [deck] } });
+	assert.equal(legacy.useDedicatedCommanderCopies, false);
+});

--- a/tests/marking-batches.test.js
+++ b/tests/marking-batches.test.js
@@ -1,0 +1,219 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const store = new Map();
+globalThis.localStorage = {
+	getItem: (k) => (store.has(k) ? store.get(k) : null),
+	setItem: (k, v) => store.set(k, String(v)),
+	removeItem: (k) => store.delete(k),
+	clear: () => store.clear(),
+};
+
+const { createPrism, createDeck, createSplitGroup, processCards, calculateRemovedCards } =
+	await import('../js/modules/processor.js');
+const { isCardDone, passKeysForCard } = await import('../js/core/utils.js');
+const { mergeRemovedCards } = await import('../js/modules/storage.js');
+const { getDeckPoolCoreCounts } = await import('../js/features/deck-list.js');
+
+function card(name, quantity = 1, isBasicLand = false) {
+	return { name, quantity, isCommander: false, isBasicLand };
+}
+
+function standalone(name, pos, cards) {
+	return createDeck({ name, bracket: 3, color: '#FF0000', stripePosition: pos, cards });
+}
+
+function visible(stripes) {
+	return stripes.filter((s) => s.markType !== 'membership');
+}
+
+// --- #146 worked examples -------------------------------------------------
+
+test('Rat Colony K5/E3 → 3 copies with 2 marks (pool), then 2 with 1 (core)', () => {
+	const prism = createPrism('T');
+	prism.decks = [
+		standalone('K', 1, [card('Rat Colony', 5)]),
+		standalone('E', 2, [card('Rat Colony', 3)]),
+	];
+	const [rats] = processCards(prism);
+	assert.equal(rats.batches.length, 2);
+	const [b1, b2] = rats.batches;
+	assert.equal(b1.copyCount, 3);
+	assert.equal(visible(b1.stripes).length, 2);
+	assert.equal(b1.isPool, true);
+	assert.equal(b2.copyCount, 2);
+	assert.equal(visible(b2.stripes).length, 1);
+	assert.equal(b2.isPool, false);
+	assert.equal(b1.copyCount + b2.copyCount, rats.totalQuantity);
+});
+
+test('Forest A8/K3/E3 → 3 copies/3 marks then 5 copies/1 mark', () => {
+	const prism = createPrism('T');
+	prism.decks = [
+		standalone('A', 1, [card('Forest', 8, true)]),
+		standalone('K', 2, [card('Forest', 3, true)]),
+		standalone('E', 3, [card('Forest', 3, true)]),
+	];
+	const [forest] = processCards(prism);
+	assert.deepEqual(
+		forest.batches.map((b) => [b.copyCount, visible(b.stripes).length]),
+		[[3, 3], [5, 1]]
+	);
+});
+
+function splitPlusStandalonePrism() {
+	// Split group (stripes style) at Side A slot 1: variants B (qty 5, slot 48)
+	// and U (qty 2, slot 47); standalone E (qty 3, slot 2). #146 combined example.
+	const prism = createPrism('T');
+	const group = createSplitGroup({ name: 'G', sideAPosition: 1, sideAColor: '#00FF00', splitStyle: 'stripes' });
+	const b = createDeck({ name: 'B', bracket: 3, color: '#0000FF', stripePosition: 48, splitGroupId: group.id, cards: [card('Island', 5, true)] });
+	const u = createDeck({ name: 'U', bracket: 3, color: '#00FFFF', stripePosition: 47, splitGroupId: group.id, cards: [card('Island', 2, true)] });
+	const e = standalone('E', 2, [card('Island', 3, true)]);
+	group.childDeckIds = [b.id, u.id];
+	prism.decks = [b, u, e];
+	prism.splitGroups = [group];
+	return { prism, group, b, u, e };
+}
+
+test('split Island B5/U2 + standalone E3 → the #146 combined example', () => {
+	const { prism, b } = splitPlusStandalonePrism();
+	const [island] = processCards(prism);
+
+	assert.equal(island.batches.length, 3);
+	const [t2, t3, t5] = island.batches;
+
+	// 2 copies: group parent + E — pool
+	assert.equal(t2.copyCount, 2);
+	assert.deepEqual(visible(t2.stripes).map((s) => s.deckName).sort(), ['E', 'G']);
+	assert.equal(t2.isPool, true);
+
+	// 1 copy: parent + B child indicator + E — pool. The child indicator exists
+	// here even though processCards' whole-group view emits none (#149 finding).
+	assert.equal(t3.copyCount, 1);
+	assert.deepEqual(visible(t3.stripes).map((s) => s.deckName).sort(), ['B', 'E', 'G']);
+	assert.ok(visible(t3.stripes).some((s) => s.deckId === b.id && s.side === 'b'));
+	assert.equal(t3.isPool, true);
+
+	// 2 copies: parent + B child indicator — core (group alone = 1 logical deck)
+	assert.equal(t5.copyCount, 2);
+	assert.deepEqual(visible(t5.stripes).map((s) => s.deckName).sort(), ['B', 'G']);
+	assert.equal(t5.isPool, false);
+
+	assert.equal(island.totalQuantity, 5);
+	// pool 3, core 2
+	assert.equal(island.batches.reduce((s, x) => s + (x.isPool ? x.copyCount : 0), 0), 3);
+	assert.equal(island.batches.reduce((s, x) => s + (x.isPool ? 0 : x.copyCount), 0), 2);
+});
+
+test('three-variant group A5/B3/C0 never yields a parent-only batch', () => {
+	const prism = createPrism('T');
+	const group = createSplitGroup({ name: 'G', sideAPosition: 1, sideAColor: '#00FF00', splitStyle: 'stripes' });
+	const a = createDeck({ name: 'A', bracket: 3, color: '#111111', stripePosition: 48, splitGroupId: group.id, cards: [card('Sol Ring', 5)] });
+	const b = createDeck({ name: 'B', bracket: 3, color: '#222222', stripePosition: 47, splitGroupId: group.id, cards: [card('Sol Ring', 3)] });
+	const c = createDeck({ name: 'C', bracket: 3, color: '#333333', stripePosition: 46, splitGroupId: group.id, cards: [card('Filler')] });
+	group.childDeckIds = [a.id, b.id, c.id];
+	prism.decks = [a, b, c];
+	prism.splitGroups = [group];
+
+	const solRing = processCards(prism).find((x) => x.name === 'Sol Ring');
+	assert.deepEqual(
+		solRing.batches.map((x) => [x.copyCount, visible(x.stripes).map((s) => s.deckName).sort()]),
+		[[3, ['A', 'B', 'G']], [2, ['A', 'G']]]
+	);
+});
+
+test('batch keys: name|#b|sorted ids|count; singleton = one batch, Σ = totalQuantity', () => {
+	const prism = createPrism('T');
+	const d1 = standalone('D1', 1, [card('Sol Ring'), card('Rat Colony', 4)]);
+	const d2 = standalone('D2', 2, [card('Sol Ring'), card('Rat Colony', 2)]);
+	prism.decks = [d1, d2];
+	const cards = processCards(prism);
+
+	const sol = cards.find((c) => c.name === 'Sol Ring');
+	assert.equal(sol.batches.length, 1);
+	assert.equal(sol.batches[0].key, `Sol Ring|#b|${[d1.id, d2.id].sort().join(',')}|1`);
+
+	const rats = cards.find((c) => c.name === 'Rat Colony');
+	const sortedIds = [d1.id, d2.id].sort();
+	assert.equal(rats.batches[0].key, `Rat Colony|#b|${sortedIds.join(',')}|2`);
+	assert.equal(rats.batches[1].key, `Rat Colony|#b|${d1.id}|2`);
+	assert.equal(rats.batches.reduce((s, b) => s + b.copyCount, 0), rats.totalQuantity);
+});
+
+// --- #151 Done identity -----------------------------------------------------
+
+test('isCardDone: batch keys, legacy plain key, pass keys, fail-safe crossing', () => {
+	const prism = createPrism('T');
+	prism.decks = [
+		standalone('A', 1, [card('Forest', 8, true), card('Sol Ring')]),
+		standalone('K', 2, [card('Forest', 3, true), card('Sol Ring')]),
+	];
+	const cards = processCards(prism);
+	const forest = cards.find((c) => c.name === 'Forest');
+	const sol = cards.find((c) => c.name === 'Sol Ring');
+
+	// single-batch: plain key
+	assert.equal(isCardDone(sol, new Set(['Sol Ring'])), true);
+
+	// multi-batch: legacy plain key deliberately NOT honored
+	assert.equal(isCardDone(forest, new Set(['Forest'])), false);
+
+	// multi-batch: every batch key marked
+	assert.equal(isCardDone(forest, new Set(forest.batches.map((b) => b.key))), true);
+	assert.equal(isCardDone(forest, new Set([forest.batches[0].key])), false);
+
+	// pass keys (legacy per-deck basic marks) still count
+	assert.deepEqual(passKeysForCard(forest).sort(), ['Forest|A', 'Forest|K']);
+	assert.equal(isCardDone(forest, new Set(['Forest|A', 'Forest|K'])), true);
+	assert.equal(isCardDone(forest, new Set(['Forest|A'])), false);
+
+	// non-repeated card has no pass keys
+	assert.deepEqual(passKeysForCard(sol), []);
+});
+
+// --- #151 removals -----------------------------------------------------------
+
+test('calculateRemovedCards reports quantity decreases and full removals', () => {
+	const oldCards = [card('Rat Colony', 5), card('Sol Ring'), card('Island', 4, true)];
+	const newCards = [card('Rat Colony', 3), card('Island', 4, true)];
+
+	const removed = calculateRemovedCards(oldCards, newCards);
+	assert.deepEqual(
+		removed.map((r) => [r.name, r.previousQuantity, r.newQuantity]),
+		[['Rat Colony', 5, 3], ['Sol Ring', 1, 0]]
+	);
+});
+
+test('mergeRemovedCards keeps max previousQuantity with the latest row', () => {
+	const local = [{ cardName: 'Rat Colony', deckId: 'd1', previousQuantity: 5, newQuantity: 4, removedAt: '2026-01-01T00:00:00Z' }];
+	const cloud = [{ cardName: 'Rat Colony', deckId: 'd1', previousQuantity: 4, newQuantity: 3, removedAt: '2026-01-02T00:00:00Z' }];
+
+	const [row] = mergeRemovedCards(local, cloud);
+	assert.equal(row.previousQuantity, 5);
+	assert.equal(row.newQuantity, 3);
+	assert.equal(row.removedAt, '2026-01-02T00:00:00Z');
+
+	// legacy rows without quantities still merge on removedAt
+	const [legacy] = mergeRemovedCards(
+		[{ cardName: 'Sol Ring', deckId: 'd1', removedAt: '2026-01-01T00:00:00Z' }],
+		[{ cardName: 'Sol Ring', deckId: 'd1', removedAt: '2026-01-03T00:00:00Z' }]
+	);
+	assert.equal(legacy.removedAt, '2026-01-03T00:00:00Z');
+});
+
+// --- #146 per-deck counts ------------------------------------------------------
+
+test('getDeckPoolCoreCounts matches the #146 combined example per deck', () => {
+	const { prism, b, u, e } = splitPlusStandalonePrism();
+	const cards = processCards(prism);
+
+	assert.deepEqual(getDeckPoolCoreCounts(b, cards), { pool: 3, core: 2 });
+	assert.deepEqual(getDeckPoolCoreCounts(u, cards), { pool: 2, core: 0 });
+	assert.deepEqual(getDeckPoolCoreCounts(e, cards), { pool: 3, core: 0 });
+
+	// per-deck pool + core equals the trusted decklist quantity
+	for (const [deck, qty] of [[b, 5], [u, 2], [e, 3]]) {
+		const { pool, core } = getDeckPoolCoreCounts(deck, cards);
+		assert.equal(pool + core, qty);
+	}
+});

--- a/tests/marking-batches.test.js
+++ b/tests/marking-batches.test.js
@@ -199,6 +199,14 @@ test('mergeRemovedCards keeps max previousQuantity with the latest row', () => {
 		[{ cardName: 'Sol Ring', deckId: 'd1', removedAt: '2026-01-03T00:00:00Z' }]
 	);
 	assert.equal(legacy.removedAt, '2026-01-03T00:00:00Z');
+
+	// names match via normalizeCardName: back face, printing suffix, whitespace
+	const merged = mergeRemovedCards(
+		[{ cardName: 'Dusk // Dawn ', deckId: 'd1', removedAt: '2026-01-01T00:00:00Z' }],
+		[{ cardName: 'dusk', deckId: 'd1', removedAt: '2026-01-02T00:00:00Z' }]
+	);
+	assert.equal(merged.length, 1);
+	assert.equal(merged[0].removedAt, '2026-01-02T00:00:00Z');
 });
 
 // --- #146 per-deck counts ------------------------------------------------------


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional dedicated commander-copy tracking for each PRISM.
  * Added support for decks with two commanders and synchronized commander fields.
  * Improved repeated-card marking with expandable batches, copy counts, and progress tracking.
  * Added quantity-aware removed-card tracking and clearer pool/core counts.
  * Updated exports and printable guides with commander and batch details.
  * Renamed the results filter to “One Mark at a Time.”

* **Bug Fixes**
  * Improved deck imports, commander parsing, restoration, and synchronization.
  * Preserved excluded decklist sections and quantities during editing.

* **Tests**
  * Added coverage for commander handling, dedicated copies, batches, removals, and data merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->