### PR TITLE
Add banned-string copy check (#166)

### DIFF
--- a/scripts/copy-check.mjs
+++ b/scripts/copy-check.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+// Banned-string check for reader-facing copy (see issue #166).
+// Catches drift BETWEEN sessions, not style within one — the drafting agent
+// has /ste-writing loaded and self-lints its own paragraph. Run by hand:
+//   node scripts/copy-check.mjs
+// Exit code is always 0: this reports, it does not gate.
+
+import { readFileSync } from 'node:fs';
+
+const HTML = ['index.html', 'guide.html', 'tools.html', 'build.html'];
+const JS = ['js/features/results.js', 'js/features/deck-list.js', 'js/layout.js'];
+
+const RULES = [
+	{ cls: 'glyph', re: /—/g },
+	{ cls: 'glyph', re: /;/g, proseOnly: true },
+	{ cls: 'contraction', re: /\b(don|can|won|isn|doesn)['’]t\b|\b(it|that)['’]s\b|\byou['’]re\b/gi },
+	{ cls: '#158 drift', re: /\bPOOL\b|\bCORE\b/g },
+	{ cls: '#158 drift', re: /shared cards|Basics by Deck|perfect-fit/gi },
+	{ cls: '#158 drift', re: /\bposition\b/g },
+];
+
+const ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ', mdash: '—', ndash: '–', rsquo: '’', lsquo: '‘' };
+
+/** Strip script/style bodies and all tags, preserving line numbering. */
+const blank = (m) => m.replace(/[^\n]/g, ' ');
+function stripHtml(src) {
+	return src
+		.replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi, blank)
+		.replace(/<[^>]+>/g, blank) // blank, not collapse: tags span lines
+		.replace(/&#(\d+);/g, (_, n) => String.fromCharCode(+n))
+		.replace(/&(\w+);/g, (_, e) => ENTITIES[e] ?? ' ');
+}
+
+/** The supporting line under a page's <h1> sits outside the copy standard (#159). */
+function exemptLines(src) {
+	const lines = src.split('\n');
+	const exempt = new Set();
+	lines.forEach((line, i) => {
+		if (!/<h1\b/.test(line)) return;
+		for (let j = i + 1; j < lines.length; j++) {
+			if (lines[j].trim()) return exempt.add(j + 1);
+		}
+	});
+	return exempt;
+}
+
+const findings = [];
+for (const file of [...HTML, ...JS]) {
+	const isHtml = file.endsWith('.html');
+	const src = readFileSync(new URL(`../${file}`, import.meta.url), 'utf8');
+	const exempt = isHtml ? exemptLines(src) : new Set();
+	const lines = (isHtml ? stripHtml(src) : src).split('\n');
+	// Every reported line number depends on this. A tag spanning lines that
+	// collapses to one space shifts every number after it, silently.
+	if (lines.length !== src.split('\n').length) throw new Error(`${file}: strip changed line count`);
+
+	lines.forEach((line, i) => {
+		const n = i + 1;
+		if (exempt.has(n)) return;
+		if (!isHtml && /^\s*(\/\/|\*|\/\*)/.test(line)) return; // comments are not reader-facing
+		for (const { cls, re, proseOnly } of RULES) {
+			if (proseOnly && !isHtml) continue; // raw JS semicolons are syntax, not prose
+			for (const m of line.matchAll(re)) {
+				findings.push({ file, n, cls, hit: m[0], ctx: line.trim().slice(0, 90) });
+			}
+		}
+	});
+}
+
+for (const f of findings) console.log(`${f.file}:${f.n} [${f.cls}] "${f.hit}" | ${f.ctx}`);
+console.log(`\n${findings.length} finding(s) across ${HTML.length + JS.length} files.`);


### PR DESCRIPTION
Closes #166. Part of #157.

`scripts/copy-check.mjs` — run by hand with `node scripts/copy-check.mjs`.

## What it checks

Catches vocabulary drift **between** sessions, not style within one. The drafting agent has `/ste-writing` loaded and re-reads its own paragraph, so a sentence-length / passive-voice linter would re-check what the author just checked. The failure #158 documented was different: ~30 strings across 7 files, each written by someone who was right at the time, that nobody noticed until a ticket went looking.

| Class | Strings |
|---|---|
| Glyphs | `—`, prose `;` |
| Contractions | `don't` `can't` `won't` `you're` `it's` `isn't` `doesn't` `that's` |
| #158 drift | `POOL` `CORE` `shared cards` `Basics by Deck` `position` `perfect-fit` |

Over `index.html`, `guide.html`, `tools.html`, `build.html`, `js/features/results.js`, `js/features/deck-list.js`, `js/layout.js`.

## Current output

**59 findings** — 35 `#158 drift`, 13 `contraction`, 11 `glyph`. Every known positive listed on #166 fires at the exact line number the ticket named:

```
guide.html:126 [contraction] "can't"
guide.html:176 [glyph] ";"
guide.html:185 [contraction] "don't"
tools.html:188 [contraction] "won't"
tools.html:240 [contraction] "you're"
tools.html:252 [contraction] "you're"   (x2, one line)
guide.html:128 [#158 drift] "POOL" / "CORE"
```

These stay red until the drafting tickets land. That is the point — they are the drift inventory.

## Three decisions #166 did not specify

**Node, not Python.** The ticket sketched ~15 lines of Python. Same length in Node, and the repo is already Node-only (`node --test`, `type: module`, no Python anywhere).

**Tags are blanked in place, not collapsed.** The ticket's sketch used `re.sub(r'<[^>]+>', ' ', s)`. For a line-numbered report that is a real bug: a tag spanning two lines collapses to one space and shifts **every line number after it**. Each tag is now replaced by its own non-newline characters blanked, preserving newlines, and the script asserts `stripped line count == source line count` per file so the bug class cannot come back silently.

**JS comment lines are skipped.** #166 said grep the JS raw and accept noise. Raw was 95 findings, roughly 40 of them `—` inside `//` comments — enough to bury `layout.js:606`, the sharpest drift instance. Skipping `^\s*(//|\*|/\*)` is one regex and is not parsing string literals. Prose semicolons are also off for JS files: a statement terminator is syntax, not prose.

The hero supporting line exemption (legal per #159) is structural — first non-blank line after an `<h1>` — not a hardcoded line number, so it survives page edits.

## Remaining noise, as predicted

`\bposition\b` is case-sensitive and word-bounded, so `stripePosition` / `sideAPosition` do not fire. What is left in `results.js` is the genuine `s.position` property, about 11 lines. That is the accepted noise #166 called for.

## Not included

No CI wiring, no pre-commit hook, no config, no npm script. **Exit code is always 0** — this reports, it does not gate. If it should gate later: `process.exit(findings.length ? 1 : 0)` plus one line in `package.json`.

No unit test. The known positives are the acceptance check and are designed to go red-to-green as drafting lands, so a test asserting them would break on purpose. The one non-obvious invariant, line-number preservation, is guarded by the inline throw instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
