### PR TITLE
copy: name the objects in build.html empty states and callouts (#157)

### DIFF
--- a/build.html
+++ b/build.html
@@ -74,6 +74,9 @@
               </wa-dropdown>
             </div>
           </div>
+          <p class="wa-caption-s" style="color: var(--wa-color-neutral-text-subtle); margin: 0;">
+            A PRISM is one named container of decks and their marks. You can keep more than one.
+          </p>
         </section>
 
         <!-- Tab Navigation -->
@@ -95,9 +98,12 @@
                    wired by the inline onboarding script at the end of body) -->
               <wa-card id="onboarding-callout" style="display: none;">
                 <div class="wa-flank:end">
-                  <div class="wa-stack wa-gap-xs">
-                    <strong>Welcome to PRISM.</strong> Add the Commander decks that share cards, and PRISM works out a colored-stripe plan so every sleeve shows which decks it belongs to.
-                    <span>New to sleeve marking? Read the <a href="guide.html">marking guide</a> first.</span>
+                  <div class="wa-flank" style="--flank-size: 22rem;">
+                    <img src="assets/Cards.svg" alt="Three card sleeves, each with colored marks at a different place along its edge" style="inline-size: 22rem; max-inline-size: 100%; block-size: auto; flex: none;" />
+                    <div class="wa-stack wa-gap-xs">
+                      <span><strong>One physical copy can serve every deck that needs it.</strong> A copy that two or more decks share is Pool. It carries one colored mark per deck, so the sleeve edge shows where it belongs.</span>
+                      <span><a href="guide.html#read-a-sleeve">Read a marked sleeve</a></span>
+                    </div>
                   </div>
                   <wa-button id="onboarding-dismiss" appearance="filled-outlined" size="small">
                     <wa-icon slot="start" name="xmark"></wa-icon>
@@ -257,20 +263,19 @@
           <wa-tab-panel name="results">
             <div class="wa-stack wa-gap-l">
               <!-- Marking prerequisites at the point of action -->
-              <wa-card id="marking-prereq-callout" style="display: none;">
-              <div class="wa-flank:end"   >
-                  <div class="wa-stack wa-gap-xs">
-                <strong>Finalize your decks before you start marking.</strong> Mid-session edits lead to confusion, so make changes after your marking pass.
-                <br />
-                <strong>Remember:</strong> Marks go on the inner Perfect Fit sleeve, double-sleeved inside an outer sleeve which protects the mark.<br />
-                    <span>Read the <a href="guide.html">marking guide</a> first.</span>
-                    </div>
-                <wa-button slot="action" id="marking-prereq-dismiss" appearance="filled-outlined" size="small">
+              <div id="marking-prereq-callout" class="wa-stack wa-gap-xs" style="display: none;">
+                <wa-callout variant="warning">
+                  <wa-icon slot="icon" name="triangle-exclamation"></wa-icon>
+                  <strong>Finalize every decklist before you start marking.</strong> An edit made during a session changes the counts under you. Make the change after the pass.
+                </wa-callout>
+                <div class="wa-split wa-align-items-center wa-gap-s">
+                  <p style="margin: 0;">Marks go on the Perfect Fit inner. An outer sleeve goes over it and protects the paint. <a href="guide.html#mark-a-session">Run a marking session</a></p>
+                  <wa-button id="marking-prereq-dismiss" appearance="filled-outlined" size="small">
                     <wa-icon slot="start" name="xmark"></wa-icon>
                     Dismiss
-                </wa-button>
+                  </wa-button>
+                </div>
               </div>
-              </wa-card>
               <!-- Stats Summary -->
               <div id="results-stats" class="wa-grid wa-gap-m" style="--min-column-size: 30ch">
                 <wa-card>
@@ -357,7 +362,7 @@
                 <!--Results-->
                 <wa-radio-group id="results-filter" orientation="horizontal" value="all" size="small">
                   <wa-radio appearance="button" value="all" size="small">All Cards</wa-radio>
