### PR TITLE
copy: align index.html and tools.html with the locked vocabulary (#157)

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,27 +68,29 @@
 
           <div class="wa-grid wa-gap-xl" style="--min-column-size: 250px;">
             <div class="wa-stack wa-gap-s wa-align-items-center" style="text-align: center;">
-              <div class="wa-frame" style="aspect-ratio: 509 / 390; max-inline-size: 75%;">
-                <img src="./assets/Deck-List.svg" alt="icon-of-deck-list" />
+              <div class="wa-frame" style="block-size: 11rem; inline-size: 100%;">
+                <img src="./assets/Deck-List.svg" alt="icon-of-deck-list" style="object-fit: contain;" />
               </div>
               <h3 class="wa-heading-xl">Import Your Decks</h3>
-              <p>Paste a deck URL from Moxfield or Archidekt. You can also type a list by hand. PRISM gives each deck one color and one stripe position. A single PRISM holds up to 48 decks, or 96 with dot splits.</p>
+              <p>Paste a deck URL from Moxfield or Archidekt. You can also type a list by hand. PRISM gives each deck one color and one slot. A single PRISM holds up to 48 decks, or 96 with dot splits.</p>
             </div>
             <div class="wa-stack wa-gap-s wa-align-items-center" style="text-align: center;">
-              <div class="wa-frame" style="aspect-ratio: 509 / 390; max-inline-size: 75%;">
-                <img src="./assets/Web-App.svg" alt="icon-of-web-app" />
+              <div class="wa-frame" style="block-size: 11rem; inline-size: 100%;">
+                <img src="./assets/Web-App.svg" alt="icon-of-web-app" style="object-fit: contain;" />
               </div>
 
-              <h3 class="wa-heading-xl">See Your Shared Cards</h3>
-              <p>PRISM finds every card that appears in two or more decks. One Sol Ring is all you need.</p>
+              <h3 class="wa-heading-xl">Find Your Pool Copies</h3>
+              <p>A copy that two or more decks use is Pool. PRISM finds every one of them, so one Sol Ring is all you need.</p>
             </div>
             <div class="wa-stack wa-gap-s wa-align-items-center" style="text-align: center;">
-              <div class="wa-frame" style="aspect-ratio: 509 / 390; max-inline-size: 75%;">
-                <img src="./assets/Spririt-Guide.svg" alt="icon-of-marking-guide" />
+              <!-- Full width, not 75%: this is a diagram of the jig's slot comb
+                   with a mark passing through it, unreadable at icon scale (#163 F1). -->
+              <div class="wa-frame" style="block-size: 11rem; inline-size: 100%;">
+                <img src="./assets/Spririt-Guide.svg" alt="The Spirit Guide jig over a sleeve, with a mark drawn through one slot of its comb" style="object-fit: contain;" />
               </div>
 
               <h3 class="wa-heading-xl">Mark Your Sleeves</h3>
-              <p>Use paint pens and the Spirit Guide alignment tool to mark the visible edge of each sleeve. Mark the Perfect Fit inner sleeve, never the outer sleeve. Double-sleeving is required. The outer sleeve protects the mark.</p>
+              <p>Use paint pens and the Spirit Guide alignment tool to mark the visible edge of each sleeve. Mark the Perfect Fit inner, never the outer sleeve. Double-sleeving is required. The outer sleeve protects the mark.</p>
             </div>
             
           </div>
@@ -114,7 +116,7 @@
                 <wa-icon name="paintbrush" style="font-size: 1.25em; color: var(--wa-color-brand-fill);"></wa-icon>
                 <span class="wa-body-l">Smart Marking</span>
               </div>
-              <p>Each deck gets one color and one fixed stripe position. Fan your cards, find the stripes, and pull the deck.</p>
+              <p>Each deck gets one color and one fixed slot. Fan your cards, find the stripes, and pull the deck.</p>
             </wa-card>
 
             <wa-card>
@@ -130,7 +132,7 @@
                 <wa-icon name="code-branch" style="font-size: 1.25em; color: var(--wa-color-brand-fill);"></wa-icon>
                 <span class="wa-body-l">Deck Variants</span>
               </div>
-              <p>Run one core commander shell with several themes. Mark the shared cards once, then mark each variant on its own. PRISM tracks the shell and its variants as one group.</p>
+              <p>Run one commander shell with several themes. Mark the copies every variant uses once, then mark each variant on its own. PRISM tracks the shell and its variants as one group.</p>
             </wa-card>
 
 
@@ -163,7 +165,7 @@
                 <wa-icon name="layer-group" style="font-size: 1.25em; color: var(--wa-color-brand-fill);"></wa-icon>
                 <span class="wa-body-l">Up to 48 Decks</span>
               </div>
-              <p>A single PRISM holds up to 48 decks, or 96 with dot splits. Each deck gets its own stripe position. For a larger collection, create more than one PRISM.</p>
+              <p>A single PRISM holds up to 48 decks, or 96 with dot splits. Each deck gets its own slot. For a larger collection, create more than one PRISM.</p>
             </wa-card>
           </div>
         </section>

--- a/tools.html
+++ b/tools.html
@@ -84,7 +84,7 @@
                   <li>PC-1M (extra fine) recommended</li>
                   <li>Wide color range</li>
                   <li>Dries in seconds</li>
-                  <li>Won't smear once dry</li>
+                  <li>Does not smear once dry</li>
                 </ul>
               </div>
             </wa-card>
@@ -158,7 +158,7 @@
             <wa-icon name="layer-group" style="margin-right: var(--wa-space-s);"></wa-icon>
             Sleeve Recommendations
           </h2>
-          <p>Most perfect-fit inner sleeves work well. We recommend:</p>
+          <p>Most Perfect Fit inner sleeves work well. We recommend:</p>
 
           <ul style="padding-left: var(--wa-space-xl); line-height: 2;">
             <li>
@@ -185,7 +185,7 @@
 
           <wa-callout variant="neutral">
             <wa-icon slot="icon" name="circle-info"></wa-icon>
-            <strong>Double-sleeving:</strong> Mark the inner sleeve on the card-face side. The marks are subtle and won't be felt through the outer sleeve.
+            <strong>Double-sleeving:</strong> Mark the Perfect Fit inner on the card-face side. The marks are subtle, and you do not feel them through the outer sleeve.
           </wa-callout>
         </section>
 
@@ -197,7 +197,7 @@
             <wa-icon name="handshake-angle" style="margin-right: var(--wa-space-s);"></wa-icon>
             PRISM Spirit Guide
           </h2>
-          <p>The Spirit Guide is a marking jig that holds your sleeve in place with guides for each stripe position. It makes marking faster, more consistent, and lets you work one-handed with its magnetic hold.</p>
+          <p>The Spirit Guide is a marking jig that holds your sleeve in place with guides for each slot. It makes marking faster, more consistent, and lets you work one-handed with its magnetic hold.</p>
 
           <wa-card appearance="filled" style="background: var(--wa-color-surface-2);">
             <div class="wa-stack wa-gap-m">
@@ -237,7 +237,7 @@
             <wa-icon name="box-archive" style="margin-right: var(--wa-space-s);"></wa-icon>
             Storage and Organization
           </h2>
-          <p>Once you're sharing cards across decks, a good storage system saves time at the table.</p>
+          <p>Once you share cards across decks, a good storage system saves time at the table.</p>
 
           <p>
             For smaller collections (8-10 decks), the
@@ -249,7 +249,7 @@
 
           <wa-callout variant="neutral">
             <wa-icon slot="icon" name="lightbulb"></wa-icon>
-            <strong>Store shared cards in a central pool box.</strong> Organize by stripe grouping (shared cards first, then by color) or by card type. When you're building a deck for the night, pull from the pool. Return everything when you're done.
+            <strong>Store your Pool copies in one central box.</strong> Organize by stripe grouping (Pool copies first, then by color) or by card type. Pull from that box when you build a deck for the night, then return everything afterwards.
           </wa-callout>
         </section>
 


### PR DESCRIPTION
PR 3 of 3 in the drafting handoff from [#157](https://github.com/codwats/prism/issues/157). The last of the ~30 drifting strings [#158](https://github.com/codwats/prism/issues/158) inventoried, on the two pages the guide rewrite does not touch. Branches from `main`, independent of [#174](https://github.com/codwats/prism/pull/174) and [#175](https://github.com/codwats/prism/pull/175).

## `index.html`

- **The Pool rung.** `See Your Shared Cards` becomes `Find Your Pool Copies` and carries a first-use definition: "A copy that two or more decks use is Pool." This is the rung [#159](https://github.com/codwats/prism/issues/159) explicitly put in scope.
- **`slot`, not `position`** in three places, plus the Deck Variants card, which said "shared cards".
- **`Spririt-Guide.svg` scale** ([#163](https://github.com/codwats/prism/issues/163) F1). It was rendering at `max-inline-size: 75%` of a `509 × 390` frame, where the slot comb and the mark passing through it are invisible — throwing away the one drawing on the landing page that teaches the physical mechanic. All three How It Works frames now take a fixed `11rem` height with `object-fit: contain`, so the diagram is legible **and** the three headings still line up. Its alt text stops calling a diagram an icon.

## `tools.html`

Four contractions expanded. `perfect-fit inner sleeves` and a bare `inner sleeve` become `Perfect Fit inner` (`CONTEXT.md:63`). The storage callout said "shared cards" twice and now names Pool. `guides for each stripe position` becomes `guides for each slot`.

## Verification

`node scripts/copy-check.mjs`: **62 → 48**. `index.html` and `tools.html` both report zero.

Both pages read end to end in the browser. The How It Works row was checked against a baseline render — the first attempt fixed the drawing but pushed the third heading 47px below the other two, and the second cropped the two icons. The shipped version does neither.

## Residue after all three PRs

`copy-check` will not reach zero, by design. What stays red:

- `position` inside `results.js` identifiers — `stripePosition` is deliberate per `CONTEXT.md:59`, "do not align either direction"
- `—` inside JS string and comment lines
- `layout.js` auth-dialog contractions — `layout.js` sits outside #159's stated scope

Worth a follow-up decision on whether the check should skip code identifiers, so a clean run means something.

🤖 Generated with [Claude Code](https://claude.com/claude-code)