### PR TITLE
docs: lock reader-facing vocabulary in CONTEXT.md (#158)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -14,8 +14,16 @@ _Avoid_: Partner deck, when referring to all multi-commander mechanics
 **Decklist**:
 The user-supplied list of cards and quantities for a deck. PRISM treats it as authoritative and does not adjudicate Commander legality.
 
+**PRISM**:
+A named container of decks, split groups, and their marks. A user may keep several. The product and the container share the name, so reader-facing prose introduces the container sense on first use.
+
 **Marking batch**:
 A result line describing a quantity of interchangeable physical copies that receive the same set of deck marks.
+
+**Marking pass**:
+One deck mark applied to a quantity of copies, summed across marking batches. Distinct from a marking batch, which is copies sharing the same _set_ of marks — a pass is a single mark that may draw copies from several batches.
+_Avoid_: marking group, basics by deck
+_In code_: the filter value is `basics-by-deck`; the control reads "Grouped by Mark". The mismatch is deliberate.
 
 **Quantity tier**:
 A quantity of one card needed by the same set of decks. Tier boundaries occur where decklist quantities differ.
@@ -23,11 +31,28 @@ A quantity of one card needed by the same set of decks. Tier boundaries occur wh
 **Split group**:
 A logical deck composed of child variants that share one physical card pool and a parent deck mark. Child marks distinguish copies needed by only some variants.
 
-**Pool copy**:
-A physical copy in a marking batch used by two or more logical decks.
+**Pool**:
+A physical copy in a marking batch used by two or more logical decks. Always capitalized — a term of art, not the ordinary word.
+_Avoid_: shared card, POOL, pool
 
-**Core copy**:
-A physical copy in a marking batch used by exactly one logical deck.
+**Core**:
+A physical copy in a marking batch used by exactly one logical deck. Always capitalized.
+_Avoid_: unshared card, CORE, core
+
+**Dedicated**:
+A qualifier on a Core batch that exists because the PRISM gives a commander its own copy instead of sharing one. Written `Core (dedicated)`, lowercase in the parentheses. Never a third category beside Pool and Core.
 
 **Physical total**:
 The number of physical copies of a card needed across a PRISM. It equals the sum of that card's marking-batch quantities.
+
+**Mark**:
+A painted indicator on a sleeve edge. Every mark is either a stripe or a dot.
+
+**Slot**:
+One of the 48 places on a sleeve edge where a deck's mark goes. Lowercase in prose; capitalized only before a number, as in `Side A - Slot 3`.
+_Avoid_: stripe position, position
+_In code_: `stripePosition` and `sideAPosition`. The mismatch is deliberate — do not align either direction.
+
+**Perfect Fit inner**:
+The inner sleeve of a double-sleeved card, and the only sleeve that is ever marked. Its partner is the outer sleeve, which protects the mark.
+_Avoid_: perfect-fit inner sleeve, inner Perfect Fit sleeve, Perfect Fit inner sleeve


### PR DESCRIPTION
Resolves the wayfinder ticket [Lock the teaching vocabulary](https://github.com/codwats/prism/issues/158) on the map [Rewrite guide.html as PRISM's depth library](https://github.com/codwats/prism/issues/157).

## What changed

`CONTEXT.md` only. One term per object, so every surface teaches the same name.

| Term | Change |
|---|---|
| **Pool** / **Core** | renamed from "Pool copy" / "Core copy"; now capitalized proper nouns. "shared card" retired |
| **Dedicated** | new — a qualifier on Core (`Core (dedicated)`), explicitly *not* a third category |
| **Slot** | new — the 1–48 sleeve-edge place. "stripe position" retired |
| **Marking pass** | new — the one-mark-per-row object, kept distinct from Marking batch |
| **Mark** | new — a stripe or a dot |
| **Perfect Fit inner** | new — the marked sleeve |
| **PRISM** | new — documented as both product and container |

## Why

Four objects had multiple names across `index.html`, `build.html`, `guide.html`, `tools.html` and the JS render paths — the shared-card object alone had three ("Pool", "Core", "shared cards"), and `tools.html:252` used two of them in a single sentence. Every remaining ticket on the map writes copy, so the names had to settle first.

## For reviewers

**No behavior or string changes in this PR.** The ~30 drifting UI strings are inventoried on #158 and deferred to the drafting tickets — this commit only records the decisions.

Two **deliberate** code ↔ reader mismatches are documented inline so neither gets "fixed" later:

- `stripePosition` / `sideAPosition` → **slot**
- `basics-by-deck` → **Grouped by Mark**

Renaming the data model would be a large diff for zero reader benefit, and `formatSlotLabel` already renders `Side A - Slot 3` as the highest-traffic string in the app.

**Worth a second opinion:** `Marking pass` is the one term coined during the session rather than chosen by the maintainer. The object previously had no name, which is what made "Marking Groups" look like a reasonable label for it mid-discussion despite colliding with the existing **Marking batch**. Rename freely.

## Related

Filed separately while resolving this — a defect outside the map's path that the guide rewrite will not touch: [Corner-change warning is ambiguous and under-warns](https://github.com/codwats/prism/issues/164).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the PRISM glossary with definitions for PRISM concepts, marking batches and passes, marks, slots, and Perfect Fit inner sleeves.
  * Standardized terminology by replacing “Pool copy” and “Core copy” with “Pool” and “Core,” and introducing the “Dedicated” qualifier.
  * Added guidance on preferred terminology, terms to avoid, and discrepancies between documentation and code labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->