-                  <wa-radio appearance="button" value="shared" size="small">POOL</wa-radio>
+                  <wa-radio appearance="button" value="shared" size="small">Pool</wa-radio>
                   <wa-radio appearance="button" value="basics-by-deck" size="small">One Mark at a Time</wa-radio>
                   <wa-radio appearance="button" value="removed" id="removed-filter-btn" size="small">Stale Marks</wa-radio>
                 </wa-radio-group>
@@ -376,9 +381,6 @@
                     <div id="deck-legend" class="wa-stack wa-gap-s">
                       <!-- Deck legend items will be inserted here -->
                     </div>
-                    <div id="no-decks-legend" style="color: var(--wa-color-neutral-text-subtle);">
-                      No decks added yet.
-                    </div>
                   </div>
                 </wa-dropdown>
                 <!-- Export actions -->
@@ -387,6 +389,7 @@
                     <wa-icon slot="start" name="download"></wa-icon>
                     Export
                   </wa-button>
+                  <span class="wa-caption-s" style="display: block; padding: var(--wa-space-s) var(--wa-space-m) 0; color: var(--wa-color-neutral-text-subtle);">The printable guide lists every card with its colors and slots, plus the deck legend.</span>
                   <wa-dropdown-item id="btn-print-guide">
                     <wa-icon slot="icon" name="print"></wa-icon>
                     Printable guide
@@ -434,11 +437,11 @@
               </div>
 
               <div id="no-results" class="wa-stack wa-gap-m wa-align-items-center" style="padding: var(--wa-space-2xl); display: none;">
-                <wa-icon name="inbox" style="font-size: 3rem; color: var(--wa-color-neutral-text-subtle);"></wa-icon>
-                <p style="color: var(--wa-color-neutral-text-subtle);">Add some decks to see your card analysis here.</p>
+                <wa-icon name="layer-group" style="font-size: 3rem; color: var(--wa-color-neutral-text-subtle);"></wa-icon>
+                <p style="color: var(--wa-color-neutral-text-subtle);">No decks yet.</p>
                 <wa-button variant="brand" id="btn-go-to-decks">
                   <wa-icon slot="start" name="plus"></wa-icon>
-                  Add Your First Deck
+                  Add Deck
                 </wa-button>
               </div>
             </div>

