### PR TITLE
Land the stale mark term in CONTEXT.md

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -48,6 +48,11 @@ The number of physical copies of a card needed across a PRISM. It equals the sum
 **Mark**:
 A painted indicator on a sleeve edge. Every mark is either a stripe or a dot.
 
+**Stale mark**:
+A mark on a sleeve for a deck that no longer needs the card. Arises when a card leaves a decklist or its quantity drops. Lowercase in prose.
+_Avoid_: removed card, pending removal
+_In code_: `removedCards`, and the filter value is `removed`.
+
 **Slot**:
 One of the 48 places on a sleeve edge where a deck's mark goes. Lowercase in prose; capitalized only before a number, as in `Side A - Slot 3`.
 _Avoid_: stripe position, position

--- a/build.html
+++ b/build.html
@@ -359,7 +359,7 @@
                   <wa-radio appearance="button" value="all" size="small">All Cards</wa-radio>
                   <wa-radio appearance="button" value="shared" size="small">POOL</wa-radio>
                   <wa-radio appearance="button" value="basics-by-deck" size="small">One Mark at a Time</wa-radio>
-                  <wa-radio appearance="button" value="removed" id="removed-filter-btn" size="small">Removed</wa-radio>
+                  <wa-radio appearance="button" value="removed" id="removed-filter-btn" size="small">Stale Marks</wa-radio>
                 </wa-radio-group>
                 <!-- Search -->
                 <wa-input id="results-search" placeholder="Search cards..." size="medium" style="max-width: 400px; flex: 1; min-width: 10rem;">

--- a/js/features/results.js
+++ b/js/features/results.js
@@ -90,10 +90,10 @@ export function updateRemovedFilterBadge() {
   const count = state.currentPrism?.removedCards?.length || 0;
 
   if (count > 0) {
-    removedBtn.textContent = `Removed (${count})`;
+    removedBtn.textContent = `Stale Marks (${count})`;
     removedBtn.style.setProperty('--wa-color-surface', 'var(--wa-color-warning-surface-subtle)');
   } else {
-    removedBtn.textContent = 'Removed';
+    removedBtn.textContent = 'Stale Marks';
     removedBtn.style.removeProperty('--wa-color-surface');
   }
 }

--- a/scripts/copy-check.mjs
+++ b/scripts/copy-check.mjs
@@ -17,6 +17,8 @@ const RULES = [
 	{ cls: '#158 drift', re: /\bPOOL\b|\bCORE\b/g },
 	{ cls: '#158 drift', re: /shared cards|Basics by Deck|perfect-fit/gi },
 	{ cls: '#158 drift', re: /\bposition\b/g },
+	{ cls: '#161 drift', re: /\bRemoved\b/g },
+	{ cls: '#161 drift', re: /removed cards?|pending removal/gi },
 ];
 
 const ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ', mdash: '—', ndash: '–', rsquo: '’', lsquo: '‘' };


### PR DESCRIPTION
Closes #171.

- `CONTEXT.md` — **Stale mark** entry added after **Mark**, which it qualifies.
- `build.html:362` + `js/features/results.js:93,96` — filter label reads **Stale Marks**. Both, because `updateRemovedFilterBadge` rewrites the label on every render; the markup edit alone would never have been visible.
- `scripts/copy-check.mjs` — one rule pair for the term's *Avoid* forms.

Three residual strings now report and are deliberately left for the drafting tickets: `guide.html:140` (the guide rewrite owns it), and `results.js:507` / `results.js:622` (#161 empty-state work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updated Terminology**
  * Renamed the Results filter from “Removed” to “Stale Marks.”
  * Updated related result labels and count displays to use the new terminology.
  * Added glossary guidance defining “Stale mark” and identifying prohibited wording.
  * Added checks to help prevent outdated removal-related terminology from reappearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->