--- a/js/features/deck-list.js
+++ b/js/features/deck-list.js
@@ -733,7 +733,7 @@ function getMoveButtonHtml(deck, isInGroup) {
     const parentName = escapeHtml(group?.name || 'parent deck');
     return `
       <wa-button appearance="plain" variant="neutral" size="small" disabled
-        title="Dot variants don't own a slot. Move &quot;${parentName}&quot; instead."
+        title="Dot variants do not own a slot. Move &quot;${parentName}&quot; instead."
         aria-label="Move ${escapeHtml(deck.name)} (unavailable for dot variants)">
         <wa-icon name="up-down-left-right"></wa-icon>
       </wa-button>
@@ -889,7 +889,7 @@ export function renderDecksList() {
     state.elements.decksList.innerHTML = `
       <div class="wa-stack wa-gap-m wa-align-items-center" style="padding: var(--wa-space-xl); text-align: center;">
         <wa-icon name="layer-group" style="font-size: 2.5rem; color: var(--wa-color-neutral-text-subtle);"></wa-icon>
-        <p style="color: var(--wa-color-neutral-text-subtle);">No decks added yet. Add your first deck below!</p>
+        <p style="color: var(--wa-color-neutral-text-subtle);">No decks yet.</p>
       </div>
     `;
     return;

--- a/js/features/export-view.js
+++ b/js/features/export-view.js
@@ -15,12 +15,10 @@ export function renderExport() {
 
   if (sortedDecks.length === 0) {
     if (state.elements.deckLegend) state.elements.deckLegend.style.display = 'none';
-    if (state.elements.noDecksLegend) state.elements.noDecksLegend.style.display = '';
     return;
   }
 
   if (state.elements.deckLegend) state.elements.deckLegend.style.display = '';
-  if (state.elements.noDecksLegend) state.elements.noDecksLegend.style.display = 'none';
 
   if (state.elements.deckLegend) {
     // Build legend items: standalone decks + split group headers with children

--- a/js/features/init.js
+++ b/js/features/init.js
@@ -76,7 +76,6 @@ function getElements() {
 
     // Export (Legend + Export dropdowns in the Results toolbar)
     deckLegend: document.getElementById('deck-legend'),
-    noDecksLegend: document.getElementById('no-decks-legend'),
     btnExportCSV: document.getElementById('btn-export-csv'),
     btnExportJSON: document.getElementById('btn-export-json'),
     btnPrintGuide: document.getElementById('btn-print-guide'),

--- a/js/features/results.js
+++ b/js/features/results.js
@@ -501,12 +501,14 @@ export function renderResults() {
 
   // Handle empty states
   if (displayCards.length === 0) {
-    let emptyMessage = 'No cards match your filter.';
+    let emptyMessage = 'No cards match your filters. Clear All Filters shows every card again.';
 
     if (filter === 'removed') {
-      emptyMessage = 'No cards pending removal. Edit a deck to see cards that need marks cleared.';
+      emptyMessage = 'No stale marks. A stale mark belongs to a deck that no longer needs the card.';
     } else if (processedCards.length === 0) {
-      return; // Don't show message if no cards exist at all
+      // Decks exist but hold no cards: a blank table under live stats reads as
+      // lost data, so state the failure instead of returning silently.
+      emptyMessage = 'No cards in any deck. Edit a deck to paste its decklist.';
     }
 
     state.elements.resultsTbody.innerHTML = `
@@ -619,7 +621,7 @@ function renderResultsHeader() {
         </th>
         <th>Remove Mark From</th>
         <th style="width: 80px; text-align: center;">
-          <button id="clear-all-removed-btn" class="btn-clear-all-removed" title="Clear all removed cards">Clear All</button>
+          <button id="clear-all-removed-btn" class="btn-clear-all-removed" title="Clear all stale marks">Clear All</button>
         </th>
       </tr>
     `;
@@ -676,13 +678,8 @@ function renderDeckFilterMenu() {
 
   const sortedDecks = [...state.currentPrism.decks].sort((a, b) => a.stripePosition - b.stripePosition);
 
-  if (sortedDecks.length === 0) {
-    // Plain wa-button like the rest of this menu — wa-menu-item is avoided
-    // codebase-wide (flaky CDN autoload, see CLAUDE.md).
-    state.elements.deckFilterMenu.innerHTML =
-      '<wa-button disabled appearance="plain" variant="neutral" size="small">No decks added</wa-button>';
-    return;
-  }
+  // No zero-deck branch: results.js:155 hides the cluster holding this menu
+  // when there are no decks, so an empty state here is unreachable (#161).
 
   // Plain wa-buttons (not wa-menu-item) to match the deck-actions kebab menu
   // styling and dodge the flaky wa-menu CDN autoload (see CLAUDE.md).

--- a/scripts/copy-check.mjs
+++ b/scripts/copy-check.mjs
@@ -15,7 +15,7 @@ const RULES = [
 	{ cls: 'glyph', re: /;/g, proseOnly: true },
 	{ cls: 'contraction', re: /\b(don|can|won|isn|doesn)['’]t\b|\b(it|that)['’]s\b|\byou['’]re\b/gi },
 	{ cls: '#158 drift', re: /\bPOOL\b|\bCORE\b/g },
-	{ cls: '#158 drift', re: /shared cards|Basics by Deck|perfect-fit/gi },
+	{ cls: '#158 drift', re: /shared cards|Basics by Deck|perfect-fit|inner Perfect Fit sleeve|Perfect Fit inner sleeve/gi },
 	{ cls: '#158 drift', re: /\bposition\b/g },
 	{ cls: '#161 drift', re: /\bRemoved\b/g },
 	{ cls: '#161 drift', re: /removed cards?|pending removal/gi },


### PR DESCRIPTION
PR 2 of 3 in the drafting handoff from [#157](https://github.com/codwats/prism/issues/157). Independent of [#174](https://github.com/codwats/prism/pull/174) — both branch from `main`.

## Empty states ([#161](https://github.com/codwats/prism/issues/161))

Copy quoted from the resolution, not re-authored.

| | Surface | Copy |
|---|---|---|
| A | Deck list, no decks | `No decks yet.` |
| B | Results, no decks | `No decks yet.` — button `Add Your First Deck` → `Add Deck`, icon `inbox` → `layer-group` |
| C | Filter matches nothing | `No cards match your filters. Clear All Filters shows every card again.` |
| D | Stale Marks filter empty | `No stale marks. A stale mark belongs to a deck that no longer needs the card.` |
| H | Decks exist, zero cards | `No cards in any deck. Edit a deck to paste its decklist.` |

A and B carry the same title by design — a reader who clicks B's button lands on A seconds later, where the repetition confirms the button worked. **H is a code change, not a string swap**: `results.js:508` returned before writing a row, leaving a blank table under populated stats. That reads as "PRISM lost your cards."

**Deleted rather than written**, both structurally unreachable: the deck-filter menu's zero-deck branch and `#no-decks-legend` (plus its element ref and both `export-view.js` branches). `results.js:155` hides the cluster holding both when there are no decks.

## Callouts

- **Onboarding callout** takes [#162](https://github.com/codwats/prism/issues/162)'s locked 36 words, with `Cards.svg` and one deep link to `guide.html#read-a-sleeve` ([#160](https://github.com/codwats/prism/issues/160) F3). #162 required an eye check at callout size: at 14rem the edge marks do not read, at 22rem they do, so it ships at 22rem rather than falling back to text.
- **Marking prereq callout** ([#162](https://github.com/codwats/prism/issues/162) F1) was a plain `wa-card` holding safety copy, where #159 requires a `danger`/`warning` callout. It becomes a `warning` callout, `inner Perfect Fit sleeve` becomes `Perfect Fit inner` (`CONTEXT.md:63` *Avoid*), and the retired "read the guide **first**" framing goes.

## Also

- **Export dropdown caption** ([#170](https://github.com/codwats/prism/issues/170)) — one line naming what the printable guide contains, a sibling of the Legend caption sixteen lines above. Names contents, never a control's location.
- **PRISM container definition** ([#162](https://github.com/codwats/prism/issues/162) F3) — `CONTEXT.md:18` requires the container sense on first use, and the header rendered a PRISM's name undefined.
- `POOL` radio → `Pool`; `copy-check.mjs:18` widened to the other two *Avoid* forms (#162 F2).

## Verification

Every surface exercised in the browser against seeded data, not read from source:

- A and B on an empty PRISM ✓
- C by typing a non-matching search ✓
- D on the Stale Marks filter ✓
- H by seeding a PRISM whose one deck holds no cards — renders under live stats as intended ✓
- Onboarding callout, prereq callout, Export caption, Legend dropdown after the `#no-decks-legend` deletion ✓

`node scripts/copy-check.mjs`: **62 → 59**. `build.html` reports zero. The widened regex surfaced two true positives it was blind to — `guide.html:155` (fixed in #174) and `index.html:91` (PR 3).

## One thing this does not fix

The prereq callout fires on the Results tab even when the PRISM has no decks, so it sits above "No decks yet." advising you to finalize decklists you have not written. Pre-existing trigger behavior, not copy — flagging rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)