### PR TITLE
Fix sitewide token/font drift, static-page audit findings, and the build.html critique

### DIFF
--- a/.impeccable/critique/2026-08-16T23-23-44Z__guide-html.md
+++ b/.impeccable/critique/2026-08-16T23-23-44Z__guide-html.md
@@ -1,0 +1,129 @@
+---
+target: guide.html (static pages critique)
+total_score: 27
+max_score: 40
+na_heuristics: 
+p0_count: 2
+p1_count: 2
+timestamp: 2026-08-16T23-23-44Z
+slug: guide-html
+---
+# Design Critique — PRISM static pages (index.html, guide.html, tools.html)
+
+Method: dual-agent (A: design review, isolated · B: detector + evidence, isolated). Browser automation unavailable (Chrome extension not connected) — no page was visually rendered; both assessments are source-derived. Assessment A resolved the Web Awesome 3.11.0 CDN cascade by hand. The five illustration SVGs carrying most of the visual identity could not be opened; the specificity verdict is bounded by that.
+
+Process note: the detector initially ran degraded (regex-only — `htmlparser2`, `css-select`, `css-tree`, `domutils` missing). Those four packages were installed to `/home/cody/node_modules` and the scan re-run at full fidelity, surfacing a second finding.
+
+## Design Health Score
+
+| # | Heuristic | index (Persuade) | guide (Read) | tools (Read) | Key issue |
+|---|---|:--:|:--:|:--:|---|
+| 1 | Visibility of System Status | 2 | 3 | 2 | `wa-cloak` + `wa-page:not(:defined){visibility:hidden}` hide the entire page until the WA CDN executes — no timeout, no fallback |
+| 2 | Match System / Real World | 3 | 3 | 2 | `guide.html:188` names a "Grouped by Mark" filter; app ships "One Mark at a Time" (`build.html:368`) |
+| 3 | User Control and Freedom | 3 | 3 | 3 | Clean anchors, no modals; no back-to-top on a 7-section procedure |
+| 4 | Consistency and Standards | 1 | 2 | 2 | All 8 feature `<h3>` are `wa-body-l` → sans 400 headings over sans 400 body; DESIGN.md §3 forbids the inversion |
+| 5 | Error Prevention | 2 | 3 | 1 | `tools.html:86` "Dries in seconds" vs `guide.html:157` "dry for 2 to 3 minutes" |
+| 6 | Recognition Rather Than Recall | 3 | 2 | 2 | guide §4 requires holding side, slot, corner, deck color, Pool/Core, and full mark-set with no on-page reference |
+| 7 | Flexibility and Efficiency | 2 | 2 | 2 | No print affordance on the document read with wet paint on your hands |
+| 8 | Aesthetic and Minimalist | 2 | 3 | 3 | Four `wa-divider`s chop index into equal slabs; "48 decks, or 96 with dot splits" stated verbatim twice |
+| 9 | Error Recovery | 1 | 3 | 2 | Both index CTAs are `<wa-button href>` with no click fallback — the trap CLAUDE.md documents by name |
+| 10 | Help and Documentation | 3 | 3 | 3 | index's "Mark Your Sleeves" step never links to guide.html |
+| | **Total** | **22/40** | **27/40** | **22/40** | **71/120 (59%) — Acceptable** |
+
+All ten scored on index (not n/a for 7/10): `layout.js` imports `getAllPrisms`, so the page knows whether you are a returning user with 12 decks and shows the identical cold-start CTA anyway.
+
+## Design Specificity Verdict
+
+**2/5 — authored copy inside an unauthored composition.**
+
+The writing could not have been produced for another product ("A Sol Ring in six decks is one Pool copy with six marks on it. It is not six cards."). The composition is stock: `wa-stack` → `wa-divider` → `wa-grid` of `wa-card` → `wa-divider` → CTA → FAQ.
+
+`css/custom.css` is 1472 lines and contains ZERO rules for these three pages beyond `.theme-logo-dark/light`. Every PRISM primitive DESIGN.md §4 defines as mandatory — ColorSwatch, DeckColorIndicator, StripeIndicator, SleeveSlot, counting numeral, 12px Sleeve — appears on NONE of the three pages. The WUBRG hexes appear in none of them. A product about colored marks at fixed positions has three public pages with no color and no positions.
+
+Deterministic scan (full engine): 2 findings, both false positives.
+- `cramped-padding`, tools.html wa-card — `<wa-card>` pads via shadow DOM `::part(body)`, invisible to a static scanner (verified tools.html:202-216).
+- `design-system-font-size`, tools.html:205 — `font-size: 2rem` on a `<wa-icon>` glyph, not text; codebase-wide idiom (profile.html:107 identical).
+
+Independently confirmed by the mechanical pass: index.html has no `<h1>`; 0 of 13 images set `width`/`height` or `loading="lazy"` (5 below-fold on guide.html).
+
+No visual overlays — browser mutation never available, no server started.
+
+## Overall Impression
+
+Biggest miss is not visual: the landing page never states the payoff. PRODUCT.md requires the money saved stay legible and explicitly clears README.md:63-67's real numbers for marketing (10 decks → 358 duplicates → ~$1,637). None appear on index.html. The only dollar reference is inside a collapsed `<wa-details>` at line 205 behind a question that presupposes adoption. Meanwhile 8 feature cards and ~250 words go to mechanism.
+
+## What's Working
+
+1. **The voice.** Every sentence resolves to something picturable with the hands. Zero exclamation points, em-dashes, emoji, or hype words in visible copy across all three pages (verified mechanically).
+2. **`guide.html:208-219` "Fix a mark you no longer want."** Enumerates failure modes before remedies, then gives the answer the product does not benefit from: replace the sleeve. Admitting unrecoverable failure is what buys trust in the rest.
+3. **The scroll-spy step bar** (`guide.html:77-86`, `236-262`). `IntersectionObserver` with `rootMargin: '-20% 0px -60% 0px'` — asymmetric band firing on the reading zone, not the viewport. `pointer-events: none` overflow chevron; `flex-wrap: nowrap` commented with its actual reason.
+
+## Priority Issues
+
+### [P0] tools.html and guide.html contradict on paint dry time
+`tools.html:86` (card tagged Recommended): "Dries in seconds". `guide.html:157`: "Let the marks dry for 2 to 3 minutes before you sleeve the card. Wet paint transfers to the outer sleeve and to the card face."
+Two pages read in sequence disagree on the timing that decides whether wet acrylic reaches a card face. Tools is read first and is more confident.
+Fix: `tools.html:86` → "Touch-dry in about a minute"; add an identically-worded "Wait 2 to 3 minutes before resleeving" to all four pen cards.
+Command: /impeccable clarify
+
+### [P0] guide.html sends users to a filter the app does not have
+`guide.html:188` "The Grouped by Mark filter"; `build.html:368` ships "One Mark at a Time". Worse, `CONTEXT.md:26` asserts the control reads "Grouped by Mark" and calls the mismatch deliberate — the glossary is stale, so copy written from the source of truth will reintroduce this.
+Fix: correct guide.html:188 and CONTEXT.md:26 in the same commit.
+Command: /impeccable clarify
+
+### [P0] Both index.html CTAs are dead until the CDN upgrades them
+`index.html:54` and `:185` are `<wa-button href="build.html">`; index.html contains zero inline JS. CLAUDE.md documents this trap by name and `layout.js:369-374` implements the fallback — but only for the profile nav button. Combined with `wa-cloak`, a stalled CDN yields a blank white document with no timeout.
+Fix: add the click fallback to both CTAs; give `wa-cloak` a timeout so the page reveals unstyled rather than never.
+Command: /impeccable harden
+
+### [P1] index.html omits the money — the entire product payoff
+Hero (45-63) and Features grid (104-173) contain no figure. README.md:63-67 holds pre-approved numbers (5 → 166 → ~$919; 10 → 358 → ~$1,637; 48 → 2,295 → ~$9,680).
+Fix: payoff in the hero subhead (line 50); three-row band with the real table between How It Works and Features plus provenance note; cut Features from 8 to 4. Do not round or dramatize.
+Command: /impeccable bolder
+
+### [P1] index.html inverts the typographic signature and has no `<h1>`
+All eight feature titles are `<h3 class="wa-body-l">`. WA 3.11.0 `utilities/text.css` sets `[class*='wa-body']` to `--wa-font-family-body` weight 400 — identical family and weight to the paragraph below, separated only by size. DESIGN.md §3 specifies adobe-aldine 1.375rem/600 and forbids sans-over-serif inversion. Heading outline is `h2, h3×3, h2, h3×8, h2, h2` with no `<h1>` (hero is `<div>`s). Five FAQ summaries use `wa-caption-m` → `--wa-color-text-quiet`, rendering questions quieter than their answers.
+Fix: `wa-body-l` → `wa-heading-m` on all eight; promote hero to a real `<h1>`; FAQ summaries → `wa-body-m` weight 500. Also index.html:46 renders the eyebrow string "One card. Every deck.™" as `wa-heading-m` serif.
+Command: /impeccable typeset
+
+### [P1] Ten uses of a banned word, in alt text and meta descriptions
+DESIGN.md §7 bans "jig". Occurrences: guide.html:151, :170, :202, :165 (alt), :166 (alt); tools.html:200, :15 (meta description), :47 (alt); index.html:91 (alt). Also tools.html:161 "Perfect Fit inner sleeves" (CONTEXT.md: use "Perfect Fit inner") and index.html:215 "Can I reorder the stripe positions?" (CONTEXT.md: use "slot" — and the answer directly below correctly says "slot picker").
+Alt text and meta descriptions are user-facing; screen-reader users and search snippets get the banned word.
+Fix: "jig" → "alignment tool" (matching index.html:95). Add these five strings to a copy-lint.
+Command: /impeccable clarify
+
+### [P2] The marking procedure has no verification step and orders work most-valuable-first
+`guide.html:142` "Mark the Pool cards first, because they carry the most marks." Pool cards are the shared staples — Sol Ring, Mana Crypt. The first paint stroke, made before the user has verified their understanding of corner/side/slot, lands on the most expensive cards, and a miscount is discovered only after repeating it across the Pool. Step 1 validates the pen; nothing validates the user.
+Fix: insert "Mark one card completely, resleeve it, and check it against PRISM before you do the rest." Amend line 142 to send the first card at a bulk common carrying several marks.
+Command: /impeccable harden
+
+## Persona Red Flags
+
+**Jordan (first-timer on index.html)** — No `<h1>`, no sentence saying what happens or why. Line 77 "or 96 with dot splits" is the first use of site vocabulary with no referent. Line 85 introduces capital-P "Pool" with no link to guide.html. The two hero CTAs are near-equal weight and neither links to guide.html. Line 95 "Double-sleeving is required" — the one hard prerequisite — is the last sentence of the third card in a grid.
+
+**Riley (stress tester on guide.html)** — Finds the ghost "Grouped by Mark" filter. `guide.html:151`, the most physically consequential instruction, is one clause with no adjacent image (the Spirit Guide illustrations are 14 lines and a callout later) and no orientation info. Line 152 allows "3 to 7mm" — 2.3× tolerance on a mark that must be distinguishable from 47 neighbours — with corrective advice arriving 11 lines after painting. The procedure is two `<ol>`s with hardcoded `start="6"`; screen readers announce "list of 5" then "list of 2". Confirms the beta review's dot-variant bug is genuinely fixed and now matches processor.js.
+
+**Casey (kitchen table, one-handed, wet pen)** — Step bar is seven `<wa-tag size="small">` chips in `nowrap; overflow-x: auto`. At 390px ~1.5 chips visible; small WA tags are far under the 44×44px minimum DESIGN.md §8 mandates, and they are the only navigation. `scroll-margin-top: 9rem` on 390×844 under header + sticky bar leaves a fraction of the screen. Nothing collapsible — step 4 back to the slot diagram is ~40 paragraphs. If the CDN stalls, `wa-cloak` gives a blank white screen mid-session.
+
+**Morgan (project-derived: 20 decks, ~$2,000 collection, deciding)** — No number on either side of the trade. No dollar benefit (withheld). No cost: no time-per-card, no session length, no pen count, no sleeve count. `guide.html:141` defines a session as "one sitting" without saying how big. The only duration on the site is `tools.html:223` "Roughly 45 minutes" — to print a file that does not exist. tools.html never says Morgan needs one pen per deck color, which at 20 decks means 20 colors (a fact living only in `DEFAULT_COLORS`); Morgan buys a 12-pack and discovers the shortfall at deck 13.
+
+## Minor Observations
+
+- `--wa-space-scale: 1.125` (`layout.js:206`) contradicts DESIGN.md §5 ("base × 0.875", "compact and data-heavy"). Shipped scale is 1.29× the documented one; changelog does not record a change.
+- Active nav link is `--wa-color-brand-60` `#9c90bd` (`layout.js:324`), ~2.9:1 on white. DESIGN.md §2.6: "On white, text is never lighter than step 40." The current-page indicator fails the project's own non-negotiable rule.
+- Em-dashes in shipped copy from `layout.js:412` and `:468` ("PRISM is in open beta — …"), rendering on all three pages. The three target files are clean; shared chrome is not.
+- `--wa-color-text-quiet` is never defined by PRISM. Every `wa-caption-*` colors from it via the WA CDN theme and happens to pass AA. Luck, not control.
+- `tools.html:45-56` is malformed: `class="wa-flank:end"` sits on the child `<div>`, not the container; works by accident via custom-property inheritance. Contains an empty `wa-stack` where a subtitle should be — the only page whose `<h1>` has no supporting line.
+- 0 of 13 images set `width`/`height` or `loading="lazy"` (5 below-fold on guide.html). Alt-text quality is above average throughout.
+- tools.html pen cards use state colors as a quality ladder (`success`/`neutral`/`warning`/`brand`); DESIGN.md §2 reserves state ramps for state. Product-name links are `color: inherit; text-decoration: none` — the four buying links have zero affordance. "Can rub off on frequently moved cards" is styled identically to "Easy to wipe off if you make a mistake."
+- `tools.html:211-214`: disabled "Coming Soon" under "Print Settings (v1)", above five settings for a nonexistent file. Beta review asked for softening; unchanged.
+- Feature names diverge from the app: "Overlap View" is `Deck Overlap Matrix` (build.html:336); "Deck Variants" is "split group" everywhere else.
+- Heading casing diverges: index Title Case, guide sentence case, tools Title Case.
+
+## Questions to Consider
+
+1. The landing page shows zero colors and zero slots. Why is the hero not a live marked sleeve, built from the StripeIndicator / SleeveSlot / DeckColorIndicator / Sleeve primitives that already exist?
+2. guide.html assumes it is read by someone whose hands are covered in acrylic. DESIGN.md §8 already specifies a print mode. Should the marking-session section be a print card you tape to the table, with the web page as reference rather than procedure?
+3. Would one honest line — "about 700 cards, one weekend, ~$1,600 in duplicates you can sell" — outperform all eight feature cards combined?
+4. Should "Mark the Pool cards first" survive a rewrite at all, or is efficiency the wrong optimization target for a first session?
+5. Three pages, one 29KB design system, four different answers to "what is a heading." Is the failure in the document, or is the missing artifact a set of composed page-level patterns a page author picks up whole?

--- a/.impeccable/critique/2026-08-16T23-23-44Z__index-html.md
+++ b/.impeccable/critique/2026-08-16T23-23-44Z__index-html.md
@@ -1,0 +1,129 @@
+---
+target: index.html (static pages critique)
+total_score: 22
+max_score: 40
+na_heuristics: 
+p0_count: 3
+p1_count: 3
+timestamp: 2026-08-16T23-23-44Z
+slug: index-html
+---
+# Design Critique — PRISM static pages (index.html, guide.html, tools.html)
+
+Method: dual-agent (A: design review, isolated · B: detector + evidence, isolated). Browser automation unavailable (Chrome extension not connected) — no page was visually rendered; both assessments are source-derived. Assessment A resolved the Web Awesome 3.11.0 CDN cascade by hand. The five illustration SVGs carrying most of the visual identity could not be opened; the specificity verdict is bounded by that.
+
+Process note: the detector initially ran degraded (regex-only — `htmlparser2`, `css-select`, `css-tree`, `domutils` missing). Those four packages were installed to `/home/cody/node_modules` and the scan re-run at full fidelity, surfacing a second finding.
+
+## Design Health Score
+
+| # | Heuristic | index (Persuade) | guide (Read) | tools (Read) | Key issue |
+|---|---|:--:|:--:|:--:|---|
+| 1 | Visibility of System Status | 2 | 3 | 2 | `wa-cloak` + `wa-page:not(:defined){visibility:hidden}` hide the entire page until the WA CDN executes — no timeout, no fallback |
+| 2 | Match System / Real World | 3 | 3 | 2 | `guide.html:188` names a "Grouped by Mark" filter; app ships "One Mark at a Time" (`build.html:368`) |
+| 3 | User Control and Freedom | 3 | 3 | 3 | Clean anchors, no modals; no back-to-top on a 7-section procedure |
+| 4 | Consistency and Standards | 1 | 2 | 2 | All 8 feature `<h3>` are `wa-body-l` → sans 400 headings over sans 400 body; DESIGN.md §3 forbids the inversion |
+| 5 | Error Prevention | 2 | 3 | 1 | `tools.html:86` "Dries in seconds" vs `guide.html:157` "dry for 2 to 3 minutes" |
+| 6 | Recognition Rather Than Recall | 3 | 2 | 2 | guide §4 requires holding side, slot, corner, deck color, Pool/Core, and full mark-set with no on-page reference |
+| 7 | Flexibility and Efficiency | 2 | 2 | 2 | No print affordance on the document read with wet paint on your hands |
+| 8 | Aesthetic and Minimalist | 2 | 3 | 3 | Four `wa-divider`s chop index into equal slabs; "48 decks, or 96 with dot splits" stated verbatim twice |
+| 9 | Error Recovery | 1 | 3 | 2 | Both index CTAs are `<wa-button href>` with no click fallback — the trap CLAUDE.md documents by name |
+| 10 | Help and Documentation | 3 | 3 | 3 | index's "Mark Your Sleeves" step never links to guide.html |
+| | **Total** | **22/40** | **27/40** | **22/40** | **71/120 (59%) — Acceptable** |
+
+All ten scored on index (not n/a for 7/10): `layout.js` imports `getAllPrisms`, so the page knows whether you are a returning user with 12 decks and shows the identical cold-start CTA anyway.
+
+## Design Specificity Verdict
+
+**2/5 — authored copy inside an unauthored composition.**
+
+The writing could not have been produced for another product ("A Sol Ring in six decks is one Pool copy with six marks on it. It is not six cards."). The composition is stock: `wa-stack` → `wa-divider` → `wa-grid` of `wa-card` → `wa-divider` → CTA → FAQ.
+
+`css/custom.css` is 1472 lines and contains ZERO rules for these three pages beyond `.theme-logo-dark/light`. Every PRISM primitive DESIGN.md §4 defines as mandatory — ColorSwatch, DeckColorIndicator, StripeIndicator, SleeveSlot, counting numeral, 12px Sleeve — appears on NONE of the three pages. The WUBRG hexes appear in none of them. A product about colored marks at fixed positions has three public pages with no color and no positions.
+
+Deterministic scan (full engine): 2 findings, both false positives.
+- `cramped-padding`, tools.html wa-card — `<wa-card>` pads via shadow DOM `::part(body)`, invisible to a static scanner (verified tools.html:202-216).
+- `design-system-font-size`, tools.html:205 — `font-size: 2rem` on a `<wa-icon>` glyph, not text; codebase-wide idiom (profile.html:107 identical).
+
+Independently confirmed by the mechanical pass: index.html has no `<h1>`; 0 of 13 images set `width`/`height` or `loading="lazy"` (5 below-fold on guide.html).
+
+No visual overlays — browser mutation never available, no server started.
+
+## Overall Impression
+
+Biggest miss is not visual: the landing page never states the payoff. PRODUCT.md requires the money saved stay legible and explicitly clears README.md:63-67's real numbers for marketing (10 decks → 358 duplicates → ~$1,637). None appear on index.html. The only dollar reference is inside a collapsed `<wa-details>` at line 205 behind a question that presupposes adoption. Meanwhile 8 feature cards and ~250 words go to mechanism.
+
+## What's Working
+
+1. **The voice.** Every sentence resolves to something picturable with the hands. Zero exclamation points, em-dashes, emoji, or hype words in visible copy across all three pages (verified mechanically).
+2. **`guide.html:208-219` "Fix a mark you no longer want."** Enumerates failure modes before remedies, then gives the answer the product does not benefit from: replace the sleeve. Admitting unrecoverable failure is what buys trust in the rest.
+3. **The scroll-spy step bar** (`guide.html:77-86`, `236-262`). `IntersectionObserver` with `rootMargin: '-20% 0px -60% 0px'` — asymmetric band firing on the reading zone, not the viewport. `pointer-events: none` overflow chevron; `flex-wrap: nowrap` commented with its actual reason.
+
+## Priority Issues
+
+### [P0] tools.html and guide.html contradict on paint dry time
+`tools.html:86` (card tagged Recommended): "Dries in seconds". `guide.html:157`: "Let the marks dry for 2 to 3 minutes before you sleeve the card. Wet paint transfers to the outer sleeve and to the card face."
+Two pages read in sequence disagree on the timing that decides whether wet acrylic reaches a card face. Tools is read first and is more confident.
+Fix: `tools.html:86` → "Touch-dry in about a minute"; add an identically-worded "Wait 2 to 3 minutes before resleeving" to all four pen cards.
+Command: /impeccable clarify
+
+### [P0] guide.html sends users to a filter the app does not have
+`guide.html:188` "The Grouped by Mark filter"; `build.html:368` ships "One Mark at a Time". Worse, `CONTEXT.md:26` asserts the control reads "Grouped by Mark" and calls the mismatch deliberate — the glossary is stale, so copy written from the source of truth will reintroduce this.
+Fix: correct guide.html:188 and CONTEXT.md:26 in the same commit.
+Command: /impeccable clarify
+
+### [P0] Both index.html CTAs are dead until the CDN upgrades them
+`index.html:54` and `:185` are `<wa-button href="build.html">`; index.html contains zero inline JS. CLAUDE.md documents this trap by name and `layout.js:369-374` implements the fallback — but only for the profile nav button. Combined with `wa-cloak`, a stalled CDN yields a blank white document with no timeout.
+Fix: add the click fallback to both CTAs; give `wa-cloak` a timeout so the page reveals unstyled rather than never.
+Command: /impeccable harden
+
+### [P1] index.html omits the money — the entire product payoff
+Hero (45-63) and Features grid (104-173) contain no figure. README.md:63-67 holds pre-approved numbers (5 → 166 → ~$919; 10 → 358 → ~$1,637; 48 → 2,295 → ~$9,680).
+Fix: payoff in the hero subhead (line 50); three-row band with the real table between How It Works and Features plus provenance note; cut Features from 8 to 4. Do not round or dramatize.
+Command: /impeccable bolder
+
+### [P1] index.html inverts the typographic signature and has no `<h1>`
+All eight feature titles are `<h3 class="wa-body-l">`. WA 3.11.0 `utilities/text.css` sets `[class*='wa-body']` to `--wa-font-family-body` weight 400 — identical family and weight to the paragraph below, separated only by size. DESIGN.md §3 specifies adobe-aldine 1.375rem/600 and forbids sans-over-serif inversion. Heading outline is `h2, h3×3, h2, h3×8, h2, h2` with no `<h1>` (hero is `<div>`s). Five FAQ summaries use `wa-caption-m` → `--wa-color-text-quiet`, rendering questions quieter than their answers.
+Fix: `wa-body-l` → `wa-heading-m` on all eight; promote hero to a real `<h1>`; FAQ summaries → `wa-body-m` weight 500. Also index.html:46 renders the eyebrow string "One card. Every deck.™" as `wa-heading-m` serif.
+Command: /impeccable typeset
+
+### [P1] Ten uses of a banned word, in alt text and meta descriptions
+DESIGN.md §7 bans "jig". Occurrences: guide.html:151, :170, :202, :165 (alt), :166 (alt); tools.html:200, :15 (meta description), :47 (alt); index.html:91 (alt). Also tools.html:161 "Perfect Fit inner sleeves" (CONTEXT.md: use "Perfect Fit inner") and index.html:215 "Can I reorder the stripe positions?" (CONTEXT.md: use "slot" — and the answer directly below correctly says "slot picker").
+Alt text and meta descriptions are user-facing; screen-reader users and search snippets get the banned word.
+Fix: "jig" → "alignment tool" (matching index.html:95). Add these five strings to a copy-lint.
+Command: /impeccable clarify
+
+### [P2] The marking procedure has no verification step and orders work most-valuable-first
+`guide.html:142` "Mark the Pool cards first, because they carry the most marks." Pool cards are the shared staples — Sol Ring, Mana Crypt. The first paint stroke, made before the user has verified their understanding of corner/side/slot, lands on the most expensive cards, and a miscount is discovered only after repeating it across the Pool. Step 1 validates the pen; nothing validates the user.
+Fix: insert "Mark one card completely, resleeve it, and check it against PRISM before you do the rest." Amend line 142 to send the first card at a bulk common carrying several marks.
+Command: /impeccable harden
+
+## Persona Red Flags
+
+**Jordan (first-timer on index.html)** — No `<h1>`, no sentence saying what happens or why. Line 77 "or 96 with dot splits" is the first use of site vocabulary with no referent. Line 85 introduces capital-P "Pool" with no link to guide.html. The two hero CTAs are near-equal weight and neither links to guide.html. Line 95 "Double-sleeving is required" — the one hard prerequisite — is the last sentence of the third card in a grid.
+
+**Riley (stress tester on guide.html)** — Finds the ghost "Grouped by Mark" filter. `guide.html:151`, the most physically consequential instruction, is one clause with no adjacent image (the Spirit Guide illustrations are 14 lines and a callout later) and no orientation info. Line 152 allows "3 to 7mm" — 2.3× tolerance on a mark that must be distinguishable from 47 neighbours — with corrective advice arriving 11 lines after painting. The procedure is two `<ol>`s with hardcoded `start="6"`; screen readers announce "list of 5" then "list of 2". Confirms the beta review's dot-variant bug is genuinely fixed and now matches processor.js.
+
+**Casey (kitchen table, one-handed, wet pen)** — Step bar is seven `<wa-tag size="small">` chips in `nowrap; overflow-x: auto`. At 390px ~1.5 chips visible; small WA tags are far under the 44×44px minimum DESIGN.md §8 mandates, and they are the only navigation. `scroll-margin-top: 9rem` on 390×844 under header + sticky bar leaves a fraction of the screen. Nothing collapsible — step 4 back to the slot diagram is ~40 paragraphs. If the CDN stalls, `wa-cloak` gives a blank white screen mid-session.
+
+**Morgan (project-derived: 20 decks, ~$2,000 collection, deciding)** — No number on either side of the trade. No dollar benefit (withheld). No cost: no time-per-card, no session length, no pen count, no sleeve count. `guide.html:141` defines a session as "one sitting" without saying how big. The only duration on the site is `tools.html:223` "Roughly 45 minutes" — to print a file that does not exist. tools.html never says Morgan needs one pen per deck color, which at 20 decks means 20 colors (a fact living only in `DEFAULT_COLORS`); Morgan buys a 12-pack and discovers the shortfall at deck 13.
+
+## Minor Observations
+
+- `--wa-space-scale: 1.125` (`layout.js:206`) contradicts DESIGN.md §5 ("base × 0.875", "compact and data-heavy"). Shipped scale is 1.29× the documented one; changelog does not record a change.
+- Active nav link is `--wa-color-brand-60` `#9c90bd` (`layout.js:324`), ~2.9:1 on white. DESIGN.md §2.6: "On white, text is never lighter than step 40." The current-page indicator fails the project's own non-negotiable rule.
+- Em-dashes in shipped copy from `layout.js:412` and `:468` ("PRISM is in open beta — …"), rendering on all three pages. The three target files are clean; shared chrome is not.
+- `--wa-color-text-quiet` is never defined by PRISM. Every `wa-caption-*` colors from it via the WA CDN theme and happens to pass AA. Luck, not control.
+- `tools.html:45-56` is malformed: `class="wa-flank:end"` sits on the child `<div>`, not the container; works by accident via custom-property inheritance. Contains an empty `wa-stack` where a subtitle should be — the only page whose `<h1>` has no supporting line.
+- 0 of 13 images set `width`/`height` or `loading="lazy"` (5 below-fold on guide.html). Alt-text quality is above average throughout.
+- tools.html pen cards use state colors as a quality ladder (`success`/`neutral`/`warning`/`brand`); DESIGN.md §2 reserves state ramps for state. Product-name links are `color: inherit; text-decoration: none` — the four buying links have zero affordance. "Can rub off on frequently moved cards" is styled identically to "Easy to wipe off if you make a mistake."
+- `tools.html:211-214`: disabled "Coming Soon" under "Print Settings (v1)", above five settings for a nonexistent file. Beta review asked for softening; unchanged.
+- Feature names diverge from the app: "Overlap View" is `Deck Overlap Matrix` (build.html:336); "Deck Variants" is "split group" everywhere else.
+- Heading casing diverges: index Title Case, guide sentence case, tools Title Case.
+
+## Questions to Consider
+
+1. The landing page shows zero colors and zero slots. Why is the hero not a live marked sleeve, built from the StripeIndicator / SleeveSlot / DeckColorIndicator / Sleeve primitives that already exist?
+2. guide.html assumes it is read by someone whose hands are covered in acrylic. DESIGN.md §8 already specifies a print mode. Should the marking-session section be a print card you tape to the table, with the web page as reference rather than procedure?
+3. Would one honest line — "about 700 cards, one weekend, ~$1,600 in duplicates you can sell" — outperform all eight feature cards combined?
+4. Should "Mark the Pool cards first" survive a rewrite at all, or is efficiency the wrong optimization target for a first session?
+5. Three pages, one 29KB design system, four different answers to "what is a heading." Is the failure in the document, or is the missing artifact a set of composed page-level patterns a page author picks up whole?

--- a/.impeccable/critique/2026-08-16T23-23-44Z__tools-html.md
+++ b/.impeccable/critique/2026-08-16T23-23-44Z__tools-html.md
@@ -1,0 +1,129 @@
+---
+target: tools.html (static pages critique)
+total_score: 22
+max_score: 40
+na_heuristics: 
+p0_count: 2
+p1_count: 1
+timestamp: 2026-08-16T23-23-44Z
+slug: tools-html
+---
+# Design Critique — PRISM static pages (index.html, guide.html, tools.html)
+
+Method: dual-agent (A: design review, isolated · B: detector + evidence, isolated). Browser automation unavailable (Chrome extension not connected) — no page was visually rendered; both assessments are source-derived. Assessment A resolved the Web Awesome 3.11.0 CDN cascade by hand. The five illustration SVGs carrying most of the visual identity could not be opened; the specificity verdict is bounded by that.
+
+Process note: the detector initially ran degraded (regex-only — `htmlparser2`, `css-select`, `css-tree`, `domutils` missing). Those four packages were installed to `/home/cody/node_modules` and the scan re-run at full fidelity, surfacing a second finding.
+
+## Design Health Score
+
+| # | Heuristic | index (Persuade) | guide (Read) | tools (Read) | Key issue |
+|---|---|:--:|:--:|:--:|---|
+| 1 | Visibility of System Status | 2 | 3 | 2 | `wa-cloak` + `wa-page:not(:defined){visibility:hidden}` hide the entire page until the WA CDN executes — no timeout, no fallback |
+| 2 | Match System / Real World | 3 | 3 | 2 | `guide.html:188` names a "Grouped by Mark" filter; app ships "One Mark at a Time" (`build.html:368`) |
+| 3 | User Control and Freedom | 3 | 3 | 3 | Clean anchors, no modals; no back-to-top on a 7-section procedure |
+| 4 | Consistency and Standards | 1 | 2 | 2 | All 8 feature `<h3>` are `wa-body-l` → sans 400 headings over sans 400 body; DESIGN.md §3 forbids the inversion |
+| 5 | Error Prevention | 2 | 3 | 1 | `tools.html:86` "Dries in seconds" vs `guide.html:157` "dry for 2 to 3 minutes" |
+| 6 | Recognition Rather Than Recall | 3 | 2 | 2 | guide §4 requires holding side, slot, corner, deck color, Pool/Core, and full mark-set with no on-page reference |
+| 7 | Flexibility and Efficiency | 2 | 2 | 2 | No print affordance on the document read with wet paint on your hands |
+| 8 | Aesthetic and Minimalist | 2 | 3 | 3 | Four `wa-divider`s chop index into equal slabs; "48 decks, or 96 with dot splits" stated verbatim twice |
+| 9 | Error Recovery | 1 | 3 | 2 | Both index CTAs are `<wa-button href>` with no click fallback — the trap CLAUDE.md documents by name |
+| 10 | Help and Documentation | 3 | 3 | 3 | index's "Mark Your Sleeves" step never links to guide.html |
+| | **Total** | **22/40** | **27/40** | **22/40** | **71/120 (59%) — Acceptable** |
+
+All ten scored on index (not n/a for 7/10): `layout.js` imports `getAllPrisms`, so the page knows whether you are a returning user with 12 decks and shows the identical cold-start CTA anyway.
+
+## Design Specificity Verdict
+
+**2/5 — authored copy inside an unauthored composition.**
+
+The writing could not have been produced for another product ("A Sol Ring in six decks is one Pool copy with six marks on it. It is not six cards."). The composition is stock: `wa-stack` → `wa-divider` → `wa-grid` of `wa-card` → `wa-divider` → CTA → FAQ.
+
+`css/custom.css` is 1472 lines and contains ZERO rules for these three pages beyond `.theme-logo-dark/light`. Every PRISM primitive DESIGN.md §4 defines as mandatory — ColorSwatch, DeckColorIndicator, StripeIndicator, SleeveSlot, counting numeral, 12px Sleeve — appears on NONE of the three pages. The WUBRG hexes appear in none of them. A product about colored marks at fixed positions has three public pages with no color and no positions.
+
+Deterministic scan (full engine): 2 findings, both false positives.
+- `cramped-padding`, tools.html wa-card — `<wa-card>` pads via shadow DOM `::part(body)`, invisible to a static scanner (verified tools.html:202-216).
+- `design-system-font-size`, tools.html:205 — `font-size: 2rem` on a `<wa-icon>` glyph, not text; codebase-wide idiom (profile.html:107 identical).
+
+Independently confirmed by the mechanical pass: index.html has no `<h1>`; 0 of 13 images set `width`/`height` or `loading="lazy"` (5 below-fold on guide.html).
+
+No visual overlays — browser mutation never available, no server started.
+
+## Overall Impression
+
+Biggest miss is not visual: the landing page never states the payoff. PRODUCT.md requires the money saved stay legible and explicitly clears README.md:63-67's real numbers for marketing (10 decks → 358 duplicates → ~$1,637). None appear on index.html. The only dollar reference is inside a collapsed `<wa-details>` at line 205 behind a question that presupposes adoption. Meanwhile 8 feature cards and ~250 words go to mechanism.
+
+## What's Working
+
+1. **The voice.** Every sentence resolves to something picturable with the hands. Zero exclamation points, em-dashes, emoji, or hype words in visible copy across all three pages (verified mechanically).
+2. **`guide.html:208-219` "Fix a mark you no longer want."** Enumerates failure modes before remedies, then gives the answer the product does not benefit from: replace the sleeve. Admitting unrecoverable failure is what buys trust in the rest.
+3. **The scroll-spy step bar** (`guide.html:77-86`, `236-262`). `IntersectionObserver` with `rootMargin: '-20% 0px -60% 0px'` — asymmetric band firing on the reading zone, not the viewport. `pointer-events: none` overflow chevron; `flex-wrap: nowrap` commented with its actual reason.
+
+## Priority Issues
+
+### [P0] tools.html and guide.html contradict on paint dry time
+`tools.html:86` (card tagged Recommended): "Dries in seconds". `guide.html:157`: "Let the marks dry for 2 to 3 minutes before you sleeve the card. Wet paint transfers to the outer sleeve and to the card face."
+Two pages read in sequence disagree on the timing that decides whether wet acrylic reaches a card face. Tools is read first and is more confident.
+Fix: `tools.html:86` → "Touch-dry in about a minute"; add an identically-worded "Wait 2 to 3 minutes before resleeving" to all four pen cards.
+Command: /impeccable clarify
+
+### [P0] guide.html sends users to a filter the app does not have
+`guide.html:188` "The Grouped by Mark filter"; `build.html:368` ships "One Mark at a Time". Worse, `CONTEXT.md:26` asserts the control reads "Grouped by Mark" and calls the mismatch deliberate — the glossary is stale, so copy written from the source of truth will reintroduce this.
+Fix: correct guide.html:188 and CONTEXT.md:26 in the same commit.
+Command: /impeccable clarify
+
+### [P0] Both index.html CTAs are dead until the CDN upgrades them
+`index.html:54` and `:185` are `<wa-button href="build.html">`; index.html contains zero inline JS. CLAUDE.md documents this trap by name and `layout.js:369-374` implements the fallback — but only for the profile nav button. Combined with `wa-cloak`, a stalled CDN yields a blank white document with no timeout.
+Fix: add the click fallback to both CTAs; give `wa-cloak` a timeout so the page reveals unstyled rather than never.
+Command: /impeccable harden
+
+### [P1] index.html omits the money — the entire product payoff
+Hero (45-63) and Features grid (104-173) contain no figure. README.md:63-67 holds pre-approved numbers (5 → 166 → ~$919; 10 → 358 → ~$1,637; 48 → 2,295 → ~$9,680).
+Fix: payoff in the hero subhead (line 50); three-row band with the real table between How It Works and Features plus provenance note; cut Features from 8 to 4. Do not round or dramatize.
+Command: /impeccable bolder
+
+### [P1] index.html inverts the typographic signature and has no `<h1>`
+All eight feature titles are `<h3 class="wa-body-l">`. WA 3.11.0 `utilities/text.css` sets `[class*='wa-body']` to `--wa-font-family-body` weight 400 — identical family and weight to the paragraph below, separated only by size. DESIGN.md §3 specifies adobe-aldine 1.375rem/600 and forbids sans-over-serif inversion. Heading outline is `h2, h3×3, h2, h3×8, h2, h2` with no `<h1>` (hero is `<div>`s). Five FAQ summaries use `wa-caption-m` → `--wa-color-text-quiet`, rendering questions quieter than their answers.
+Fix: `wa-body-l` → `wa-heading-m` on all eight; promote hero to a real `<h1>`; FAQ summaries → `wa-body-m` weight 500. Also index.html:46 renders the eyebrow string "One card. Every deck.™" as `wa-heading-m` serif.
+Command: /impeccable typeset
+
+### [P1] Ten uses of a banned word, in alt text and meta descriptions
+DESIGN.md §7 bans "jig". Occurrences: guide.html:151, :170, :202, :165 (alt), :166 (alt); tools.html:200, :15 (meta description), :47 (alt); index.html:91 (alt). Also tools.html:161 "Perfect Fit inner sleeves" (CONTEXT.md: use "Perfect Fit inner") and index.html:215 "Can I reorder the stripe positions?" (CONTEXT.md: use "slot" — and the answer directly below correctly says "slot picker").
+Alt text and meta descriptions are user-facing; screen-reader users and search snippets get the banned word.
+Fix: "jig" → "alignment tool" (matching index.html:95). Add these five strings to a copy-lint.
+Command: /impeccable clarify
+
+### [P2] The marking procedure has no verification step and orders work most-valuable-first
+`guide.html:142` "Mark the Pool cards first, because they carry the most marks." Pool cards are the shared staples — Sol Ring, Mana Crypt. The first paint stroke, made before the user has verified their understanding of corner/side/slot, lands on the most expensive cards, and a miscount is discovered only after repeating it across the Pool. Step 1 validates the pen; nothing validates the user.
+Fix: insert "Mark one card completely, resleeve it, and check it against PRISM before you do the rest." Amend line 142 to send the first card at a bulk common carrying several marks.
+Command: /impeccable harden
+
+## Persona Red Flags
+
+**Jordan (first-timer on index.html)** — No `<h1>`, no sentence saying what happens or why. Line 77 "or 96 with dot splits" is the first use of site vocabulary with no referent. Line 85 introduces capital-P "Pool" with no link to guide.html. The two hero CTAs are near-equal weight and neither links to guide.html. Line 95 "Double-sleeving is required" — the one hard prerequisite — is the last sentence of the third card in a grid.
+
+**Riley (stress tester on guide.html)** — Finds the ghost "Grouped by Mark" filter. `guide.html:151`, the most physically consequential instruction, is one clause with no adjacent image (the Spirit Guide illustrations are 14 lines and a callout later) and no orientation info. Line 152 allows "3 to 7mm" — 2.3× tolerance on a mark that must be distinguishable from 47 neighbours — with corrective advice arriving 11 lines after painting. The procedure is two `<ol>`s with hardcoded `start="6"`; screen readers announce "list of 5" then "list of 2". Confirms the beta review's dot-variant bug is genuinely fixed and now matches processor.js.
+
+**Casey (kitchen table, one-handed, wet pen)** — Step bar is seven `<wa-tag size="small">` chips in `nowrap; overflow-x: auto`. At 390px ~1.5 chips visible; small WA tags are far under the 44×44px minimum DESIGN.md §8 mandates, and they are the only navigation. `scroll-margin-top: 9rem` on 390×844 under header + sticky bar leaves a fraction of the screen. Nothing collapsible — step 4 back to the slot diagram is ~40 paragraphs. If the CDN stalls, `wa-cloak` gives a blank white screen mid-session.
+
+**Morgan (project-derived: 20 decks, ~$2,000 collection, deciding)** — No number on either side of the trade. No dollar benefit (withheld). No cost: no time-per-card, no session length, no pen count, no sleeve count. `guide.html:141` defines a session as "one sitting" without saying how big. The only duration on the site is `tools.html:223` "Roughly 45 minutes" — to print a file that does not exist. tools.html never says Morgan needs one pen per deck color, which at 20 decks means 20 colors (a fact living only in `DEFAULT_COLORS`); Morgan buys a 12-pack and discovers the shortfall at deck 13.
+
+## Minor Observations
+
+- `--wa-space-scale: 1.125` (`layout.js:206`) contradicts DESIGN.md §5 ("base × 0.875", "compact and data-heavy"). Shipped scale is 1.29× the documented one; changelog does not record a change.
+- Active nav link is `--wa-color-brand-60` `#9c90bd` (`layout.js:324`), ~2.9:1 on white. DESIGN.md §2.6: "On white, text is never lighter than step 40." The current-page indicator fails the project's own non-negotiable rule.
+- Em-dashes in shipped copy from `layout.js:412` and `:468` ("PRISM is in open beta — …"), rendering on all three pages. The three target files are clean; shared chrome is not.
+- `--wa-color-text-quiet` is never defined by PRISM. Every `wa-caption-*` colors from it via the WA CDN theme and happens to pass AA. Luck, not control.
+- `tools.html:45-56` is malformed: `class="wa-flank:end"` sits on the child `<div>`, not the container; works by accident via custom-property inheritance. Contains an empty `wa-stack` where a subtitle should be — the only page whose `<h1>` has no supporting line.
+- 0 of 13 images set `width`/`height` or `loading="lazy"` (5 below-fold on guide.html). Alt-text quality is above average throughout.
+- tools.html pen cards use state colors as a quality ladder (`success`/`neutral`/`warning`/`brand`); DESIGN.md §2 reserves state ramps for state. Product-name links are `color: inherit; text-decoration: none` — the four buying links have zero affordance. "Can rub off on frequently moved cards" is styled identically to "Easy to wipe off if you make a mistake."
+- `tools.html:211-214`: disabled "Coming Soon" under "Print Settings (v1)", above five settings for a nonexistent file. Beta review asked for softening; unchanged.
+- Feature names diverge from the app: "Overlap View" is `Deck Overlap Matrix` (build.html:336); "Deck Variants" is "split group" everywhere else.
+- Heading casing diverges: index Title Case, guide sentence case, tools Title Case.
+
+## Questions to Consider
+
+1. The landing page shows zero colors and zero slots. Why is the hero not a live marked sleeve, built from the StripeIndicator / SleeveSlot / DeckColorIndicator / Sleeve primitives that already exist?
+2. guide.html assumes it is read by someone whose hands are covered in acrylic. DESIGN.md §8 already specifies a print mode. Should the marking-session section be a print card you tape to the table, with the web page as reference rather than procedure?
+3. Would one honest line — "about 700 cards, one weekend, ~$1,600 in duplicates you can sell" — outperform all eight feature cards combined?
+4. Should "Mark the Pool cards first" survive a rewrite at all, or is efficiency the wrong optimization target for a first session?
+5. Three pages, one 29KB design system, four different answers to "what is a heading." Is the failure in the document, or is the missing artifact a set of composed page-level patterns a page author picks up whole?

--- a/.impeccable/critique/2026-08-17T00-30-00Z__build-html.md
+++ b/.impeccable/critique/2026-08-17T00-30-00Z__build-html.md
@@ -1,0 +1,115 @@
+---
+target: build.html
+total_score: 24
+max_score: 40
+na_heuristics: 
+p0_count: 1
+p1_count: 3
+timestamp: 2026-08-17T00-30-00Z
+slug: build-html
+---
+Method: dual-agent (A: isolated design review · B: isolated detector + browser evidence). Neither saw the other's output. Assessment B had no claude-in-chrome tools and drove system Chromium over CDP directly; overlay injection succeeded.
+
+## Design Health Score
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 3 | Sync status, capacity-aware deck tag and progress ring are solid; the disabled indeterminate roll-up checkbox never explains why it can't be clicked |
+| 2 | Match System / Real World | 3 | Sleeve geometry and "clear 2 copies" are excellent; Pool/Core ships in four casings and "Move Stripe Position" uses the exact term CONTEXT.md forbids |
+| 3 | User Control and Freedom | 2 | "New PRISM" is a one-way door for logged-out users; no undo anywhere |
+| 4 | Consistency and Standards | 2 | Three color-input treatments on one page; one hand-rolled button in the table header; .wa-caption-* ships at line-height 1.2 against DESIGN.md's 1.5 |
+| 5 | Error Prevention | 2 | Strong guards on slot exhaustion and duplicate names, but "Clear All" stale marks destroys the list unconfirmed, and a deck edit that invalidates paint proceeds without confirmation |
+| 6 | Recognition Rather Than Recall | 2 | Stripes column carries deck identity only in a title on an 18px div — unreachable on touch — and the legend is hidden in a dropdown on another visual plane |
+| 7 | Flexibility and Efficiency | 3 | SCRY-Mode keyboard flow, stripe-signature clustering, copy-undone are expert-grade; shortcuts documented nowhere, slot picker has no keyboard path |
+| 8 | Aesthetic and Minimalist Design | 2 | Results toolbar is 6 controls plus a 4-option radio group in one wrapping row; Add Deck is 10 field groups in one card |
+| 9 | Error Recovery | 2 | Parse errors with line numbers are excellent; all form validation is a bottom-right toast with no field focus, on a form taller than the viewport |
+| 10 | Help and Documentation | 3 | Contextual guide.html deep links land at the right moments; Pool vs Core never defined on the tab where the counts appear |
+| **Total** | | **24/40** | **Acceptable — significant improvements needed** |
+
+Error Prevention was moved from Assessment A's 3 to 2 in synthesis: A scored it before knowing the bulk "Clear All" path is both unconfirmed and rendering through four CSS custom properties that do not exist in Web Awesome 3.11.
+
+## Design Specificity Verdict
+
+Split: the engine is unmistakably authored for PRISM, the chrome is category-interchangeable.
+
+Authored-for-PRISM: stripeSignature() (js/features/results.js:36) clusters cards needing the same pens in the same places — a decision made from the physical cost of a pen swap. The slot picker (js/features/stripe-reorder-dialog.js:232) draws a to-scale sleeve with two real edges honoring the chosen starting corner. The multi-batch row (js/features/results.js:433) ships a deliberately disabled roll-up checkbox because a working one would imply marks the user must not paint.
+
+Category-interchangeable: the three stat cards (build.html:283-329) are the stock SaaS metric tile — swap "Pool Cards" for "Monthly Active Users" and nothing changes. The Results toolbar (build.html:347-418) lifts into a CRM unchanged. The original core wears an off-the-shelf shell, and the shell is what a first-time visitor sees first.
+
+Deterministic scan: detect.mjs on build.html exits 0, zero findings. On js/features + js/layout.js it exits 2 with 2 advisory findings, both design-system-font-size (js/features/deck-list.js:891, js/features/stripe-reorder-dialog.js:256). Both false positives — font-size on <wa-icon> is WA's glyph-sizing idiom, not typography. No hardcoded-color rule fired.
+
+Visual overlays: injection succeeded against headless Chromium; overlay reported 11 anti-patterns empty-state, 15 seeded. tight-leading x11 is real and corroborated by DESIGN.md (measured 14px/16.8px = 1.2 vs documented 1.5). Two line-length hits (~166 chars, becoming body-text-viewport-edge at 390px) real but minor. text-occlusion is the overlay panel colliding with a wa-switch, self-inflicted. monotonous-spacing false positive (4px is --wa-space-2xs). No user-visible overlay remains — that browser was headless and is shut down.
+
+## Overall Impression
+
+A tool with a genuinely original core and a first-run surface that hides it. Biggest opportunity: the high-stakes moment is under-weighted while low-stakes chrome is over-built. "3 cards unchecked (new stripes added)" — meaning paint already on sleeves is now incomplete — ships as an auto-dismissing toast (js/features/deck-list.js:470), while session completion earns a disabled dialog and rows fading to 45% opacity: the language of decay, not achievement.
+
+## What's Working
+
+1. Stripe-signature clustering as secondary sort (js/features/results.js:36, applied :559) — optimizes pen swaps and hand travel, not the data. Invisible unless you're holding a pen.
+2. The slot picker refuses to fake its geometry, then solves touch honestly (js/features/stripe-reorder-dialog.js:232, css/custom.css:843-894) — true proportions kept, invisible ::after hit area bled into the 2px gaps, 44px on mobile.
+3. The batch model's refusal of a false affordance (js/features/results.js:433) — designing against convenience because the output is irreversible.
+
+## Priority Issues
+
+### [P0] "New PRISM" strands a logged-out user's entire PRISM, and the dialog copy promises it won't
+Why it matters: header CTA at build.html:658, always visible, top-right. Dialog says "Your current PRISM will be saved and can be accessed later" (build.html:481). False when logged out: NAV_LINKS has no PRISMs entry; profile.html's PRISM list is inside the logged-in block only. Two clicks and every deck plus every mark record is unreachable. The data is the index to paint already on physical sleeves. Beta review HIGH finding #105, still open.
+Fix: add a getAllPrisms()-driven switcher to the existing #prism-overflow dropdown (build.html:64). Rewrite build.html:481 to say where the old PRISM lives. Demote the header CTA.
+Suggested command: /impeccable harden
+
+### [P1] The page has no accessible spine: no headings, an unlabeled primary field, a keyboard-dead slot picker
+Why it matters: (a) No <h1>, no <h2>; first headings are three <h3 class="wa-caption-s"> stat labels at caption size (build.html:289,305,320), so heading nav lands on "Total Cards" and the page title is a wa-input. (b) <wa-textarea id="deck-list" required> (build.html:210) has no label — accessible name measured empty, and because required is set WA renders a bare floating "*" above the decklist box. Same bug at build.html:564 in the edit dialog. The recent a11y commits on this branch missed it. (c) renderSlot (js/features/stripe-reorder-dialog.js:99) builds 48 bare divs with click listeners, no tabindex/role/aria-label; zero role= or tabindex anywhere in js/features/.
+Fix: label both textareas; promote PRISM name to a real h1 and demote the stat labels; give slots role/tabindex/arrow-keys with aria-label from formatSlotLabel(). initColorSwatches (js/features/deck-form.js:41) already does this correctly — copy that pattern.
+Suggested command: /impeccable audit
+
+### [P1] Marked rows fall to ~2.6:1 contrast, and the strikethrough is on the wrong cell
+Why it matters: .results-table .marked-row { opacity: 0.45 } (css/custom.css:122) computes #34353c to ~#a3a3a7 on white, ~2.6:1, failing AA. By session end this is the majority state of the table. css/custom.css:126 applies line-through to td:first-child — the checkbox cell, not the card name (DESIGN.md specifies the name). Stripe swatches also dim, so the painted color is harder to compare against the pen in hand.
+Fix: explicit --wa-color-neutral-text-subtle on the name cell; move line-through to .card-name-cell; hold checkbox and .stripe-indicators at full opacity.
+Suggested command: /impeccable polish
+
+### [P1] At the table, on a phone, the Stripes column is undecodable and the checkbox is half-size
+Why it matters: DESIGN.md §8 commits to usable at the table one-handed. Deck identity lives only in a title attribute on a non-interactive div (js/features/results.js:57); touch never fires title. Indicator shrinks to 14x14 below 600px. Only decoder is the Legend dropdown, closed by default, scrolls away. .mark-checkbox is 18px, 24px on mobile (css/custom.css:935), against a 44px commitment, for the control tapped hundreds of times per session.
+Fix: when countVisibleMarks <= 3 render the deck name as text beside the swatch on narrow viewports; make stripe cells tappable to reveal deck name and slot; give the checkbox cell a 44px ::before hit area as the slot picker already does.
+Suggested command: /impeccable adapt
+
+### [P2] "Clear All" stale marks: four dead CSS tokens, a hand-rolled button, unconfirmed bulk destruction
+Why it matters: .btn-clear-all-removed (css/custom.css:463) uses --wa-border-radius-medium, --wa-font-size-x-small, --wa-space-2x-small, --wa-space-x-small. None exist in the shipped 3.11.0 kit (verified against CDN CSS; 3.11 uses -m/-xs/-2xs). All four declarations dropped: zero padding, square corners, inherited font size — in a table header, reading as broken. Also the only hand-rolled <button> on Results (js/features/results.js:624), against DESIGN.md §4. handleClearAllRemoved (js/features/deck-list.js:277) wipes every stale-mark row with no confirmation; a stale-mark row is the record of paint that must be scraped off a sleeve.
+Fix: <wa-button appearance="outlined" variant="danger" size="small"> plus a confirm reusing #delete-dialog. Sweep custom.css for other WA-2 token names — --wa-color-brand-border-quiet (css/custom.css:1294) is also dead, and DESIGN.md's --wa-border-radius-xl does not exist in 3.11.
+Suggested command: /impeccable harden
+
+## Persona Red Flags
+
+Sam (screen reader + keyboard): slot picker is 48 clickable divs with no role/tabindex/label — a primary action entirely unreachable. Heading nav lands on "Total Cards". Decklist textarea announces as an unnamed required field showing a bare "*". Stripes column title-on-a-div is not reliably announced. Marked rows at 0.45 opacity unreadable at low vision. Credit: initColorSwatches uses real buttons with aria-pressed and aria-label; #color-swatches is a labeled role="group".
+
+Casey (one-handed, at the table): stripes convey nothing without hover; Legend two taps away in a dropdown that closes on scroll; 24px checkbox against a 44px commitment. Add Deck form sits below the entire deck list (build.html:141 after #decks-list at :126) — with 20 decks, a long scroll to the primary creation action, and the only header button is "New PRISM". SCRY-Mode works for her but its launcher is the last of six controls in a wrapping toolbar, landing on its own line at 390px.
+
+Alex (power user): d/s/Enter/-> shortcuts (js/features/scry-mode.js:147) documented nowhere in the UI. Single-column sort only — cannot sort by copies within deck count, the natural batching order. Three separate menus produce files. Well served by stripe-signature clustering, copy-undone, printable guide, URL import with Enter-to-submit.
+
+Jordan (first-timer): the first control on the core page is "Dedicated commander copies" (build.html:119), an expert per-PRISM setting. Decks empty state offers no call to action at all (js/features/deck-list.js:889) while Results' empty state does. Bracket presents 5 options with equal weight to Deck Name and Commander while affecting nothing in the engine.
+
+## Minor Observations
+
+- [P2] The "Position Numbers" preference does nothing. Defaults to none, hint reads "None hides numbers", but positionNumHtml (js/features/results.js:46) renders when exact || showNums, and exact is true for any card with <=5 visible marks regardless of preference. Gate exact on numbersMode !== 'none'.
+- Pool/Core in four casings on one page: "Pool+Core" (build.html:293, correct), lowercase pool/core (js/features/deck-list.js:827), "CORE" (js/features/analysis.js:171,191), literal pool/core/dedicated in batch labels (js/features/results.js:460). CONTEXT.md:34-41 lists POOL and pool under Avoid.
+- CONTEXT.md:26 documents the pass control as "Grouped by Mark"; build.html:368 and guide.html:188 ship "One Mark at a Time". CONTEXT.md:56-59 bans "stripe position"; build.html:629 labels a dialog "Move Stripe Position". DESIGN.md says write "Perfect Fit inner sleeve" while CONTEXT.md:61-63 lists that exact phrase under Avoid — the two docs contradict each other.
+- Caption text ships at line-height 1.2 against DESIGN.md's 1.5, measured in eleven places (three visible on load, eight in closed dialogs).
+- build.html:186 sets --flank-size:175px on the child of .wa-flank, not the container, so the 175px column never applies.
+- build.html:201 has a <wa-divider vertical> with nothing on its far side. Vestigial.
+- Three color-input treatments, three labels for one concept: native 40x32 with dashed border (build.html:189, title only, no label), native 60x40 border:none (build.html:530), wa-color-picker (build.html:619) — "Current Marker" / "Marker Color" / "Shared Stripe Color", none of which is DESIGN.md's "deck color". Both native inputs under 44px.
+- css/custom.css:99 — tr:nth-child(even) with rgba(255,255,255,0.015) is a white overlay on a white surface. Dead zebra striping.
+- First paint is a different table shape than every subsequent one: static thead declares 3 columns with colspan="3" skeletons; renderResultsHeader() injects 4 (js/features/results.js:629).
+- Em-dashes and one exclamation point in runtime copy against DESIGN.md §7: js/features/init.js:299, js/features/results.js:372 and :460, js/features/scry-mode.js:62, exclamation at js/features/scry-mode.js:105. Static build.html copy is clean.
+- 9 Web Awesome deprecation warnings on load: size="large"/"medium"/"small" should be "l"/"m"/"s" across wa-input, wa-button, wa-switch, wa-tag, wa-radio, wa-radio-group, wa-file-input, wa-select. No JS errors, no horizontal overflow at 1440px or 390px, all custom elements upgraded, Typekit fonts confirmed loading.
+- CLAUDE.md documents Web Awesome 3.10.0; the kit serves 3.11.0. DESIGN.md §4 documents four tabs; the page ships two (better IA, but export/import scattered into three menus with no home).
+
+## Cognitive Load
+
+5 of 8 checks fail — HIGH band. Failures: single focus, chunking, visual hierarchy, minimal choices, working memory. Passing: visual grouping, one-thing-at-a-time (SCRY-Mode), progressive disclosure.
+Decision points above four visible options: bracket radio (5), color swatch grid (22), deck-card actions (5 icon-only buttons), Results filter row (4 radios + 6 sibling controls), Filters dropdown (unbounded to 48 deck rows).
+
+## Questions to Consider
+
+1. If the pen is the real bottleneck, why is the table organized by card instead of by pen? What would "one pen at a time" look like — pick up violet, here are all 34 marks it makes, put it down? batches / marksForParticipants already support the projection.
+2. None of the three stat cards reports the number the user came for. What changes if the headline figure is duplicates avoided?
+3. Marking is irreversible, but Done is the cheapest control HTML offers. Why does the individual mark get an 18px checkbox with no confirmation, no undo window, and a fade-to-45% as its only feedback?
+4. The Decks and Results tabs hold two halves of one mapping, joined in the user's working memory across a tab switch. What if the legend were a permanent rail, and what would have to be cut to make room?

--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -103,7 +103,7 @@
       "refersTo": "input",
       "description": "White fill, 1px neutral stroke, brand focus ring.",
       "html": "<input class=\"ds-input\" type=\"text\" placeholder=\"Deck name\">",
-      "css": ".ds-input { height: 2.5rem; padding: 0 0.75rem; border: 1px solid #b0b0b9; border-radius: 4px; background: #ffffff; font-family: halyard-micro, system-ui, sans-serif; font-size: 14px; color: #34353c; } .ds-input::placeholder { color: #76767f; } .ds-input:focus { outline: none; border-color: #7d719c; box-shadow: 0 0 0 3px #eadeff; }"
+      "css": ".ds-input { height: 2.5rem; padding: 0 0.75rem; border: 1px solid #b0b0b9; border-radius: 4px; background: #ffffff; font-family: halyard-micro, system-ui, sans-serif; font-size: 14px; color: #34353c; } .ds-input::placeholder { color: #5a5a62; } .ds-input:focus { outline: none; border-color: #7d719c; box-shadow: 0 0 0 3px #eadeff; }"
     },
     {
       "name": "Tag",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,7 +271,6 @@ Preview viewport should be 1280px+ wide to see the desktop layout (sidebar nav).
 
 ### Issue tracker
 
-Issues and PRDs are tracked in this repository's GitHub Issues using the `gh` CLI. See `docs/agents/issue-tracker.md`.
 Issues live in GitHub Issues (codwats/prism), via the `gh` CLI. See `docs/agents/issue-tracker.md`.
 
 ### Triage labels
@@ -280,5 +279,4 @@ Triage uses the five default canonical labels. See `docs/agents/triage-labels.md
 
 ### Domain docs
 
-Domain documentation uses a single-context layout. See `docs/agents/domain.md`.
 Single-context layout — `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,7 +23,7 @@ A result line describing a quantity of interchangeable physical copies that rece
 **Marking pass**:
 One deck mark applied to a quantity of copies, summed across marking batches. Distinct from a marking batch, which is copies sharing the same _set_ of marks — a pass is a single mark that may draw copies from several batches.
 _Avoid_: marking group, basics by deck
-_In code_: the filter value is `basics-by-deck`; the control reads "Grouped by Mark". The mismatch is deliberate.
+_In code_: the filter value is `basics-by-deck`; the control reads "One Mark at a Time" (`build.html`). Both mismatches are deliberate, and the control label is the one to use in reader-facing prose.
 
 **Quantity tier**:
 A quantity of one card needed by the same set of decks. Tier boundaries occur where decklist quantities differ.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,6 +1,6 @@
 # PRISM
 
-PRISM models Commander decks and the physical sleeved cards shared between them.
+PRISM models Commander decks and the physical sleeved cards shared between them, and hosts the community gallery of artwork for those cards.
 
 ## Language
 
@@ -61,3 +61,34 @@ _In code_: `stripePosition` and `sideAPosition`. The mismatch is deliberate — 
 **Perfect Fit inner**:
 The inner sleeve of a double-sleeved card, and the only sleeve that is ever marked. Its partner is the outer sleeve, which protects the mark.
 _Avoid_: perfect-fit inner sleeve, inner Perfect Fit sleeve, Perfect Fit inner sleeve
+
+### Gallery
+
+**Artist**:
+A person whose gallery profile is claimed by their PRISM account. The artist asks to claim the profile; an admin approves it.
+_Avoid_: creator, contributor, and uploader when the maker is meant
+_In code_: a `gallery_artists` row with `user_id` set.
+
+**Attribution**:
+The credit naming who made a work, carried whether or not that person has an account. Most makers never sign up, and their work is credited all the same.
+_Avoid_: unclaimed artist, artist name
+_In code_: `gallery_artworks.artist_name`, and `gallery_artists` rows with `user_id` null. A claim sets `user_id` on the same row, so an Attribution becomes an Artist in place and the credit never changes.
+
+**Uploader**:
+The account that submitted a work. Often not the Artist — the two are only the same person when an Artist uploads their own work.
+_Avoid_: submitter, poster
+_In code_: `gallery_artworks.uploader_id`.
+
+**Alter**:
+A real card painted over by hand. The gallery shows a photograph of one, never a file to print, so an Alter is commissioned rather than downloaded.
+_Avoid_: altered art, custom card, proxy
+_In code_: `type = 'alter'`. The view filtered to Alters is called Alter Alley in reader-facing prose.
+
+**Highlight**:
+An admin's mark that a work is editorially featured. It says nothing about whether the work can be bought — the store link alone decides that.
+_Avoid_: featured, promoted, and any sense of "merch exists"
+_In code_: `gallery_artworks.highlighted`, deliberately independent of `store_url`.
+
+**Commission**:
+A request from a signed-in visitor to an Artist who has commissions open. PRISM relays it once and keeps both addresses private; the conversation continues by reply, away from PRISM.
+_Avoid_: contact request, inquiry, order

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -8,7 +8,7 @@ colors:
   primary-quiet: "#f6eeff"
   primary-stroke: "#7d719c"
   neutral-text: "#34353c"
-  neutral-text-subtle: "#76767f"
+  neutral-text-subtle: "#5a5a62"
   surface-default: "#ffffff"
   surface-2: "#f2f2fc"
   surface-3: "#e5e5ef"
@@ -231,28 +231,40 @@ Extended deck colors continue past WUBRG when a PRISM holds more than five decks
 
 ### 2.5 Semantic tokens (build against these)
 
+WA 3.11 renamed or dropped its own versions of most of these (`neutral-text` → `text-normal`, `neutral-text-subtle` → `text-quiet`, no bare `brand-fill`, no `surface-2`/`surface-3`, no state `-surface`/`-text` roles, etc.). PRISM now defines every token below itself, in `js/layout.js`'s injected `:root` block — do not rely on the CDN theme to provide them.
+
 ```css
 /* Surfaces */
---wa-color-surface-default: #ffffff;      /* page + cards (light) */
+--wa-color-surface-default: #ffffff;      /* page + cards (light) — WA-native */
+--wa-color-surface-1:  var(--wa-color-surface-default);  /* raised/bordered popovers (tooltips, previews) */
 --wa-color-surface-2:  var(--wa-color-neutral-95);  /* sunken panels, table heads */
 --wa-color-surface-3:  var(--wa-color-neutral-90);  /* deepest sunken */
---wa-color-surface-border: var(--wa-color-neutral-80);
+--wa-color-surface-border: var(--wa-color-neutral-80);  /* WA-native */
+--wa-color-neutral-stroke: var(--wa-color-neutral-80);  /* borders, ColorSwatch ring on light colors */
 
 /* Text */
 --wa-color-neutral-text:        var(--wa-color-neutral-20);
---wa-color-neutral-text-subtle: var(--wa-color-neutral-50);
+--wa-color-neutral-text-subtle: var(--wa-color-neutral-40);  /* step 40, not 50 — see §2.6 */
 
 /* Brand */
 --wa-color-brand-text:         var(--wa-color-brand-30);
 --wa-color-brand-fill:         var(--wa-color-brand-40);  /* icons, selection */
---wa-color-brand-fill-loud:    var(--wa-color-brand-30);  /* solid buttons */
+--wa-color-brand-fill-loud:    var(--wa-color-brand-30);  /* solid buttons — WA-native */
 --wa-color-brand-fill-subtle:  var(--wa-color-brand-90);
---wa-color-brand-fill-quiet:   var(--wa-color-brand-95);
---wa-color-brand-on-loud:      #ffffff;
+--wa-color-brand-fill-quiet:   var(--wa-color-brand-95);  /* WA-native */
+--wa-color-brand-on-loud:      #ffffff;                   /* WA-native */
 --wa-color-brand-stroke:       var(--wa-color-brand-50);
+--wa-color-brand-stroke-subtle: var(--wa-color-brand-70);  /* split-group card borders */
+
+/* State (success/warning/danger — same pattern for each) */
+--wa-color-warning-text:            var(--wa-color-warning-40);
+--wa-color-warning-fill:            var(--wa-color-warning-50);  /* WA-native as -fill-loud/-normal/-quiet */
+--wa-color-warning-surface:         var(--wa-color-warning-90);
+--wa-color-warning-surface-subtle:  var(--wa-color-warning-95);
+--wa-color-warning-stroke-subtle:   var(--wa-color-warning-70);
 ```
 
-Dark mode (`.wa-dark`) remaps: surfaces to `neutral-10/20/30`, `neutral-text` to `neutral-95`, `brand-text` to `brand-80`, state text to the 80 step, state surfaces to the 20 step.
+Dark mode (`.wa-dark`) remaps the ramp-derived tokens above: surfaces to `neutral-10/20/30`, `neutral-text` to `neutral-95`, `neutral-text-subtle` to `neutral-80`, `neutral-stroke` to `neutral-30`, `brand-text`/`brand-stroke` to `brand-80`/`brand-70`, state text to the 80 step, state surface to the 20 step (surface-subtle one step further, the 10 step). Tokens that resolve through a WA-native token (`surface-1` via `surface-default`, `brand-fill-loud`, etc.) don't need a PRISM-authored dark remap — WA already themes those itself.
 
 ### 2.6 Contrast rules (non-negotiable)
 
@@ -538,6 +550,7 @@ Motion  0.1–0.15s ease, color + shadow only
 
 ## Changelog
 
+- **v2.3** — Semantic tokens are now PRISM-authored, not borrowed from the WA CDN theme. The 3.10→3.11 WA upgrade renamed or dropped ~22 token names this codebase relies on (`neutral-text`, `neutral-text-subtle`, `brand-fill`, `surface-2`/`-3`, every state `-text`/`-surface`/`-surface-subtle`, etc.) — every `var()` reference to them was silently resolving to nothing sitewide. `js/layout.js` now defines all of them explicitly, plus a `.wa-dark` remap block, with `neutral-text-subtle` corrected to step 40 (was 50, which §2.6 already forbade for anything but large text) in the same pass. See §2.5.
 - **v2.2** — WUBRG accent hexes corrected to the shipped values (`js/modules/processor.js` `DEFAULT_COLORS`): W `#EEB41B`, U `#3995D9`, B `#8662D2`, R `#E2484B`, G `#4FAB33` — more vibrant/higher-pop than the prior draft values, matched to on-screen RGB rather than print-mixed intuition.
 - **v2.1** — Typography moved to Adobe Fonts: **halyard-micro** replaces Inter for all UI, **adobe-aldine** replaces Crimson Pro and now carries headings as well as longform. Geist Mono unchanged. Weight roles: body 400, heading 600, longform 400, code 400.
 - **v2.0** — 11-step ramps, semantic token layer, WUBRG restricted to identity use.

--- a/TO-DO.md
+++ b/TO-DO.md
@@ -1,9 +1,16 @@
 # TO-DO
 
-Open work carried out of the `/impeccable critique` of `index.html`, `guide.html`,
-and `tools.html` (snapshots in `.impeccable/critique/`, run 2026-08-16).
+Open work carried out of the `/impeccable critique` runs. Snapshots live in
+`.impeccable/critique/`. Two runs so far, one section each:
 
-Everything the critique tagged P0 or P1 is fixed on branch
+- **`index.html`, `guide.html`, `tools.html`** (2026-08-16)
+- **`build.html`** (2026-08-17)
+
+---
+
+## Static pages (critique run 2026-08-16)
+
+Everything that critique tagged P0 or P1 is fixed on branch
 `fix/static-page-font-loading` (PR #178), along with the site-wide CDN-resilience
 work, the `CONTEXT.md` label correction, the guide calibration step, and
 `--wa-color-text-quiet`. What follows is what was deliberately left.
@@ -13,7 +20,7 @@ Scores at the time of the critique: `index.html` 22/40, `guide.html` 27/40,
 
 ---
 
-## Shared chrome (`js/layout.js`)
+### Shared chrome (`js/layout.js`)
 
 These render on all nine pages, so each one is a sitewide defect.
 
@@ -33,13 +40,12 @@ These render on all nine pages, so each one is a sitewide defect.
   the other match. This is a judgment call about the product's density, not a
   bug to silently patch.
 
-## Accessibility
+### Accessibility
 
-- [ ] **`build.html` renders a bare `*` above the decklist textarea.** Spotted
-  while rendering the app to verify a `layout.js` change. Looks like a
-  required-field marker whose label text is missing, which would leave the
-  textarea without an accessible name. Unrelated to this branch; worth its own
-  look.
+- [x] **`build.html` renders a bare `*` above the decklist textarea.** Confirmed
+  as diagnosed: both `wa-textarea`s were `required` with no `label`, so WA
+  rendered the asterisk into an empty label slot and the accessible name was
+  empty. Fixed in `1dd614b`; the name is now "Decklist *".
 - [ ] **The guide's marking procedure is two lists.** `guide.html` splits the
   steps into `<ol>` (1-5) and `<ol start="6">` around the dry-time callout.
   Screen readers announce "list of 5 items" then "list of 2 items", and the
@@ -49,7 +55,7 @@ These render on all nine pages, so each one is a sitewide defect.
   the three static pages, none with intrinsic dimensions (layout shift) or lazy
   loading. `guide.html` has five well below the fold.
 
-## `tools.html` content (all P2 in the critique)
+### `tools.html` content (all P2 in the critique)
 
 - [ ] **Pen cards mix pros and cons in one undifferentiated list.** "Easy to wipe
   off if you make a mistake" and "Can rub off on frequently moved cards" sit
@@ -74,7 +80,7 @@ These render on all nine pages, so each one is a sitewide defect.
 - [ ] **Four products × four attributes is a comparison table wearing a card
   grid.** Consider the results-table treatment DESIGN.md §4 already specifies.
 
-## Cross-page consistency
+### Cross-page consistency
 
 - [ ] **Feature names do not match the app.** `index.html` says "Overlap View";
   `build.html` calls it the Deck Overlap Matrix. "Deck Variants" is a "split
@@ -91,14 +97,14 @@ These render on all nine pages, so each one is a sitewide defect.
   brand-10 `#23173b`). It must be a literal because browser chrome reads it
   before CSS, but it should still correspond to a documented value.
 
-## Code cleanup
+### Code cleanup
 
 - [ ] **`.impact-table caption` duplicates the `.visually-hidden` utility.**
   `css/custom.css:292` inlines the visually-hidden pattern that
   `css/custom.css:13` now provides. Use the utility class on the caption and
   drop the duplicate rule.
 
-## Bigger questions (design direction, not defects)
+### Bigger questions (design direction, not defects)
 
 These came out of the critique's design-specificity verdict, which scored 2/5:
 the copy is unmistakably this product, the composition is not. `css/custom.css`
@@ -123,3 +129,152 @@ positions has three public pages with no color and no positions.
 - [ ] **`guide.html` never uses the `longform` type role.** DESIGN.md §3 defines
   it as adobe-aldine 18px/1.75 and annotates it "Guide pages, editorial". The one
   page it was written for sets every paragraph in 16px body sans.
+
+---
+
+## `build.html` (critique run 2026-08-17)
+
+Scored **24/40**, cognitive load HIGH (5 of 8 checks fail). Snapshot in
+`.impeccable/critique/2026-08-17T00-30-00Z__build-html.md`.
+
+Fixed on `fix/static-page-font-loading` in `1dd614b` and `7cf854e`: the P0 PRISM
+strand, the unconfirmed stale-mark wipe, the missing heading spine, the unlabeled
+decklist textareas, keyboard access to the slot picker, `title`-only deck
+identity in the Stripes column, and the undersized mark checkbox.
+
+**One P1 from that plan was never run** — the marked-row legibility pass below.
+It is the first item deliberately, not by score order.
+
+### Marked rows (P1, WCAG AA)
+
+- [ ] **Marked rows fall to roughly 2.6:1.** `css/custom.css:161` sets
+  `opacity: 0.45` on `.marked-row`, which computes body text `#34353c` to about
+  `#a3a3a7` on white — failing AA (4.5:1) by a wide margin. By the end of a
+  session this is the majority state of the table, so it is not an edge case.
+  Replace the opacity with an explicit `--wa-color-neutral-text-subtle` on the
+  name cell and hold the checkbox and `.stripe-indicators` at full opacity, so
+  what you already painted stays auditable against the pen in your hand.
+- [ ] **The strikethrough is on the wrong cell.** `css/custom.css:165` applies
+  `line-through` to `td:first-child`, which is the checkbox cell. DESIGN.md
+  §"Results table" specifies the card name. Move it to `.card-name-cell`.
+
+### Settings and vocabulary
+
+- [ ] **The `Position Numbers` preference does nothing.** It defaults to `none`
+  and its hint reads "None hides numbers", but `positionNumHtml` renders whenever
+  `exact || showNums`, and `exact` is true for any card with ≤5 visible marks
+  regardless of the preference (`js/features/results.js:333`). Most cards have
+  1-3 marks, so setting it to None is visibly inert. Gate `exact` on
+  `numbersMode !== 'none'`. A setting that ignores its own value is the fastest
+  way to teach a user that settings do not work here.
+- [ ] **Pool/Core ships in four casings on one page.** `CONTEXT.md:34-41` says
+  always capitalized and lists `POOL` and `pool` under *Avoid*. Shipped:
+  "Pool+Core" (`build.html`, correct), `${pool} pool • ${core} core`
+  (`js/features/deck-list.js:883`), "Cards become CORE"
+  (`js/features/analysis.js:171` and `:191`), and literal `pool`/`core`/
+  `dedicated` in batch sub-row labels (`js/features/results.js`).
+- [ ] **A dialog title uses the term `CONTEXT.md` bans.** `build.html` labels the
+  slot picker "Move Stripe Position"; `CONTEXT.md:56-59` bans "stripe position"
+  in prose in favour of "slot". `js/layout.js` likewise labels a setting
+  "Position Numbers".
+- [ ] **DESIGN.md and CONTEXT.md contradict each other.** DESIGN.md §7 says to
+  write "Perfect Fit inner sleeve"; `CONTEXT.md:61-63` lists that exact phrase
+  under *Avoid* in favour of "Perfect Fit inner". One document has to yield.
+
+### Copy rules in JS-rendered strings
+
+The static HTML is clean; every violation below is in a template literal, which
+is why a scan of the `.html` files misses them.
+
+- [ ] **Em-dashes.** `js/features/init.js:367` ("Sync failed — Retry"),
+  `js/features/scry-mode.js:61` and `:62`, `js/features/analysis.js:195` and
+  `:210`, `js/features/deck-form.js:145`, and the batch sub-row label in
+  `js/features/results.js`. DESIGN.md §7 bans them.
+- [ ] **An exclamation point.** `js/features/scry-mode.js:105` reads "All cards
+  reviewed!". DESIGN.md §7 is explicit, and this is the last line a user sees at
+  the end of a marking session.
+
+### Design-system drift
+
+- [ ] **Caption text ships at line-height 1.2 against a documented 1.5.**
+  Measured across `.wa-caption-s/m/xs` in eleven places (three visible on load,
+  eight inside closed dialogs). DESIGN.md §3 specifies 1.5 for both "Body small /
+  UI" and "Caption / meta".
+- [ ] **Nine Web Awesome deprecation warnings on every load.**
+  `size="large"/"medium"/"small"` should be `"l"/"m"/"s"` across `wa-input`,
+  `wa-button`, `wa-switch`, `wa-tag`, `wa-radio`, `wa-radio-group`,
+  `wa-file-input`, and `wa-select`.
+- [ ] **Three color-input treatments, three names, one concept.** A native
+  `<input type="color">` at 40×32 with a dashed border, another at 60×40 with
+  `border: none`, and a `<wa-color-picker>` — labelled "Current Marker",
+  "Marker Color", and "Shared Stripe Color". None is DESIGN.md's "deck color",
+  and both native inputs are under 44px.
+- [ ] **`--flank-size` is set on the child, not the flank container.**
+  `build.html:210` puts it on the `.wa-stack` inside `.wa-flank`, so the intended
+  175px column never applies.
+- [ ] **A `<wa-divider vertical>` with nothing on its far side.**
+  `build.html:224`. Vestigial.
+- [ ] **Dead zebra striping.** `css/custom.css:119` paints
+  `rgba(255, 255, 255, 0.015)` on even rows — a white overlay on a white surface.
+  It does nothing in light mode and almost nothing in dark.
+- [ ] **First paint is a different table shape than every later one.** The static
+  `<thead>` declares three columns and the skeletons use `colspan="3"`
+  (`build.html:452`, `:459-462`), but `renderResultsHeader()` injects four.
+- [ ] **Docs describe a page that does not exist.** `CLAUDE.md` documents Web
+  Awesome 3.10.0 while the kit serves 3.11.0, and DESIGN.md §4 documents four
+  tabs (Decks / Results / Export / Import) where the page ships two. Two is the
+  better IA, but the consequence is that export and import are scattered across
+  three separate menus with no home.
+
+### First-run and flow (P2, from the persona walk)
+
+- [ ] **The first control a beginner meets is the most advanced one.**
+  "Dedicated commander copies" sits at the top of the Decks tab. It is a
+  per-PRISM setting that changes the whole batch derivation and that nobody on
+  run one can evaluate.
+- [ ] **The Decks empty state offers no next step.** `js/features/deck-list.js`
+  renders "No decks yet." with no call to action, while the Results empty state
+  does have an Add Deck button.
+- [ ] **Bracket is collected on equal footing with Deck Name and Commander and
+  affects nothing.** `bracket` never reaches stripe assignment, Pool/Core
+  classification, or any count — it is display-and-export metadata only. Either
+  make it drive something real or stop making it one of the first five decisions.
+- [ ] **The SCRY-Mode keyboard shortcuts are documented nowhere in the UI.**
+  `d` / `s` / Enter / → (`js/features/scry-mode.js`). Flagged in the 2026-06 beta
+  review and still true.
+- [ ] **The Add Deck form sits below the entire deck list.** At 20 decks that is a
+  long scroll to the primary creation action, with no Add Deck affordance in the
+  header.
+- [ ] **Sorting is single-column only.** You cannot sort by copies within deck
+  count, which is the natural batching order for a long marking session.
+
+### Bigger questions (`build.html`)
+
+The engine is unmistakably this product — the stripe-signature sort, the to-scale
+slot picker, the batch model's refusal of a false parent checkbox. The chrome is
+not: the three stat cards are the stock SaaS metric tile and the Results toolbar
+would lift into a CRM unchanged. Leaving the chrome as-is was an explicit
+decision on 2026-08-17, so these are recorded as questions, not defects.
+
+- [ ] **If the pen is the real bottleneck, why is the table organized by card
+  instead of by pen?** SCRY-Mode is one card at a time and the sort already
+  clusters by identical stripe signature. "One pen at a time" — pick up violet,
+  here are all 34 marks it makes across every card, put it down — is the actual
+  physical workflow, and `batches` / `marksForParticipants` already support the
+  projection.
+- [ ] **None of the three stat cards reports the number the user came for.**
+  Total Cards, Pool Cards, and Marked are internal quantities. People open PRISM
+  to learn how many copies they do not have to buy.
+- [ ] **Marking is irreversible, but Done is the cheapest control HTML offers.**
+  The batch model already refuses a false parent checkbox because over-marking
+  cannot be undone, yet an individual mark is an 18px checkbox with no
+  confirmation, no undo window, and a fade as its only feedback. Relatedly, the
+  message "3 cards unchecked (new stripes added)" — which means paint already on
+  sleeves is now incomplete — ships as an auto-dismissing toast
+  (`js/features/deck-list.js`), the lowest-weight surface available.
+- [ ] **The Decks and Results tabs hold two halves of one mapping.** Colour→deck
+  lives on one, mark→card on the other, and the user carries the join in working
+  memory across a tab switch, on a phone, at a table. What would have to be cut
+  to make the legend a permanent rail?
+
+---

--- a/TO-DO.md
+++ b/TO-DO.md
@@ -137,26 +137,26 @@ positions has three public pages with no color and no positions.
 Scored **24/40**, cognitive load HIGH (5 of 8 checks fail). Snapshot in
 `.impeccable/critique/2026-08-17T00-30-00Z__build-html.md`.
 
-Fixed on `fix/static-page-font-loading` in `1dd614b` and `7cf854e`: the P0 PRISM
-strand, the unconfirmed stale-mark wipe, the missing heading spine, the unlabeled
-decklist textareas, keyboard access to the slot picker, `title`-only deck
-identity in the Stripes column, and the undersized mark checkbox.
+Fixed on `fix/static-page-font-loading` in `1dd614b`, `7cf854e`, and `db8bbe0`:
+the P0 PRISM strand, the unconfirmed stale-mark wipe, the missing heading spine,
+the unlabeled decklist textareas, keyboard access to the slot picker,
+`title`-only deck identity in the Stripes column, the undersized mark checkbox,
+and marked-row legibility.
 
-**One P1 from that plan was never run** — the marked-row legibility pass below.
-It is the first item deliberately, not by score order.
+**Every P0 and P1 from this critique is now closed.** What follows is the P2 and
+below, plus four design questions.
 
-### Marked rows (P1, WCAG AA)
+### Marked rows (P1, WCAG AA) — done
 
-- [ ] **Marked rows fall to roughly 2.6:1.** `css/custom.css:161` sets
-  `opacity: 0.45` on `.marked-row`, which computes body text `#34353c` to about
-  `#a3a3a7` on white — failing AA (4.5:1) by a wide margin. By the end of a
-  session this is the majority state of the table, so it is not an edge case.
-  Replace the opacity with an explicit `--wa-color-neutral-text-subtle` on the
-  name cell and hold the checkbox and `.stripe-indicators` at full opacity, so
-  what you already painted stays auditable against the pen in your hand.
-- [ ] **The strikethrough is on the wrong cell.** `css/custom.css:165` applies
-  `line-through` to `td:first-child`, which is the checkbox cell. DESIGN.md
-  §"Results table" specifies the card name. Move it to `.card-name-cell`.
+- [x] **Marked rows fell to roughly 2.6:1.** `.marked-row` used `opacity: 0.45`,
+  computing body text to about `#a3a3a7` on white and failing AA in what becomes
+  the majority state of the table. Replaced with a quiet token colour on the name
+  cell, leaving the swatches and checkbox at full strength. Measured against the
+  warning-tinted Pool row, the worst-case background: **5.80:1** light, **10.29:1**
+  dark. Fixed in `db8bbe0`.
+- [x] **The strikethrough was on the wrong cell.** It applied to `td:first-child`,
+  the checkbox cell, where DESIGN.md §"Results table" specifies the card name.
+  Moved to `.card-name-cell` and `.batch-subrow-label`. Fixed in `db8bbe0`.
 
 ### Settings and vocabulary
 

--- a/TO-DO.md
+++ b/TO-DO.md
@@ -1,0 +1,125 @@
+# TO-DO
+
+Open work carried out of the `/impeccable critique` of `index.html`, `guide.html`,
+and `tools.html` (snapshots in `.impeccable/critique/`, run 2026-08-16).
+
+Everything the critique tagged P0 or P1 is fixed on branch
+`fix/static-page-font-loading` (PR #178), along with the site-wide CDN-resilience
+work, the `CONTEXT.md` label correction, the guide calibration step, and
+`--wa-color-text-quiet`. What follows is what was deliberately left.
+
+Scores at the time of the critique: `index.html` 22/40, `guide.html` 27/40,
+`tools.html` 22/40. Re-run `/impeccable critique` to see them move.
+
+---
+
+## Shared chrome (`js/layout.js`)
+
+These render on all nine pages, so each one is a sitewide defect.
+
+- [ ] **Em-dashes in shipped copy.** `js/layout.js:449` and `:505` both read
+  "PRISM is in open beta — …". DESIGN.md §7 bans em-dashes in copy. The nine
+  pages themselves are clean; only the injected chrome violates it.
+- [ ] **Active nav link fails the project's own contrast rule.**
+  `js/layout.js:360` colors the current-page link `--wa-color-brand-60`
+  (`#9c90bd`), roughly 2.9:1 on white. DESIGN.md §2.6 is explicit that text on
+  white is never lighter than step 40. Use `brand-30` or `brand-40`. Note the
+  link also carries a `wa-body-m` weight bump, so location is not conveyed by
+  color alone, but the color is still below the floor.
+- [ ] **Spacing scale contradicts DESIGN.md.** `js/layout.js:242` sets
+  `--wa-space-scale: 1.125`; DESIGN.md §5 specifies "Web Awesome base × 0.875"
+  and a "compact and data-heavy" mood. The shipped scale is 1.29× the documented
+  one and the changelog does not record a change. Decide which is right and make
+  the other match. This is a judgment call about the product's density, not a
+  bug to silently patch.
+
+## Accessibility
+
+- [ ] **`build.html` renders a bare `*` above the decklist textarea.** Spotted
+  while rendering the app to verify a `layout.js` change. Looks like a
+  required-field marker whose label text is missing, which would leave the
+  textarea without an accessible name. Unrelated to this branch; worth its own
+  look.
+- [ ] **The guide's marking procedure is two lists.** `guide.html` splits the
+  steps into `<ol>` (1-5) and `<ol start="6">` around the dry-time callout.
+  Screen readers announce "list of 5 items" then "list of 2 items", and the
+  numbering depends on the hardcoded `start="6"` staying in sync if a step is
+  ever inserted. Consider one list with the callout inside an `<li>`.
+- [ ] **No image carries `width`/`height` or `loading="lazy"`.** 13 images across
+  the three static pages, none with intrinsic dimensions (layout shift) or lazy
+  loading. `guide.html` has five well below the fold.
+
+## `tools.html` content (all P2 in the critique)
+
+- [ ] **Pen cards mix pros and cons in one undifferentiated list.** "Easy to wipe
+  off if you make a mistake" and "Can rub off on frequently moved cards" sit
+  adjacent in the same bullet style; the second one means marks disappear from
+  cards you shuffle, which defeats the system. Split into labelled pros/cons, or
+  promote the defect into a `wa-callout variant="warning"` on that card.
+- [ ] **State colors used as a quality ladder.** Tags run `success` / `neutral` /
+  `warning` / `brand` across the four pens. DESIGN.md §2 reserves state ramps for
+  state, and amber on "Budget" reads as caution rather than price. Keep
+  `success` on the one recommendation and make the rest `neutral`.
+- [ ] **The buying links have no affordance.** Each product name is an `<a>`
+  styled `color: inherit; text-decoration: none`, so the four links the page
+  exists to offer look like plain text.
+- [ ] **Affiliate disclosure sits below the links it discloses.** It is in the
+  Sleeves section, under four undisclosed `amzn.to` links in Paint Pens. Move it
+  above the pen grid.
+- [ ] **"Coming Soon" STL button.** A disabled brand button under a heading
+  reading "Print Settings (v1)", above five concrete print settings for a file
+  that does not exist. The 2026-06 beta review asked for this to be softened and
+  it is unchanged. Either give it a date or state plainly that the file is not
+  released yet.
+- [ ] **Four products × four attributes is a comparison table wearing a card
+  grid.** Consider the results-table treatment DESIGN.md §4 already specifies.
+
+## Cross-page consistency
+
+- [ ] **Feature names do not match the app.** `index.html` says "Overlap View";
+  `build.html` calls it the Deck Overlap Matrix. "Deck Variants" is a "split
+  group" everywhere else in the product and the codebase.
+- [ ] **Heading casing diverges.** `index.html` and `tools.html` use Title Case
+  section headings, `guide.html` uses sentence case. Each is defensible alone;
+  together they read as drift. DESIGN.md §3 does not currently rule on section
+  headings, so decide and write it down.
+- [ ] **`index.html`'s "Mark Your Sleeves" step never links to `guide.html`.**
+  The step that describes the physical work does not point at the page that
+  explains it.
+- [ ] **`theme-color` is an undocumented hex.** `#281645` on all three static
+  pages matches no `--wa-color-brand-*` step (nearest are brand-05 `#180a2e` and
+  brand-10 `#23173b`). It must be a literal because browser chrome reads it
+  before CSS, but it should still correspond to a documented value.
+
+## Code cleanup
+
+- [ ] **`.impact-table caption` duplicates the `.visually-hidden` utility.**
+  `css/custom.css:292` inlines the visually-hidden pattern that
+  `css/custom.css:13` now provides. Use the utility class on the caption and
+  drop the duplicate rule.
+
+## Bigger questions (design direction, not defects)
+
+These came out of the critique's design-specificity verdict, which scored 2/5:
+the copy is unmistakably this product, the composition is not. `css/custom.css`
+carries no rules for these pages beyond the logo swap, and none of the PRISM
+primitives DESIGN.md §4 defines as mandatory — ColorSwatch, StripeIndicator,
+SleeveSlot, DeckColorIndicator, the counting numeral, the 12px Sleeve — appear
+on any of them. Nor do the WUBRG colors. A product about colored marks at fixed
+positions has three public pages with no color and no positions.
+
+- [ ] **Should the `index.html` hero be a live marked sleeve?** The primitives
+  already exist. A hero where a visitor clicks four deck names and watches four
+  WUBRG stripes land on a sleeve edge would teach the whole mental model in
+  three seconds and could not be pasted onto another product.
+- [ ] **Should the guide's marking session be a print card rather than a web
+  page?** DESIGN.md §8 already specifies a print mode. The procedure is read at a
+  table, one-handed, with wet paint on the reader's hands, and the page currently
+  has no print affordance, no back-to-top, and nothing collapsible.
+- [ ] **The site states neither side of the trade.** The payoff is now on
+  `index.html`, but the cost is not: no time per card, no session length, no pen
+  count, no sleeve count. A reader needs one pen per deck color, which at 20
+  decks means 20 colors, and that fact lives only in `DEFAULT_COLORS`.
+- [ ] **`guide.html` never uses the `longform` type role.** DESIGN.md §3 defines
+  it as adobe-aldine 18px/1.75 and annotates it "Guide pages, editorial". The one
+  page it was written for sets every paragraph in 16px body sans.

--- a/build.html
+++ b/build.html
@@ -48,6 +48,8 @@
             <img src="./assets/Prism-Icon-Main.svg" alt="Prism Logo" style="height:1.5em;" class="wa-border-radius-square theme-logo-light">
               <wa-input
                 id="prism-name"
+                label="PRISM name"
+                class="wa-visually-hidden-label"
                 placeholder="My PRISM"
                 size="large"
                 style="--wa-input-border-width: 0; font-weight: 600;"

--- a/build.html
+++ b/build.html
@@ -25,15 +25,16 @@
     <link rel="preconnect" href="https://fonts.bunny.net" />
     <link rel="preconnect" href="https://fonts.bunny.net" crossorigin />
     <link rel="preconnect" href="https://cdn.jsdelivr.net" />
+    <link rel="preconnect" href="https://use.typekit.net" />
+    <link rel="preconnect" href="https://use.typekit.net" crossorigin />
     <!-- Web Awesome, fonts, and app CSS as static tags so the browser preload scanner
          starts them immediately; layout.js injectHeadResources skips tags already present -->
-         <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/themes/default.css">
-               <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/native.css" />
-          <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/utilities.css" />
-          <script type="module" src="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/webawesome.loader.js"></script>
-    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Inter:ital,wght@0,100..900;1,100..900&display=swap" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/themes/default.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/native.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/utilities.css" />
+    <script type="module" src="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/webawesome.loader.js"></script>
     <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Geist+Mono:wght@100..900&display=swap" />
-    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Crimson+Pro:ital,wght@0,200..900;1,200..900&display=swap" />
+    <link rel="stylesheet" href="https://use.typekit.net/gbw6ibc.css" />
     <link rel="stylesheet" href="css/custom.css" />
   </head>
   <body>

--- a/build.html
+++ b/build.html
@@ -332,7 +332,7 @@
                       <div class="wa-cluster wa-gap-xs">
                         <span class="wa-heading-xl" id="stat-shared">0</span>
                         <wa-badge variant="neutral" appearance="outlined" pill>
-                          Cards in 2+ Decks
+                          Copies in 2+ Decks
                         </wa-badge>
                       </div>
                     </div>

--- a/build.html
+++ b/build.html
@@ -97,7 +97,7 @@
               <!-- First-run orientation (dismissal persisted in localStorage,
                    wired by the inline onboarding script at the end of body) -->
               <wa-card id="onboarding-callout" style="display: none;">
-                <div class="wa-flank:end">
+                <div class="wa-flank:end" style="align-items: flex-start;">
                   <div class="wa-flank" style="--flank-size: 22rem;">
                     <img src="assets/Cards.svg" alt="Three card sleeves, each with colored marks at a different place along its edge" style="inline-size: 22rem; max-inline-size: 100%; block-size: auto; flex: none;" />
                     <div class="wa-stack wa-gap-xs">
@@ -183,7 +183,7 @@
 
                   <div class="wa-flank wa-align-items-start">
                     <div class="wa-stack wa-gap-xs" style="--flank-size:175px;">
-                      <label class="wa-caption-m">Current Marker</label>
+                      <label class="wa-caption-m" for="deck-color">Current Marker</label>
                         <input type="color" id="deck-color" value="#EEB41B" title="Pick a custom color" style="width: 40px; height: 32px; border: 2px dashed var(--wa-color-neutral-stroke); border-radius: var(--wa-border-radius-m); cursor: pointer;" />
                         <div id="color-warning" class="wa-caption-s" style="color: var(--wa-color-warning-text); display: none;">
                           <wa-icon name="triangle-exclamation" style="font-size: 0.9em;"></wa-icon>
@@ -191,9 +191,9 @@
                         </div>
                     </div>
                     <div class="wa-stack wa-gap-xs">
-                      <label class="wa-caption-m">Select a Color</label>
+                      <label class="wa-caption-m" id="color-swatches-label">Select a Color</label>
                       <div class="wa-cluster wa-gap-s wa-align-items-center">
-                       <div id="color-swatches" class="wa-cluster wa-gap-xs">
+                       <div id="color-swatches" class="wa-cluster wa-gap-xs" role="group" aria-labelledby="color-swatches-label">
                          <!-- Color swatches will be inserted here -->
                         </div>
                         <wa-divider vertical style="height: 12px;"></wa-divider>
@@ -524,7 +524,7 @@
         </wa-radio-group>
 
         <div class="wa-stack wa-gap-xs">
-          <label class="wa-caption-m">Marker Color</label>
+          <label class="wa-caption-m" for="edit-deck-color">Marker Color</label>
           <input type="color" id="edit-deck-color" style="width: 60px; height: 40px; border: none; border-radius: var(--wa-border-radius-m); cursor: pointer;" />
         </div>
 
@@ -613,7 +613,7 @@
         <input type="hidden" id="edit-group-id" />
         <wa-input id="edit-group-name" label="Group Name" required></wa-input>
         <div class="wa-stack wa-gap-xs">
-          <label class="wa-caption-m">Shared Stripe Color</label>
+          <label class="wa-caption-m" for="edit-group-color">Shared Stripe Color</label>
           <wa-color-picker id="edit-group-color" format="hex" no-format-toggle></wa-color-picker>
         </div>
       </div>

--- a/build.html
+++ b/build.html
@@ -670,7 +670,7 @@
     </wa-dialog>
 
     <!-- Stripe Reorder Dialog -->
-    <wa-dialog id="stripe-reorder-dialog" label="Move Stripe Position" style="--width: min(580px, 92vw);">
+    <wa-dialog id="stripe-reorder-dialog" label="Move to a Different Slot" style="--width: min(580px, 92vw);">
       <div id="stripe-reorder-content" class="wa-stack wa-gap-l">
         <!-- Content injected by stripe-reorder-dialog.js -->
       </div>

--- a/build.html
+++ b/build.html
@@ -49,6 +49,10 @@
   <body>
     <wa-page mobile-breakpoint="768">
       <main class="wa-stack wa-gap-xl">
+        <!-- The page's real title. The visible PRISM name is an editable input,
+             so without this the document outline started at an <h3> stat label. -->
+        <h1 class="visually-hidden">Build Your PRISM</h1>
+
         <!-- PRISM Name -->
         <section class="wa-stack wa-gap-s">
           <div class="wa-split wa-align-items-center">
@@ -74,6 +78,15 @@
                 <wa-button slot="trigger" appearance="plain" variant="neutral" size="small" aria-label="More actions">
                   <wa-icon name="ellipsis"></wa-icon>
                 </wa-button>
+                <!-- Switch-PRISM entries are injected before this divider by
+                     renderPrismSwitcher() in features/init.js. Without them a
+                     logged-out user has no route back to an earlier PRISM. -->
+                <wa-divider id="prism-switch-divider"></wa-divider>
+                <wa-dropdown-item id="btn-new-prism">
+                  <wa-icon slot="icon" name="plus"></wa-icon>
+                  New PRISM
+                </wa-dropdown-item>
+                <wa-divider></wa-divider>
                 <wa-dropdown-item id="btn-export-json">
                   <wa-icon slot="icon" name="file-code"></wa-icon>
                   Download backup (.json)
@@ -132,7 +145,8 @@
               </div>
 
               <!-- Existing Decks List -->
-              <section id="decks-list" class="wa-stack wa-gap-m">
+              <h2 class="visually-hidden">Your Decks</h2>
+              <section id="decks-list" class="wa-stack wa-gap-m" aria-label="Your decks">
                 <!-- Loading skeletons — replaced by the first renderDecksList() -->
                 <div class="skeleton-deck-card">
                   <wa-skeleton effect="pulse" class="skeleton-line-title"></wa-skeleton>
@@ -150,7 +164,7 @@
               <wa-card id="add-deck-card">
                 <div slot="header" class="wa-cluster wa-gap-s wa-align-items-center">
                   <wa-icon name="plus-circle" style="color: var(--wa-color-brand-fill);"></wa-icon>
-                  <span class="wa-heading-m">Add a Deck</span>
+                  <h2 class="wa-heading-m" style="margin: 0;">Add a Deck</h2>
                 </div>
 
                 <form id="deck-form" class="wa-stack wa-gap-l">
@@ -214,10 +228,12 @@
                   </div>
 
 
-                  <wa-file-input id="deck-file-input" accept=".txt,.dec,.dek,.mwDeck" label="Decklist" hint="Drag & drop or click to upload a .txt, .dec, .dek, or .mwDeck file" size="small"></wa-file-input>
+                  <wa-file-input id="deck-file-input" accept=".txt,.dec,.dek,.mwDeck" label="Decklist file" hint="Drag & drop or click to upload a .txt, .dec, .dek, or .mwDeck file" size="small"></wa-file-input>
 
                   <wa-textarea
                     id="deck-list"
+                    label="Decklist"
+                    hint="One card per line, quantity first. Paste from any deck builder."
                     placeholder="1 Sol Ring&#10;1 Arcane Signet&#10;1 Command Tower&#10;12 Island&#10;..."
                     rows="8"
                     required
@@ -273,6 +289,7 @@
           <!-- Results Panel -->
           <wa-tab-panel name="results">
             <div class="wa-stack wa-gap-l">
+              <h2 class="visually-hidden">Marking Results</h2>
               <!-- Marking prerequisites at the point of action -->
               <div id="marking-prereq-callout" class="wa-stack wa-gap-xs" style="display: none;">
                 <wa-callout variant="warning">
@@ -295,7 +312,7 @@
                       <wa-icon slot="icon" name="box-open"></wa-icon>
                     </wa-avatar>
                     <div class="wa-stack wa-gap-2xs">
-                      <h3 class="wa-caption-s">Total Cards</h3>
+                      <p class="wa-caption-s" style="margin: 0;">Total Cards</p>
                       <div class="wa-cluster wa-gap-xs">
                         <span class="wa-heading-xl" id="stat-total">0</span>
                         <wa-badge variant="neutral" appearance="outlined" pill>
@@ -311,7 +328,7 @@
                       <wa-icon slot="icon" name="object-group"></wa-icon>
                     </wa-avatar>
                     <div class="wa-stack wa-gap-2xs">
-                      <h3 class="wa-caption-s">Pool Cards</h3>
+                      <p class="wa-caption-s" style="margin: 0;">Pool Cards</p>
                       <div class="wa-cluster wa-gap-xs">
                         <span class="wa-heading-xl" id="stat-shared">0</span>
                         <wa-badge variant="neutral" appearance="outlined" pill>
@@ -326,7 +343,7 @@
                     <wa-progress-ring value="0" id="marked-progress" style="--track-width: 6px; --indicator-width: 8px; --size: 48px;">
                     </wa-progress-ring>
                     <div class="wa-stack wa-gap-2xs">
-                      <h3 class="wa-caption-s">Marked</h3>
+                      <p class="wa-caption-s" style="margin: 0;">Marked</p>
                       <div class="wa-cluster wa-gap-xs">
                         <span class="wa-heading-xl" id="stat-marked">0/0</span>
                         <wa-badge variant="neutral" appearance="outlined" pill>
@@ -487,10 +504,27 @@
 
     <!-- New PRISM Confirmation Dialog -->
     <wa-dialog id="new-prism-dialog" label="Create New PRISM">
-      <p>This will create a new empty PRISM. Your current PRISM will be saved and can be accessed later.</p>
+      <p>This will create a new empty PRISM and switch you to it.</p>
+      <p style="color: var(--wa-color-neutral-text-subtle);">
+        <strong id="new-prism-current-name">Your current PRISM</strong> is saved on this device. To come back to it,
+        open the <wa-icon name="ellipsis" style="vertical-align: -0.1em;"></wa-icon> menu beside the PRISM name and pick it from the list.
+      </p>
       <div slot="footer" class="wa-cluster wa-gap-s">
         <wa-button id="btn-cancel-new" variant="neutral" appearance="outlined">Cancel</wa-button>
         <wa-button id="btn-confirm-new" variant="brand">Create New</wa-button>
+      </div>
+    </wa-dialog>
+
+    <!-- Clear All Stale Marks Confirmation Dialog -->
+    <wa-dialog id="clear-all-removed-dialog" label="Clear all stale marks">
+      <p>Clear all <strong id="clear-all-removed-count"></strong> stale marks from this list?</p>
+      <p style="color: var(--wa-color-neutral-text-subtle);">
+        Each row is a mark still painted on a sleeve for a deck that no longer needs the card.
+        Clearing the list does not remove the paint, and the list cannot be rebuilt.
+      </p>
+      <div slot="footer" class="wa-cluster wa-gap-s">
+        <wa-button id="btn-cancel-clear-all-removed" variant="neutral" appearance="outlined">Cancel</wa-button>
+        <wa-button id="btn-confirm-clear-all-removed" variant="danger">Clear All</wa-button>
       </div>
     </wa-dialog>
 
@@ -566,12 +600,13 @@
           </div>
         </wa-details>
 
-        <wa-file-input id="edit-deck-file-input" accept=".txt,.dec,.dek,.mwDeck" label="Decklist" hint="Drag & drop or click to upload a .txt, .dec, .dek, or .mwDeck file" size="small"></wa-file-input>
+        <wa-file-input id="edit-deck-file-input" accept=".txt,.dec,.dek,.mwDeck" label="Decklist file" hint="Drag & drop or click to upload a .txt, .dec, .dek, or .mwDeck file" size="small"></wa-file-input>
 
         <div id="edit-deck-list-updated" class="wa-caption-s" style="color: var(--wa-color-neutral-text-subtle);"></div>
 
         <wa-textarea
           id="edit-deck-list"
+          label="Decklist"
           placeholder="1 Sol Ring&#10;1 Arcane Signet&#10;..."
           rows="10"
           required
@@ -662,10 +697,10 @@
 
     <script type="module">
       import { initLayout } from './js/layout.js';
-      initLayout({
-        activePage: 'build',
-        headerCta: { id: 'btn-new-prism', label: 'New PRISM', icon: 'plus', variant: 'neutral', appearance: 'outlined' }
-      });
+      // No headerCta: "New PRISM" lives in the PRISM overflow menu beside the
+      // switcher, so a mis-click in the primary-action slot can no longer
+      // swap the PRISM out from under the user.
+      initLayout({ activePage: 'build', headerCta: null });
     </script>
     <script type="module" src="js/app.js"></script>
     <script>

--- a/build.html
+++ b/build.html
@@ -14,6 +14,15 @@
     <title>Build Your PRISM - MTG Deck Sleeve Marking Tool</title>
     <style>.wa-cloak { visibility: hidden; }</style>
     <style>wa-page:not(:defined) { visibility: hidden; }</style>
+    <!-- CDN resilience. Both rules above hide the page until Web Awesome loads, and
+         nothing removes them if it never does, so a blocked or stalled kit leaves a
+         blank white document. Reveal at 5s regardless: unstyled but readable beats
+         invisible. WA removes the class itself on a normal load, well before this. -->
+    <style>
+      @keyframes prism-uncloak { to { visibility: visible; } }
+      .wa-cloak,
+      wa-page:not(:defined) { animation: prism-uncloak 0s linear 5s forwards; }
+    </style>
     <!-- iOS Home Screen icon (layout.js injects these as a fallback) -->
     <link rel="apple-touch-icon" href="./assets/apple-touch-icon.png" />
     <link rel="manifest" href="./assets/site.webmanifest" />

--- a/build.html
+++ b/build.html
@@ -557,7 +557,7 @@
 
         <wa-file-input id="edit-deck-file-input" accept=".txt,.dec,.dek,.mwDeck" label="Decklist" hint="Drag & drop or click to upload a .txt, .dec, .dek, or .mwDeck file" size="small"></wa-file-input>
 
-        <div id="edit-deck-list-updated" class="wa-caption-s" style="color: var(--wa-color-neutral-600);"></div>
+        <div id="edit-deck-list-updated" class="wa-caption-s" style="color: var(--wa-color-neutral-text-subtle);"></div>
 
         <wa-textarea
           id="edit-deck-list"

--- a/css/custom.css
+++ b/css/custom.css
@@ -138,6 +138,26 @@ wa-page[view='desktop'] [data-toggle-nav] {
   accent-color: var(--wa-color-brand-fill);
 }
 
+/* The most-repeated target in a marking session. A <label> wrapper carries the
+   hit area natively (no JS, no ::before on a replaced element) while the box
+   itself stays 18px, per DESIGN.md §8: pad the target, don't shrink the block.
+   Sized by input method rather than viewport — a touchscreen laptop needs the
+   big target too, and a mouse-driven phone-width window does not. */
+.mark-checkbox-hit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+@media (pointer: coarse) {
+  .mark-checkbox-hit {
+    min-width: 44px;
+    min-height: 44px;
+    margin: calc(var(--wa-space-xs) * -1) 0;
+  }
+}
+
 .results-table .marked-row {
   opacity: 0.45;
 }
@@ -372,6 +392,78 @@ wa-page[view='desktop'] [data-toggle-nav] {
 }
 
 /* ============================================================================
+   Stripes Cell — tap to decode
+   ============================================================================ */
+
+/* One focusable control wrapping the whole strip: a keyboard user gets a single
+   tab stop per row carrying every mark in its accessible name, and a touch user
+   gets a way to read deck names that `title` never gave them. */
+.stripe-cell-toggle {
+  display: block;
+  width: 100%;
+  padding: var(--wa-space-2xs);
+  margin: calc(var(--wa-space-2xs) * -1);
+  background: none;
+  border: 1px solid transparent;
+  border-radius: var(--wa-border-radius-s);
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+}
+
+.stripe-cell-toggle:hover {
+  background: var(--wa-color-surface-2);
+}
+
+.stripe-cell-toggle:focus-visible {
+  outline: 2px solid var(--wa-color-brand-fill);
+  outline-offset: 1px;
+}
+
+.stripe-cell-toggle[aria-expanded='true'] {
+  border-color: var(--wa-color-surface-border);
+  background: var(--wa-color-surface-2);
+}
+
+/* Full-width row under the card, so the decode reads at the left edge instead
+   of inside the Stripes column, which sits past the right edge of a phone. */
+.results-table .stripe-detail-row > td {
+  background: var(--wa-color-surface-2);
+  padding-top: var(--wa-space-xs);
+  padding-bottom: var(--wa-space-xs);
+}
+
+.stripe-detail {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--wa-space-2xs) var(--wa-space-l);
+  font-size: var(--wa-font-size-xs);
+  color: var(--wa-color-neutral-text-subtle);
+}
+
+.stripe-detail li {
+  display: flex;
+  align-items: center;
+  gap: var(--wa-space-xs);
+}
+
+.stripe-detail-swatch {
+  flex: none;
+  width: 12px;
+  height: 12px;
+  border-radius: var(--wa-border-radius-s);
+  border: 1px solid var(--wa-color-neutral-stroke);
+}
+
+.stripe-detail-swatch-dot {
+  border-radius: 50%;
+}
+
+/* ============================================================================
    Loading Skeletons
    ============================================================================ */
 
@@ -479,10 +571,9 @@ wa-page[view='desktop'] [data-toggle-nav] {
     font-size: var(--wa-font-size-s);
   }
 
-  .stripe-indicator {
-    width: 14px;
-    height: 14px;
-  }
+  /* The stripe block is the thing being matched against a pen at the table, so
+     it keeps its 18px size on narrow screens. DESIGN.md §8: pad the target,
+     never shrink the visual block. */
 }
 
 /* Toast styles handled by <wa-toast> component */

--- a/css/custom.css
+++ b/css/custom.css
@@ -328,7 +328,7 @@ wa-page[view='desktop'] [data-toggle-nav] {
 }
 
 /* ============================================================================
-   Landing page: What You Get Back table (index.html #payoff)
+   Landing page: Duplicates You Free Up table (index.html #payoff)
    Same structural DNA as .results-table (collapsed borders, 1px rules, token
    spacing), scaled up for marketing: the resale column carries the heading
    serif at display size, because that number is the point of the section.

--- a/css/custom.css
+++ b/css/custom.css
@@ -115,12 +115,27 @@ wa-page[view='desktop'] [data-toggle-nav] {
   background: var(--wa-color-surface-2);
 }
 
-.results-table tbody tr:nth-child(even) {
-  background: rgba(255, 255, 255, 0.015);
+/* Zebra banding. The old rule was `tr:nth-child(even)` filled with
+   rgba(255,255,255,0.015) — a 1.5%-opacity white wash over a white surface,
+   which rendered nothing in light mode and almost nothing in dark. It is now
+   driven by an `alt-row` class set per card in results.js, because the
+   stripe-detail rows interleave and only some cards emit one, so :nth-child()
+   parity no longer tracks cards at all.
+
+   Kept well below the hover fill so hover still reads as the stronger state.
+   The band colour is a variable rather than two competing rules, so the class
+   selector stays at one level: row hover and the stale-mark tint then win on
+   specificity and source order without needing overrides. */
+:root {
+  --prism-zebra: color-mix(in srgb, var(--wa-color-neutral-90) 45%, transparent);
 }
 
-.results-table tbody tr:nth-child(even):hover {
-  background: var(--wa-color-surface-2);
+.wa-dark {
+  --prism-zebra: color-mix(in srgb, var(--wa-color-neutral-30) 30%, transparent);
+}
+
+.results-table .alt-row {
+  background: var(--prism-zebra);
 }
 
 /* No Pool row tint. Pool is already legible three ways: the Stripes column

--- a/css/custom.css
+++ b/css/custom.css
@@ -322,8 +322,22 @@ wa-page[view='desktop'] [data-toggle-nav] {
 
 .impact-table {
   width: 100%;
+  /* Capped well inside the 720px section container. At full width the row
+     stretched to 720px and left ~285px of dead space between "5 decks" and
+     "~$919", so the two halves of a single fact read as separate items. The
+     same table is legible on a 390px phone precisely because that gap is small;
+     this brings the desktop gap back to roughly the same absolute distance. */
+  max-width: 30rem;
+  margin-inline: auto;
   border-collapse: collapse;
 }
+
+/* Deliberately no `font-variant-numeric: tabular-nums` here. It is the obvious
+   move for a column of figures, but halyard-micro's tnum feature also widens
+   the space glyph: it stretched the pure-text header "Duplicates freed" by
+   4.4px and left visible gaps in "5 decks" and "166 cards". The money column is
+   right-aligned with values of differing length, so lining figures buy almost
+   nothing here and cost legibility in every other cell. */
 
 .impact-table caption {
   /* The visible lead paragraph already frames the table, so this is for
@@ -342,7 +356,12 @@ wa-page[view='desktop'] [data-toggle-nav] {
 .impact-table td {
   padding: var(--wa-space-m) var(--wa-space-s);
   text-align: left;
-  border-bottom: 1px solid var(--wa-color-surface-border);
+  /* `surface-border` is picked for a white page. This table sits on the sunken
+     `surface-2` ground, where that token resolves to the same value as the
+     ground itself in dark mode (both rgb(52,53,60)) — a 1.00 contrast ratio, so
+     the rules were literally invisible, and only 1.12 in light. `neutral-stroke`
+     is the token that stays one step off the surface in both themes. */
+  border-bottom: 1px solid var(--wa-color-neutral-stroke);
 }
 
 .impact-table thead th {

--- a/css/custom.css
+++ b/css/custom.css
@@ -123,13 +123,12 @@ wa-page[view='desktop'] [data-toggle-nav] {
   background: var(--wa-color-surface-2);
 }
 
-.results-table .shared-row {
-  background: var(--wa-color-warning-surface-subtle);
-}
-
-.results-table .shared-row:hover {
-  background: var(--wa-color-warning-surface);
-}
+/* No Pool row tint. Pool is already legible three ways: the Stripes column
+   shows one mark per deck, the default sort puts many-mark cards on top, and
+   the Pool filter isolates them. A fourth encoding on the row background
+   added nothing, and it used the warning ramp — amber reading as caution on
+   the rows that are actually saving the user money. The stale-mark tint below
+   stays: that one marks real outstanding work. */
 
 .results-table .mark-checkbox {
   width: 18px;

--- a/css/custom.css
+++ b/css/custom.css
@@ -158,11 +158,27 @@ wa-page[view='desktop'] [data-toggle-nav] {
   }
 }
 
-.results-table .marked-row {
-  opacity: 0.45;
+/* A done row recedes without becoming unreadable.
+
+   This replaced `opacity: 0.45`, which computed body text (#34353c) to roughly
+   #a3a3a7 on white — about 2.6:1, failing WCAG AA in what becomes the majority
+   state of the table by the end of a marking session. It also dimmed the stripe
+   swatches, so the colour you had just painted got harder to compare against the
+   pen in your hand, which is exactly the check you want before sleeving a card
+   back into a deck.
+
+   So: the name goes quiet and struck through, while the swatches and the
+   checkbox stay at full strength and the row stays auditable. */
+.results-table .marked-row .card-name-cell,
+.results-table .marked-row .batch-subrow-label,
+.results-table .marked-row .copies-cell {
+  color: var(--wa-color-neutral-text-subtle);
 }
 
-.results-table .marked-row td:first-child {
+/* DESIGN.md §"Results table" specifies the card name struck through. The old
+   rule targeted td:first-child, which is the checkbox cell. */
+.results-table .marked-row .card-name-cell,
+.results-table .marked-row .batch-subrow-label {
   text-decoration: line-through;
 }
 

--- a/css/custom.css
+++ b/css/custom.css
@@ -259,6 +259,76 @@ wa-page[view='desktop'] [data-toggle-nav] {
 }
 
 /* ============================================================================
+   Landing page: What You Get Back table (index.html #payoff)
+   Same structural DNA as .results-table (collapsed borders, 1px rules, token
+   spacing), scaled up for marketing: the resale column carries the heading
+   serif at display size, because that number is the point of the section.
+   ============================================================================ */
+
+.impact-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.impact-table caption {
+  /* The visible lead paragraph already frames the table, so this is for
+     screen readers only rather than a second on-screen summary. */
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.impact-table th,
+.impact-table td {
+  padding: var(--wa-space-m) var(--wa-space-s);
+  text-align: left;
+  border-bottom: 1px solid var(--wa-color-surface-border);
+}
+
+.impact-table thead th {
+  font-size: var(--wa-font-size-s);
+  font-weight: 600;
+  color: var(--wa-color-neutral-text-subtle);
+  white-space: nowrap;
+}
+
+.impact-table tbody tr:last-child th,
+.impact-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.impact-table .impact-collection {
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.impact-table .impact-value {
+  font-family: var(--wa-font-family-heading);
+  font-size: var(--wa-font-size-2xl);
+  font-weight: var(--wa-font-weight-heading);
+  line-height: 1.2;
+  color: var(--wa-color-brand-text);
+  text-align: right;
+  white-space: nowrap;
+}
+
+@media (max-width: 480px) {
+  .impact-table th,
+  .impact-table td {
+    padding: var(--wa-space-s) var(--wa-space-2xs);
+  }
+
+  .impact-table .impact-value {
+    font-size: var(--wa-font-size-xl);
+  }
+}
+
+/* ============================================================================
    Dark Mode Overrides
    ============================================================================ */
 

--- a/css/custom.css
+++ b/css/custom.css
@@ -4,6 +4,25 @@
  */
 
 /* ============================================================================
+   Visually Hidden
+   ============================================================================ */
+
+/* Structural headings that give the page a navigable outline without changing
+   the visual design. Not display:none — that would hide them from assistive
+   tech too, which is the opposite of the point. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ============================================================================
    Sync Status Indicator
    ============================================================================ */
 
@@ -530,21 +549,13 @@ wa-page[view='desktop'] [data-toggle-nav] {
   background: var(--wa-color-danger-surface);
 }
 
-.btn-clear-all-removed {
-  background: none;
-  border: 1px solid var(--wa-color-surface-border);
-  border-radius: var(--wa-border-radius-medium);
-  color: var(--wa-color-neutral-text);
-  font-size: var(--wa-font-size-x-small);
-  padding: var(--wa-space-2x-small) var(--wa-space-x-small);
-  cursor: pointer;
+/* "Clear All" is a <wa-button appearance="outlined" variant="danger">; the
+   hand-rolled rules that lived here referenced five WA 2.x token names that no
+   longer resolve in 3.11 (--wa-border-radius-medium, --wa-font-size-x-small,
+   --wa-space-2x-small, --wa-space-x-small, --wa-color-danger-border), so every
+   declaration was being dropped. */
+#clear-all-removed-btn {
   white-space: nowrap;
-}
-
-.btn-clear-all-removed:hover {
-  background: var(--wa-color-danger-surface-subtle);
-  border-color: var(--wa-color-danger-border);
-  color: var(--wa-color-danger-text);
 }
 
 .removed-deck-label {
@@ -961,6 +972,16 @@ wa-page[view='desktop'] [data-toggle-nav] {
 .stripe-reorder-slot--occupied:active {
   border-color: var(--wa-color-warning-70) !important;
   box-shadow: 0 0 0 2px var(--wa-color-warning-70);
+}
+
+/* Keyboard focus. The slots carry a roving tabindex, so this ring is the only
+   thing telling a keyboard user where they are on the sleeve. It must read
+   against both the empty (dashed) and the deck-colored occupied slots, so it
+   sits outside the border rather than replacing it. */
+.stripe-reorder-slot:focus-visible {
+  outline: 2px solid var(--wa-color-brand-fill);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px var(--wa-color-brand-fill-subtle);
 }
 
 .stripe-reorder-edge-labels {

--- a/docs/adr/0001-gallery-stays-in-prism.md
+++ b/docs/adr/0001-gallery-stays-in-prism.md
@@ -1,0 +1,44 @@
+# The gallery stays in PRISM's Supabase project
+
+The community gallery is welded to identity, not to PRISM's deck-marking domain: four
+foreign keys to `auth.users`, ~15 RLS policies built on `auth.uid()` / `is_gallery_admin()`,
+and a Storage bucket whose paths are `<auth.uid()>/<uuid>.<ext>`. It is not a separate
+domain — it is *PRISM accounts, plus artwork*. So it stays where the accounts are, and
+[defcat-website](https://github.com/codwats/defcat-website) renders it read-only:
+approved artworks and artists over plain PostgREST with the anon key, a teaser strip of
+the latest three highlights, and every action that needs an account linking back to PRISM.
+
+## Considered options
+
+1. **A third Supabase project for the gallery** — rejected. A third project means a third
+   `auth.users`, so every FK and policy above loses the identity it points at, uploaders
+   need a third account, and cross-project JWT verification becomes a permanent tax paid
+   to make a diagram tidier.
+2. **Move the gallery to defcat's project** — rejected for the mirror image of the same
+   reason, and it would strand PRISM's uploaders.
+3. **Merge the two projects into one auth realm** — rejected. defcat's project has ~22
+   user-scoped tables (`profiles`, `decks`, `deck_submissions`, `user_credits`, …) all
+   FK'd to its own `auth.users`; PRISM's has `prisms`, `deck_cards`, `subscriptions`,
+   `stripe_customers`, and the gallery. "One auth realm" is therefore a database merger
+   in whichever direction, with a cutover that kills every live session — the most
+   expensive and least reversible option on the table.
+
+Options 1–3 were all priced against a requirement that evaporated: defcat needs no
+authenticated gallery actions of its own. It shows the art and links across.
+
+## Consequences
+
+- **defcat's Patreon login is untouched.** Worth knowing, because it looks like an
+  obstacle and is not: `src/app/auth/patreon-callback/route.ts` is a hand-rolled OAuth
+  exchange that calls `admin.createUser` and mints a *Supabase* session. Patreon is the
+  identity source; Supabase Auth is already the realm. Nothing about it conflicts with
+  PRISM's email/password — the two simply never meet.
+- **Neither site gains the other's login method.** A PRISM user cannot sign in to defcat,
+  and a patron gets no PRISM account from their Patreon. If a patron ever complains about
+  signing up twice, the cheap fix is bridging — defcat's callback runs a second time
+  against PRISM's project, same email, ~1 file — not a merger.
+- **One moderation queue, in PRISM.** Uploads, artist profiles, claims, and approvals
+  happen in one place. This is the main thing option 3 would have bought and the main
+  cost of building gallery writes on defcat.
+- **defcat's reads need no CORS work.** A public Storage bucket and anon PostgREST are
+  cross-origin by default.

--- a/docs/research/shopify-storefront-integration.md
+++ b/docs/research/shopify-storefront-integration.md
@@ -1,0 +1,454 @@
+# Shopify storefront integration without a subdomain
+
+Research for [Integrate the Shopify store into PRISM without a subdomain](https://github.com/codwats/prism/issues/180), conducted 2026-08-20. Current stable Storefront API version at time of writing: **2026-07**.
+
+## Conclusion
+
+- **Checkout is always Shopify-hosted, but the host the buyer sees is the store's *primary domain*, not `myshopify.com`.** Shopify states plainly that "customers are always directed back to a Shopify-hosted checkout," and documents the standard headless pattern: point a subdomain (for example `checkout.prismmtg.com`) at the Online Store and mark it **Primary**. `cart.checkoutUrl` then returns that host. Verified live on Shopify's own demo store — see [Checkout domain](#1-checkout-domain). No plan gate is documented for this; it is domain configuration, not a Plus feature. There is no supported way to render the checkout *page itself* inside prismmtg.com.
+- **The Storefront API works from a plain browser `fetch()` with no build step and, as of the current version, no token at all.** Shopify documents tokenless access covering Products, Collections, Search, Pages/Blogs and **Cart (read/write)** — everything a catalog + cart + checkout handoff needs. Responses carry `access-control-allow-origin: *` (verified live). The public token is explicitly designed to be visible to buyers.
+- **`/api/shopify-edge` is not required and is actively harmful.** Shopify documents that "public access capacity scales with the number of buyers, based on their IP address." A single edge-function egress IP collapses every buyer into one bucket. The proxy pattern PRISM uses for Moxfield/Archidekt exists to defeat CORS; Shopify has no CORS problem to defeat.
+- **A fourth option the issue does not list: Storefront Web Components.** Shopify ships `<script src="https://cdn.shopify.com/storefront/web-components.js">` plus `<shopify-store>` / `<shopify-context>` / `<shopify-cart>` — declarative HTML, no build step, no token, styled via your own markup, CSS parts and slots. This sits between "Buy Button" and "hand-rolled Storefront API" and is the closest fit to PRISM's no-bundler vanilla stack.
+- **Buy Button is the weakest option and rests on a deprecated dependency.** `buy-button-js` is still released (v3.0.6, Aug 2025; commits through Aug 2026), but it depends on `shopify-buy` (JS Buy SDK), which Shopify marked **deprecated as of January 2025**. Shopify's own help centre says it does "not recommend the use of Buy Buttons on your Shopify online store."
+- **Checkout API is gone, not merely deprecated.** Deprecated in API version 2024-04, shut off **April 1, 2025**. Cart API is the only path.
+- **Cart permalinks are documented and supported** by both help.shopify.com and shopify.dev, with a rich parameter set (discounts, attributes, notes, prefilled checkout fields, locale). They are the zero-JavaScript floor.
+
+---
+
+## 1. Checkout domain
+
+### Checkout is always Shopify-hosted
+
+From [Migrate from the online store to Hydrogen § Subdomain for checkout](https://shopify.dev/docs/storefronts/headless/hydrogen/migrate):
+
+> Regardless of whether you're using the online store or Hydrogen, customers are always directed back to a Shopify-hosted checkout. Traditionally, a checkout URL might look something like `{shop}.myshopify.com/123456/checkouts…`.
+>
+> To make sure your Hydrogen site works correctly, assign a subdomain for your storefront to checkout. For example, if your Hydrogen store is `example.com`, then assign `checkout.example.com` to checkout. To do this:
+>
+> 1. Connect the subdomain
+> 2. Set the **Target** to **Online Store**.
+> 3. Set the **Domain** type to **Primary**.
+
+The same procedure appears in [Redirect traffic to the Hydrogen channel § Step 1](https://shopify.dev/docs/storefronts/headless/hydrogen/migrate/redirect-traffic), which names Shopify's own demo as the reference implementation:
+
+> The [hydrogen.shop](https://hydrogen.shop/) demo provides an example of this routing pattern. The primary domain `hydrogen.shop` receives traffic on the Hydrogen storefront while the subdomain `checkout.hydrogen.shop` receives traffic at checkout.
+>
+> **Note:** For custom storefronts not hosted on Oxygen, only the subdomain must point to Shopify.
+
+That note matters for PRISM: prismmtg.com stays on Netlify. Only the checkout subdomain's DNS goes to Shopify.
+
+### What host the buyer actually sees — verified live
+
+Executed 2026-08-20 against Shopify's public demo store, tokenless, with a browser-shaped `Origin` header:
+
+```
+POST https://checkout.hydrogen.shop/api/2026-07/graphql.json
+{"query":"mutation{cartCreate(input:{lines:[{quantity:1,merchandiseId:\"gid://shopify/ProductVariant/41007289630776\"}]}){cart{id checkoutUrl}}}"}
+```
+
+Response:
+
+```json
+{"data":{"cartCreate":{"cart":{
+  "id":"gid://shopify/Cart/hWNFsvNSBFDk5Qz0xhnQEVTl?key=7c026214…",
+  "checkoutUrl":"https://checkout.hydrogen.shop/cart/c/hWNFsvNSBFDk5Qz0xhnQEVTl?key=JpGRVv2JSim…"
+}}}}
+```
+
+The buyer sees `checkout.hydrogen.shop` — a subdomain of the merchant's own domain. `{ shop { primaryDomain { url } } }` on the same store returns `https://checkout.hydrogen.shop`, confirming that `checkoutUrl`'s host is the store's **primary domain** as configured in Shopify admin.
+
+The shipped docs example in [Create and update a cart § Step 7](https://shopify.dev/docs/storefronts/headless/building-with-the-storefront-api/cart/manage) shows the un-configured case, where the primary domain is still the myshopify one:
+
+```json
+{"data":{"cart":{"checkoutUrl":"https://exam.myshopify.com/cart/c/29567c413f68cf5e8c1cb623954f3a28"}}}
+```
+
+So: `myshopify.com` is what you get if you do nothing; a subdomain of your own domain is what you get after the documented three-step domain change. Neither is prismmtg.com itself.
+
+### Plans
+
+| Capability | Plan gate | Source |
+| --- | --- | --- |
+| Checkout served on a subdomain of your own domain | **None documented** — it is the Online Store primary-domain setting | [Migrate to Hydrogen](https://shopify.dev/docs/storefronts/headless/hydrogen/migrate), [Redirect traffic](https://shopify.dev/docs/storefronts/headless/hydrogen/migrate/redirect-traffic) |
+| Checkout branding: logo, header/content/form colours, fonts, button colours, one-page vs three-page layout | All plans (checkout editor) | [Customizing and editing your checkout and accounts pages](https://help.shopify.com/en/manual/checkout-settings/customize-checkout-configurations) |
+| Checkout Branding API (`checkoutBrandingUpsert`, now superseded by `checkoutAndAccountsConfigurationUpdate`) | **Plus** (or a development store) | [About checkout styling](https://shopify.dev/docs/apps/build/checkout/styling): "Checkout styling customizations are available only to Shopify Plus merchants." The [`checkoutBrandingUpsert` reference](https://shopify.dev/docs/api/admin-graphql/latest/mutations/checkoutBrandingUpsert) states "the shop must be on a Plus plan or a Development store plan." |
+| Checkout UI extensions / Checkout Blocks | **Plus** | Same page |
+| Domain count | 20 domains/subdomains on regular plans, 1,000 on Plus | [Domains](https://help.shopify.com/en/manual/domains) |
+
+### Not answered by the docs
+
+- **No page states a plan floor for the checkout-subdomain pattern.** It is described in Hydrogen/headless docs and is a plain Settings → Domains operation, but Shopify never writes "available on all plans" in so many words. Treat as strongly implied, not stated.
+- **Domain masking / reverse-proxying checkout under prismmtg.com is not documented anywhere as supported, on any plan** — including Plus. The absence is consistent across the domain, checkout-settings and headless docs; it is an absence of support, not a documented prohibition.
+- **`shop.app`**: cart permalinks document `payment=shop_pay` as directing buyers to a Shop Pay checkout, but no primary page states what host Shop Pay renders on. Unverified.
+
+---
+
+## 2. Storefront API from a no-build-step vanilla JS site
+
+### Endpoint and version
+
+```
+POST https://{shop}.myshopify.com/api/{api_version}/graphql.json
+```
+
+Current stable version is **2026-07** ([Storefront API reference](https://shopify.dev/docs/api/storefront/latest), `api_version: 2026-07`). Shopify releases "four times a year." The store's primary domain also serves the endpoint — `https://checkout.hydrogen.shop/api/2026-07/graphql.json` responded normally in the live test above.
+
+### Authentication — three modes
+
+From [Storefront API reference § Authentication](https://shopify.dev/docs/api/storefront/latest):
+
+> The Storefront API supports both tokenless access and token-based authentication.
+>
+> **Tokenless access** allows API queries without an access token providing access to essential features such as:
+> * Products and Collections
+> * Selling Plans
+> * Search
+> * Pages, Blogs, and Articles
+> * Cart (read/write)
+>
+> Tokenless access has a query complexity limit of 1,000.
+
+> * **Public access**: Used to query the API from a browser or mobile app, where the token is visible to buyers. Create a public access token with the `storefrontAccessTokenCreate` mutation on the GraphQL Admin API. Then send it in the `X-Shopify-Storefront-Access-Token` header.
+> * **Private access**: Used to query the API from a server or other private context, like a Hydrogen backend, where the token stays secret. Send it in the `Shopify-Storefront-Private-Token` header.
+
+> **Caution:** Unlike public access tokens, private access tokens should be treated as secret and not used on the client-side.
+
+Token-based auth is only needed for: Product Tags, Metaobjects and Metafields, Menu (Online Store navigation), and Customers. **A catalog + product pages + cart + checkout handoff needs no token at all.**
+
+| Mode | Header | Browser-safe? |
+| --- | --- | --- |
+| Tokenless | none | Yes — no secret exists |
+| Public | `X-Shopify-Storefront-Access-Token` | Yes — "the token is visible to buyers" |
+| Private / delegate | `Shopify-Storefront-Private-Token` (+ `Shopify-Storefront-Buyer-IP`) | **No** — "should be treated as secret and not used on the client-side" |
+
+A private token is obtained via the Headless channel, a [delegate access token](https://shopify.dev/docs/apps/build/authentication-authorization/delegate-api-access), or unauthenticated scopes on an existing token. Apps are capped at "a maximum of 100 active storefront access tokens per shop."
+
+### CORS
+
+**Shopify's docs do not mention CORS for the Storefront API anywhere I could find.** This is a documentation gap. Verified empirically on 2026-08-20:
+
+```
+OPTIONS https://mock.shop/api            Origin: https://prismmtg.com
+→ 200, access-control-allow-origin: *
+       access-control-allow-methods: POST, OPTIONS
+       access-control-allow-headers: *
+
+POST https://checkout.hydrogen.shop/api/2026-07/graphql.json   Origin: https://prismmtg.com
+→ 200, access-control-allow-origin: *
+```
+
+`access-control-allow-headers: *` covers `X-Shopify-Storefront-Access-Token`, so a public-token request from the browser also passes preflight. Shopify's own [Storefront Web Components](https://shopify.dev/docs/api/storefront-web-components/getting-started) — a browser-only, script-tag product — are conclusive circumstantial evidence that browser-origin requests are the intended path, since they have no server side at all.
+
+### Rate limits
+
+From [Shopify API limits](https://shopify.dev/docs/api/usage/limits#rate-limits):
+
+| API | Rate-limiting method | Standard | Advanced | Plus |
+| --- | --- | --- | --- | --- |
+| GraphQL Admin API | Calculated query cost | 100 pts/s | 200 pts/s | 1000 pts/s |
+| **Storefront API** | **None** | **None** | **None** | **None** |
+
+> The Storefront API is designed to support businesses of all sizes, and scales to support surges in buyer traffic or your largest flash sale. **Requests from real buyers aren't subject to a fixed request-per-minute limit.**
+
+Not cost-based, not per-token, not per-app. What is limited:
+
+- **Bots/crawlers.** "Shopify rate-limits automated traffic — such as bots and crawlers … Unsigned, anonymous bots receive the strictest limits." Bot operators can sign requests with [Web Bot Auth](https://datatracker.ietf.org/doc/draft-meunier-web-bot-auth-architecture/) for higher limits.
+- **Malicious traffic.** "If a request appears to be malicious, Shopify responds with a `430 Shopify Security Rejection` error code."
+- **Checkout creation.** "Shopify limits the amount of checkouts that can be created on the Storefront API per minute. If an API client exceeds this throttle, then a `200 Throttled` error response is returned." Note the status is **200**, not 429 — the error is in the body. Shopify recommends "a request queue with an exponential backoff algorithm." The per-minute number is **not published**.
+- **Input arrays**: max 250 items. **Pagination**: max 25,000 objects.
+- **Cart**: max 500 line items ([Cart](https://shopify.dev/docs/storefronts/headless/building-with-the-storefront-api/cart)).
+
+Responses include `extensions.cost.requestedQueryCost` (observed: 12 for a `cartCreate`), which is how the tokenless complexity limit of 1,000 is measured.
+
+---
+
+## 3. Does PRISM need `/api/shopify-edge`?
+
+**No. It is optional at best and counterproductive in practice.**
+
+The decisive sentence is in [Storefront API § Authentication](https://shopify.dev/docs/api/storefront/latest):
+
+> **Public access capacity scales with the number of buyers, based on their IP address.**
+
+And on the private-token path ([same page](https://shopify.dev/docs/api/storefront/latest#make-server-side-requests-with-a-private-access-token)):
+
+> When the request results from buyer traffic, also include the `Shopify-Storefront-Buyer-IP` (case-sensitive) header with the buyer's IP address. Shopify uses this header to enforce IP-level bot and platform protection and to manage traffic from a single high-volume user, such as a bot.
+>
+> **Caution:** Without the `Shopify-Storefront-Buyer-IP` header, Shopify can't differentiate requests from different buyers, which can result in throttled API requests, limited bot protection, and unauthenticated flows at checkout.
+
+Concretely:
+
+1. **There is no secret to hide.** Tokenless access covers products, collections, search, content and cart read/write. Even a public token is documented as buyer-visible. The Moxfield/Archidekt precedent does not transfer — those proxies exist because those APIs reject browser origins; Shopify sends `access-control-allow-origin: *`.
+2. **A proxy makes capacity worse.** All buyers arrive from Netlify's edge egress IPs. That is exactly the "single high-volume user" shape Shopify's own caution describes, and it forfeits per-buyer capacity scaling.
+3. **A proxy can be made correct, but only with work.** Forwarding the real client IP requires a private token plus a correct `Shopify-Storefront-Buyer-IP` header — a new secret to manage, in exchange for capacity you already had for free.
+4. **One legitimate reason to keep a proxy exists**: the cart-ID secret (see §5), which Shopify says not to put in client-side code. If PRISM decides to honour that caution literally, cart mutations must move server-side. Shopify's own browser-only Web Components do not honour it, which is a real inconsistency in Shopify's guidance — flagged, not resolved.
+
+---
+
+## 4. What the anon Storefront token exposes
+
+From [Access scopes § Unauthenticated access scopes](https://shopify.dev/docs/api/usage/access-scopes#unauthenticated-access-scopes):
+
+> Unauthenticated access scopes provide apps with read-only access to the Storefront API. Unauthenticated access is intended for interacting with a store on behalf of a customer.
+
+Complete documented list:
+
+| Scope | Access |
+| --- | --- |
+| `unauthenticated_read_checkouts`, `unauthenticated_write_checkouts` | `Cart` object |
+| `unauthenticated_read_customers`, `unauthenticated_write_customers` | `Customer` object |
+| `unauthenticated_read_customer_tags` | `tags` field on `Customer` |
+| `unauthenticated_read_content` | `Article`, `Blog`, `Comment` |
+| `unauthenticated_read_metaobjects` | `Metaobject` |
+| `unauthenticated_read_product_inventory` | `quantityAvailable` on `ProductVariant`, `totalAvailable` on `Product` |
+| `unauthenticated_read_product_listings` | `Product` and `Collection` |
+| `unauthenticated_read_product_pickup_locations` | `Location`, `StoreAvailability` |
+| `unauthenticated_read_product_tags` | `tags` field on `Product` |
+| `unauthenticated_read_selling_plans` | Selling plan content on `Product` |
+
+Answers to the specific questions:
+
+- **Customer data:** only via `unauthenticated_read_customers` / `unauthenticated_write_customers`, and only through the `Customer` object, which requires a customer access token to resolve a specific customer. Grant it only if you build accounts. Note the page's own header calls unauthenticated scopes "read-only" while the table lists three `write_` scopes — an internal inconsistency in Shopify's own doc.
+- **Orders:** no unauthenticated scope grants order access. Orders are reachable only through an authenticated customer via the [Customer Account API](https://shopify.dev/docs/api/customer).
+- **Inventory quantities:** yes, but only with `unauthenticated_read_product_inventory` explicitly granted, and only `quantityAvailable` / `totalAvailable`. Tokenless access does not include it — the [Web Components getting-started guide](https://shopify.dev/docs/api/storefront-web-components/getting-started) says a token is needed "if you want to display the inventory count."
+- **Draft/unpublished products:** the Storefront API is a **sales channel**. The Headless channel "gives you all of Shopify's channel features, such as product publishing, scheduled product publishing" ([Manage headless channels](https://shopify.dev/docs/storefronts/headless/building-with-the-storefront-api/manage-headless-channels)). Products not published to the channel are not returned. **Shopify does not state this as an explicit security guarantee on the Storefront API reference page** — it follows from the channel model rather than from a sentence I can quote.
+
+**Abuse risks and mitigations Shopify names:**
+
+- Bot/crawler rate limiting, with Web Bot Auth as the sanctioned escape hatch for legitimate crawlers.
+- `430 Shopify Security Rejection` for traffic judged malicious.
+- Checkout-creation throttle (`200 Throttled`).
+- "We recommend only requesting the scopes that your app needs, to reduce the security risk if the token leaks."
+- Max 100 active storefront access tokens per shop, and tokens are rotatable from the Headless channel.
+- Plus-only [bot protection](https://help.shopify.com/manual/checkout-settings/bot-protection) for cart.
+
+**Not answered:** Shopify does not document any way to restrict a public storefront token by referring origin, domain allowlist, or referrer. Anyone can copy the token (or use tokenless access) and query the same catalog from anywhere. Shopify's position is that this is acceptable because the data is public catalog data.
+
+---
+
+## 5. Cart API state of play
+
+### Checkout API is sunset
+
+From [Migrate to the Storefront Cart API](https://shopify.dev/docs/storefronts/headless/building-with-the-storefront-api/cart/migrate-to-cart-api):
+
+> In API version **2024-04**, Checkout APIs on the REST Admin and Storefront API are deprecated, with the exception of the REST Admin API's Abandoned checkouts resource. In version **2025-04**, the Checkout APIs will be sunset and no longer function.
+
+From the changelog entry [Checkout APIs will be shut down April 1, 2025](https://shopify.dev/changelog/checkout-apis-will-be-shut-down-april-1-2025) (dated March 2, 2025, version 2025-04, flagged *Deprecation announcement / Action required*):
+
+> Reminder: The Checkout APIs (Storefront Checkout Mutations and REST Checkout Endpoints) are deprecated and will be shut off on April 1, 2025. Customers will not be able to create or complete checkouts using the deprecated Checkout APIs after the deadline.
+
+This date is in the past. There is no fallback; Cart API is the only path.
+
+### Minimal happy path (2026-07 field names)
+
+Shopify's [Create and update a cart](https://shopify.dev/docs/storefronts/headless/building-with-the-storefront-api/cart/manage) guide is a **two**-step happy path, not three — `cartCreate` takes lines directly, so `cartLinesAdd` is only needed for later additions.
+
+1. **`cartCreate`** — [reference](https://shopify.dev/docs/api/storefront/latest/mutations/cartCreate): "Creates a new `Cart` for a buyer session. You can optionally initialize the cart with merchandise lines, discount codes, gift card codes, buyer identity for international pricing, and custom attributes. The returned cart includes a `checkoutUrl`."
+
+   ```graphql
+   mutation {
+     cartCreate(input: {
+       lines: [{ quantity: 1, merchandiseId: "gid://shopify/ProductVariant/1" }]
+     }) {
+       cart { id checkoutUrl cost { totalAmount { amount currencyCode } } }
+       userErrors { message }
+       warnings { ... }
+     }
+   }
+   ```
+
+2. **`cartLinesUpdate`** (quantity change) / `cartLinesAdd` / `cartLinesRemove`; also `cartBuyerIdentityUpdate`, `cartDiscountCodesUpdate`, `cartMetafieldsSet`, and four `cartDeliveryAddresses*` mutations.
+
+3. **Read `checkoutUrl`** — `query { cart(id: "...") { checkoutUrl } }`. The guide warns:
+
+   > For security reasons, the `checkoutUrl` should be requested when the buyer is ready to navigate to checkout and can be re-requested if it is stale.
+
+### Cart ID shape and the secret
+
+> The cart ID consists of a token and a secret key parameter in the form of `<token>?key=<secret>`. When you work with any Cart API, you must always provide the full ID. […] If you do not include the secret key during a query, the buyer's private details (such as email or address) will be removed from the cart response. Additionally, if you attempt to modify the cart through a mutation without a key, the mutation will fail with an error message indicating the cart does not exist.
+>
+> **Caution:** Never expose the `secret` part of the ID. Treat it like a password—don't include it in shareable links, public pages, or any client-side code.
+>
+> **Caution:** Shopify may change the format and length of cart tokens at any time. Apps must be built to handle cart tokens of any format.
+
+**This is the sharpest unresolved tension in the whole research.** A browser-only cart has nowhere to keep the cart ID but `localStorage`, which is client-side code by any reading. Shopify's own Storefront Web Components do exactly that. Shopify does not reconcile the two positions anywhere I could find. Practical reading: the caution is aimed at *sharing* the ID (links, server logs, public pages), not at the buyer's own browser holding their own cart — but that reading is inference, not documentation.
+
+### Cart persistence
+
+From [Cart § Speed and scale](https://shopify.dev/docs/storefronts/headless/building-with-the-storefront-api/cart):
+
+> * **Rate limits:** Carts don't have any global API rate limits.
+> * **Cart limits:** A shop or customer can create an unlimited number of carts.
+> * **Abandoned carts:** Unused and abandoned carts automatically expire within **30 days** of creation.
+> * **Completed carts:** Shopify automatically deletes the cart when the customer completes their checkout.
+
+And from the migration guide: "Completed carts are deleted upon order creation. Unlike the Checkout API, you can't query a completed cart for order information or completion status." Also: "No webhooks are fired for `cart/create` or `cart/update` for the Storefront Cart API."
+
+---
+
+## 6. Cart permalinks
+
+Documented in two places — [help.shopify.com § Cart permalinks](https://help.shopify.com/en/manual/checkout-settings/cart-permalink) and [shopify.dev § Create cart permalinks](https://shopify.dev/docs/apps/build/checkout/create-cart-permalinks).
+
+**Format:**
+
+```
+https://{shop}.myshopify.com/cart/{variant_id}:{quantity}(,{variant_id}:{quantity})*
+```
+
+Multiple lines are comma-separated. Documented example:
+
+```
+https://my-shop-name.myshopify.com/cart/36485954240671:3,31384149360662:1
+```
+
+**Documented query parameters:**
+
+| Parameter | Effect |
+| --- | --- |
+| `discount` | Apply discount code(s), comma-separated. Codes containing commas cannot be passed. |
+| `note` | Displays in the Notes section on the order details page |
+| `attributes[key]=value` | Custom attributes; multiple allowed; display in Notes |
+| `properties` | Line item properties, Base64 URL-encoded JSON, up to 25 |
+| `checkout[...]` | Pre-fill checkout fields (email, shipping address) |
+| `access_token` | Storefront access token, for sales-channel attribution |
+| `source_name` | Match an attribution handle owned by your app |
+| `ref` | Referral code in the Conversion summary |
+| `storefront=true` | Land on the online-store cart page instead of checkout |
+| `payment=shop_pay` | Direct the buyer to Shop Pay checkout |
+| locale path prefix | e.g. `/fr/cart/...` for a localized checkout |
+
+Documented example with discount: `https://my-shop-name.myshopify.com/cart/36485954240671:1?payment=shop_pay&discount=15off`
+
+**Documented limitations:** "Selling plans don't work with cart permalinks." "Cart permalinks cannot bypass storefront passwords."
+
+**Stability:** Both pages present permalinks as ordinary supported functionality — a merchant-facing help article plus a developer guide under `apps/build/checkout`. Neither page carries a beta, deprecation, or "convenience only" caveat. Neither carries an explicit stability guarantee either; there is no API version attached to permalinks, so they are outside Shopify's versioning contract. **Shopify does not document a maximum number of variants per permalink.**
+
+Because the host is the store's primary domain, the same primary-domain configuration from §1 applies: with `checkout.prismmtg.com` set as Primary, permalinks would be built against that host.
+
+---
+
+## 7. Buy Button / embed script
+
+### Status
+
+| Fact | Evidence |
+| --- | --- |
+| `buy-button-js` v3.0.6 released 2025-08-25; commits through 2026-08-14; not archived; MIT | [GitHub repo](https://github.com/Shopify/buy-button-js) (releases + commits API, checked 2026-08-20) |
+| Depends on `shopify-buy` 3.0.7 — the JS Buy SDK | [package.json](https://github.com/Shopify/buy-button-js/blob/main/package.json) |
+| **JS Buy SDK is deprecated** | [js-buy-sdk README](https://github.com/Shopify/js-buy-sdk): "**The JS Buy SDK is deprecated as of January, 2025.** It will no longer be updated or maintained by Shopify past that point. A final major version, v3.0, has been released to remove the SDK's dependency on the deprecated Checkout APIs, replacing them with Cart APIs. […] Recommended Option: switch to the Storefront API Client" |
+| No deprecation notice on `buy-button-js` itself | Its README covers v3.0 troubleshooting only |
+| Shopify discourages Buy Buttons on your own Shopify store | [Buy Button channel](https://help.shopify.com/en/manual/online-sales-channels/buy-button): they "do not recommend the use of Buy Buttons on your Shopify online store or blog, because they can cause problems with the checkout process." Also "Buy Buttons created before October 10, 2016 are no longer supported." |
+| Available on all Shopify plans | Same page |
+| CDN still live | `https://sdks.shopifycdn.com/buy-button/latest/buy-button-storefront.min.js` → HTTP 200 (verified 2026-08-20) |
+
+So: a maintained wrapper around an explicitly deprecated core, with an active discouragement from Shopify's own help centre for the closest analogous use case.
+
+### Styling control
+
+From [BuyButton.js customization docs](https://shopify.github.io/buy-button-js/customization/):
+
+- Components render **inside iframes by default** — "Iframes are beneficial for most users because they isolate the embed in a 'sandbox' so that other parts of your website don't interact with it in unwanted ways." `iframe` defaults to `true` for top-level components, `false` for nested ones.
+- Customization is a JS `options` object per component: `contents` (boolean toggles per element), `text` (labels), `styles` (CSS-shaped nested objects incl. pseudo-selectors), `order`, `events`, `classes`, `templates` (Mustache), `DOMEvents`.
+- Turning off the iframe to use your own CSS means the components "will appear unstyled" — you inherit the full styling burden with no Shopify defaults.
+
+**Can it match Web Awesome?** Only by re-declaring PRISM's design tokens as JS style objects inside the iframe, or by disabling iframes and rewriting every template. Both paths mean the Buy Button ends up styled *parallel to* `custom.css` rather than *by* it — the `--wa-*` custom properties on PRISM's `:root` do not cross an iframe boundary. This is precisely the "hardest to make look like PRISM" cost the issue anticipated.
+
+---
+
+## 8. Anything else that changes the decision
+
+### Storefront Web Components — a fourth option
+
+[Storefront Web Components](https://shopify.dev/docs/api/storefront-web-components) are not in the issue's option list but map onto PRISM's constraints better than any of the three.
+
+> Storefront Web Components let you bring Shopify-powered commerce capabilities to any website. Display products, showcase collections, and offer a checkout, all with a few lines of embedded HTML.
+
+From [Getting started](https://shopify.dev/docs/api/storefront-web-components/getting-started):
+
+```html
+<script src="https://cdn.shopify.com/storefront/web-components.js"></script>
+<shopify-store store-domain="https://your-store.myshopify.com" country="US" language="en"></shopify-store>
+<shopify-context type="product" handle="your-product-handle">
+  <template>
+    <h1 class="your-style"><shopify-data query="product.title"></shopify-data></h1>
+  </template>
+</shopify-context>
+```
+
+> **You don't need an access token to use Storefront Web Components.** However, if you want to display the inventory count or any custom data about a product, then you need to add an access token.
+
+Key properties for PRISM:
+
+- **Script tag from Shopify's CDN, no bundler** — the same delivery model as the Web Awesome kit already in every `<head>`.
+- **Custom elements with `<template>` slots**, so the surrounding markup is yours: "Since the component outputs a text node, to match your site's design you can wrap it in any necessary HTML elements." This is genuinely different from Buy Button — your HTML, Shopify's data.
+- **Components:** `shopify-store`, `shopify-context`, `shopify-list-context`, `shopify-data`, `shopify-media`, `shopify-money`, `shopify-variant-selector`, `shopify-cart`, `shopify-account` ([full list](https://shopify.dev/docs/api/storefront-web-components/components)).
+- **`<shopify-cart>`** renders into a native `<dialog>`, exposes `showModal()` / `show()` / `close()` / `addLine()`, and is styled via **CSS parts** (`dialog`, `line-heading`, `line-image`, `line-price`, `primary-button`, `secondary-button`, `tertiary-button`, `input-field`, `discount-code`, `discount-error`) and slots ([reference](https://shopify.dev/docs/api/storefront-web-components/components/shopify-cart)). Real `::part()` styling, not an iframe.
+- `<shopify-store>` exposes a `buyNow(e, options)` method for skipping the cart.
+- Caveat: "The cart component doesn't support mixing products from multiple stores."
+- The track is actively developed — [`shopify-account` shipped 2026-02-18](https://shopify.dev/changelog/shopify-account-web-component-for-storefronts) and is on its way to being *required* for Theme Store themes.
+- **Not answered:** the docs carry no stability label (GA / beta / preview) and no API version for the web-components bundle. `web-components.js` is unversioned and auto-updating — Shopify pushes changes to it without a version pin on your side. That is a real risk axis with no documentation to quantify it.
+
+The seam is identical to the Storefront API option (checkout on Shopify's hosted checkout via `checkoutUrl`); the difference is purely how much JavaScript PRISM writes.
+
+### Hydrogen / Oxygen
+
+Irrelevant. [Options for building headless](https://shopify.dev/docs/storefronts/headless/getting-started/build-options) frames Hydrogen as "Shopify's opinionated fullstack approach" built on React Router, deployed to Oxygen. PRISM has no bundler, no React, no Node runtime, and is hosted on Netlify. The correct row of Shopify's own table is "Build headless using the framework of your choice and Shopify's backend using only the Storefront API → Headless channel."
+
+The only Hydrogen artifact worth borrowing is the **checkout-subdomain routing pattern**, which the docs explicitly generalize: "For custom storefronts not hosted on Oxygen, only the subdomain must point to Shopify."
+
+### Customer Account API
+
+[Customer Account API](https://shopify.dev/docs/api/customer) is where orders and account data live; it is cost-limited (100 pts/s standard, 200 Plus) unlike the Storefront API. Not needed for anonymous catalog + cart + checkout. If PRISM ever wants "my orders" inside prismmtg.com, `<shopify-account>` is the low-effort path (passwordless + social sign-in, "styling control via CSS variables"). Note that Shopify accounts are a **separate identity system from PRISM's Supabase auth** — nothing in the docs bridges them, and merging them is not a documented capability.
+
+### Product images
+
+The Storefront API [`Image`](https://shopify.dev/docs/api/storefront/latest/objects/Image) object returns Shopify-CDN URLs and the `url` field accepts an `ImageTransformInput` for "resizing, cropping, scaling for retina displays, and converting between image formats," plus a `thumbhash` field for placeholders. Serving those URLs directly from prismmtg.com is the documented, intended use — the same as `<shopify-media>`, which "generates an image or video element with `srcset` and `sizes` attributes." No CSP or hotlink restriction is documented; PRISM would need `cdn.shopify.com` added to any image CSP.
+
+### Prices and taxes
+
+[`CartCost`](https://shopify.dev/docs/storefronts/headless/building-with-the-storefront-api/cart/manage) distinguishes three pricing surfaces:
+
+> * **Checkout pricing**: The final sale price.
+> * **Cart pricing**: The estimated final sale price.
+> * **Product queries**: The price that displays on a product page.
+
+And on `Cart.cost`: "The estimated costs that the buyer will pay at checkout. The costs are subject to change and changes will be reflected at checkout."
+
+So any price PRISM renders is an estimate; tax and shipping resolve on Shopify's checkout. **Shopify does not document any legal requirement about how a custom storefront must display prices or taxes** — no primary page covers this. Jurisdictional price-display law is outside Shopify's docs entirely; note as a gap, not as "no requirement exists."
+
+### Terms and branding
+
+The [Shopify API License and Terms of Use](https://www.shopify.com/legal/api-terms) governs *Applications* built by Partners. Its relevant restrictions are: no "systematic or automated data collection activities (including scraping, data mining, data extraction and data harvesting)"; request no "more than the minimum amount of data … needed"; and use Shopify's Trademarks only per the brand guidelines and "for the sole purpose of notifying Merchants that the Application is compatible with the Service."
+
+**Not answered:** the API terms are written for third-party developers building for other merchants, not for a merchant building their own storefront over their own catalog. No primary page states an attribution or "Powered by Shopify" requirement for a custom storefront. Shopify's whole headless product line presupposes merchants render their own catalog on their own domain, so the practical answer is clearly "allowed" — but I found no clause that says so explicitly. Do not treat the absence of a branding requirement as a documented permission.
+
+---
+
+## Decision inputs
+
+| Axis | Buy Button (`buy-button-js`) | Cart permalinks | Storefront Web Components | Storefront API (hand-rolled `fetch`) |
+| --- | --- | --- | --- | --- |
+| **Visual control** | Low. Iframe-sandboxed by default; styles are a JS object tree; `--wa-*` tokens don't cross the iframe. Disabling the iframe means fully unstyled components. | Total for the pages you write (they're just PRISM pages) — zero control over the destination. | High. Your markup and CSS in `<template>`; `<shopify-cart>` styled via `::part()` and slots. Cart chrome is still Shopify's DOM. | Total. Every element is PRISM markup, styled by `custom.css` and Web Awesome tokens like every other page. |
+| **Work for a no-build-step vanilla site** | Low to write, high to make look right. One script tag; then fight the styling model. | Lowest. Static product pages plus one `<a href>` per product. No JS, no API. | Low. One script tag, declarative custom elements. Familiar model — same shape as the Web Awesome autoloader already in every `<head>`. | Highest. Hand-write GraphQL queries, cart-state module, `localStorage` persistence, error/throttle handling, variant selection. A new `js/modules/shopify.js` plus feature modules. |
+| **Where the seam falls** | Buyer leaves for Shopify checkout from inside an iframe-hosted cart. | Buyer leaves at the very first click — no cart in PRISM at all. | Buyer leaves at "Checkout" from a PRISM-styled cart dialog. Same `checkoutUrl`. | Buyer leaves at "Checkout" from a fully PRISM cart. Same `checkoutUrl`. |
+| **Host at the seam** | Store primary domain (`checkout.prismmtg.com` if configured, else `*.myshopify.com`) | Same | Same | Same |
+| **Edge function needed** | No | No | No | No — and a proxy would hurt (per-buyer IP capacity) |
+| **Token needed** | Public storefront access token | None (optional `access_token` for attribution) | None for catalog + cart; token only for inventory counts, metafields, metaobjects, accounts | None for catalog + cart; same exceptions |
+| **What breaks it** | JS Buy SDK deprecated Jan 2025; Shopify discourages Buy Buttons near your own store; iframe styling ceiling | No cart, no quantity edits, no multi-item basket UX beyond one prebuilt link; selling plans unsupported; no discount codes containing commas | Unversioned auto-updating CDN bundle with no stability label; cart DOM is Shopify's; single-store only | You own cart-state bugs, `200 Throttled` handling, cart-ID/secret storage, and the 30-day cart expiry |
+| **Ongoing version risk** | Deprecated dependency, no sunset date announced for the wrapper | Outside API versioning; no announced changes | Unversioned bundle — Shopify pushes changes with no pin | Versioned (`2026-07`), 4 releases/year, explicit deprecation changelogs |
+
+**Cross-cutting facts that hold for all four:**
+
+- The final payment step is on Shopify's hosted checkout. The only lever is *which host* — `*.myshopify.com` by default, or a subdomain of prismmtg.com after a Settings → Domains change. Never prismmtg.com itself.
+- Making checkout render at `checkout.prismmtg.com` means setting that subdomain as the store's **Primary** domain with target **Online Store**. Note the wording collision with the issue: the issue rules out a `shop.` subdomain *for the storefront*; the checkout subdomain is a different thing and is unavoidable if you want to leave `myshopify.com` behind.
+- Checkout look-and-feel below Plus is limited to the checkout editor: logo, colours, fonts, one-page vs three-page. The Checkout Branding API is Plus-only.
+- The Checkout API is dead (April 1, 2025). Anything built now uses Cart.
+- Carts expire 30 days after creation; completed carts are deleted and cannot be queried.
+
+## Limitations
+
+- Live verification used Shopify's public demo stores (`mock.shop`, `checkout.hydrogen.shop`) on 2026-08-20, not PRISM's own store. Behaviour on a store with different plan/settings could differ; nothing observed suggests it would.
+- CORS behaviour is **observed**, not documented. Shopify could change it without a versioned deprecation notice, since it is not part of the GraphQL schema contract.
+- The checkout-creation throttle number is not published, so the practical ceiling on cart→checkout conversions per minute is unknown.
+- No primary source states a plan floor for the checkout-subdomain pattern, states that domain-masking checkout is prohibited (only that it is undocumented), or states branding/attribution requirements for a merchant's own custom storefront. Those are documentation gaps, deliberately left unfilled here.

--- a/gallery.html
+++ b/gallery.html
@@ -15,6 +15,15 @@
     <meta name="description" content="Partnered and community artwork for MTG proxies, tokens, and showcase treatments. Personal, non-commercial use with artist credit." />
     <style>.wa-cloak { visibility: hidden; }</style>
     <style>wa-page:not(:defined) { visibility: hidden; }</style>
+    <!-- CDN resilience. Both rules above hide the page until Web Awesome loads, and
+         nothing removes them if it never does, so a blocked or stalled kit leaves a
+         blank white document. Reveal at 5s regardless: unstyled but readable beats
+         invisible. WA removes the class itself on a normal load, well before this. -->
+    <style>
+      @keyframes prism-uncloak { to { visibility: visible; } }
+      .wa-cloak,
+      wa-page:not(:defined) { animation: prism-uncloak 0s linear 5s forwards; }
+    </style>
     <!-- iOS Home Screen icon (layout.js injects these as a fallback) -->
     <link rel="apple-touch-icon" href="./assets/apple-touch-icon.png" />
     <link rel="manifest" href="./assets/site.webmanifest" />

--- a/gallery.html
+++ b/gallery.html
@@ -26,15 +26,16 @@
     <link rel="preconnect" href="https://fonts.bunny.net" />
     <link rel="preconnect" href="https://fonts.bunny.net" crossorigin />
     <link rel="preconnect" href="https://cdn.jsdelivr.net" />
+    <link rel="preconnect" href="https://use.typekit.net" />
+    <link rel="preconnect" href="https://use.typekit.net" crossorigin />
     <!-- Web Awesome, fonts, and app CSS as static tags so the browser preload scanner
          starts them immediately; layout.js injectHeadResources skips tags already present -->
-         <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/themes/default.css">
-               <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/native.css" />
-          <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/utilities.css" />
-          <script type="module" src="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/webawesome.loader.js"></script>
-    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Inter:ital,wght@0,100..900;1,100..900&display=swap" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/themes/default.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/native.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/utilities.css" />
+    <script type="module" src="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/webawesome.loader.js"></script>
     <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Geist+Mono:wght@100..900&display=swap" />
-    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Crimson+Pro:ital,wght@0,200..900;1,200..900&display=swap" />
+    <link rel="stylesheet" href="https://use.typekit.net/gbw6ibc.css" />
     <link rel="stylesheet" href="css/custom.css" />
   </head>
   <body>

--- a/guide.html
+++ b/guide.html
@@ -15,6 +15,29 @@
     <meta name="description" content="How PRISM sleeve marking works: read a marked sleeve, tell Pool from Core, choose slots, run a marking session, count copies, mark split groups, and fix a mark." />
     <style>.wa-cloak { visibility: hidden; }</style>
     <style>wa-page:not(:defined) { visibility: hidden; }</style>
+    <!-- CDN resilience. Both rules above hide the page until Web Awesome loads, and
+         nothing removes them if it never does, so a blocked or stalled kit leaves a
+         blank white document. Reveal at 5s regardless: unstyled but readable beats
+         invisible. WA removes the class itself on a normal load, well before this. -->
+    <style>
+      @keyframes prism-uncloak { to { visibility: visible; } }
+      .wa-cloak,
+      wa-page:not(:defined) { animation: prism-uncloak 0s linear 5s forwards; }
+    </style>
+    <script>
+      // <wa-button href> only navigates once WA upgrades the element, so every CTA on
+      // this page is dead until then. Delegated from document so it also covers the
+      // header button layout.js injects later. No-op once WA is defined.
+      document.addEventListener('click', function (event) {
+        if (window.customElements && customElements.get('wa-button')) return;
+        var btn = event.target.closest && event.target.closest('wa-button[href]');
+        if (!btn || btn.hasAttribute('disabled')) return;
+        var href = btn.getAttribute('href');
+        if (!href) return;
+        if (btn.getAttribute('target') === '_blank') window.open(href, '_blank', 'noopener');
+        else window.location.href = href;
+      });
+    </script>
     <!-- iOS Home Screen icon (layout.js injects these as a fallback) -->
     <link rel="apple-touch-icon" href="./assets/apple-touch-icon.png" />
     <link rel="manifest" href="./assets/site.webmanifest" />

--- a/guide.html
+++ b/guide.html
@@ -148,7 +148,7 @@
           <ol style="padding-left: var(--wa-space-xl); line-height: 1.8; margin: 0;">
             <li>Test the pen on a spare sleeve. Make sure the paint shows against the sleeve color. See <a href="tools.html">Tools</a> for pens that work.</li>
             <li>Take the inner sleeve out of the outer sleeve.</li>
-            <li>Hold the sleeve in the jig, or against a straight edge.</li>
+            <li>Hold the sleeve in the Spirit Guide, or against a straight edge.</li>
             <li>Paint a short line at the slot for the deck. A line of 3 to 7mm is enough.</li>
             <li>Paint the other marks that copy needs in the same pass.</li>
           </ol>
@@ -162,12 +162,12 @@
           </ol>
           <p>Set a line length you can repeat and keep to it. Marks that vary in length are harder to read at a glance than marks that vary only in color and place.</p>
           <div class="wa-grid wa-gap-m" style="--min-column-size: 240px;">
-            <img src="assets/Spririt-Guide.svg" alt="The Spirit Guide jig over a sleeve, with a mark drawn through one slot of its comb" style="max-inline-size: 100%; block-size: auto;" />
-            <img src="assets/spiritguide.avif" alt="The printed Spirit Guide jig holding a sleeve" style="max-inline-size: 100%; block-size: auto; border-radius: var(--wa-border-radius-m);" />
+            <img src="assets/Spririt-Guide.svg" alt="The Spirit Guide over a sleeve, with a mark drawn through one slot of its comb" style="max-inline-size: 100%; block-size: auto;" />
+            <img src="assets/spiritguide.avif" alt="The printed Spirit Guide holding a sleeve" style="max-inline-size: 100%; block-size: auto; border-radius: var(--wa-border-radius-m);" />
           </div>
           <wa-callout variant="brand" appearance="outlined">
             <wa-icon slot="icon" name="handshake-angle"></wa-icon>
-            <strong>Use the Spirit Guide.</strong> It holds the sleeve and shows every slot, so you paint all of a card's colors in one pass. Until the STL lands on <a href="tools.html">Tools</a>, any straight-edge jig works.
+            <strong>Use the Spirit Guide.</strong> It holds the sleeve and shows every slot, so you paint all of a card's colors in one pass. Until the STL lands on <a href="tools.html">Tools</a>, any straight edge works.
           </wa-callout>
           <p><strong>Double-sleeve every marked card.</strong> The outer sleeve protects the paint from handling. It also keeps the deck legal for play, because every card in it shows the same outer sleeve.</p>
         </section>
@@ -185,7 +185,7 @@
           <p>Add the batches together and you get the Physical total, which is the number of copies to own. For the Islands above, the Physical total is 12.</p>
           <p>You never mark all twelve Islands for both decks. Eight marked for Deck B is exactly enough, because Deck B never needs a ninth.</p>
           <p>Basic lands are the loudest case, not a special case. Any card you run more than one of works the same way. So does a card that one deck runs four of and another runs two.</p>
-          <p>The Grouped by Mark filter shows the work one mark at a time. Each row is a single deck's mark on a number of copies, which is what your hand does at the table.</p>
+          <p>The One Mark at a Time filter shows exactly that. Each row is a single deck's mark on a number of copies, which is what your hand does at the table.</p>
         </section>
 
         <wa-divider></wa-divider>
@@ -199,7 +199,7 @@
           <div>
             <img src="assets/split-variant.svg" alt="Cards sorted into two variants of one deck, each variant marked at its own Side B slot" style="max-inline-size: 100%; block-size: auto;" />
           </div>
-          <p><strong>Dots.</strong> Each variant gets a colored dot next to the group's Side A mark, on the same edge. This style holds exactly two variants, because the jig has one dot hole.</p>
+          <p><strong>Dots.</strong> Each variant gets a colored dot next to the group's Side A mark, on the same edge. This style holds exactly two variants, because the Spirit Guide has one dot hole.</p>
           <p>Pick dots when the group has two variants and you want the opposite edge left clear. Pick stripes for anything larger.</p>
         </section>
 

--- a/guide.html
+++ b/guide.html
@@ -54,6 +54,18 @@
       #step-bar .step-chip wa-tag {
         cursor: pointer;
       }
+      /* Persistent hint that the bar scrolls sideways past the last visible
+         chip — sticky so it rides the trailing edge as the user scrolls. */
+      #step-bar-hint {
+        position: sticky;
+        right: 0;
+        flex: none;
+        align-self: center;
+        padding-inline-start: var(--wa-space-xs);
+        color: var(--wa-color-neutral-text-subtle);
+        background: var(--wa-color-surface-default);
+        pointer-events: none;
+      }
       .guide-step {
         padding-block: var(--wa-space-xl);
         scroll-margin-top: 9rem;
@@ -70,6 +82,7 @@
         <a href="#count-copies" data-step="count-copies" class="step-chip"><wa-tag variant="neutral" appearance="outlined" size="small" pill>Count the copies you need</wa-tag></a>
         <a href="#mark-variants" data-step="mark-variants" class="step-chip"><wa-tag variant="neutral" appearance="outlined" size="small" pill>Mark a split group</wa-tag></a>
         <a href="#fix-a-mark" data-step="fix-a-mark" class="step-chip"><wa-tag variant="neutral" appearance="outlined" size="small" pill>Fix a mark you no longer want</wa-tag></a>
+        <wa-icon id="step-bar-hint" name="chevron-right" aria-hidden="true"></wa-icon>
       </div>
 
       <main style="max-width: 800px; margin: 0 auto;">

--- a/guide.html
+++ b/guide.html
@@ -59,6 +59,12 @@
       #step-bar .step-chip {
         flex: none;
         text-decoration: none;
+        /* DESIGN.md §8 wants a 44px minimum touch target, met by padding the hit
+           area rather than inflating the chip: this bar is the only navigation
+           on a page people scroll one-handed with a wet pen in the other. */
+        display: inline-flex;
+        align-items: center;
+        min-block-size: 44px;
       }
       #step-bar .step-chip wa-tag {
         cursor: pointer;
@@ -77,7 +83,11 @@
       }
       .guide-step {
         padding-block: var(--wa-space-xl);
-        scroll-margin-top: 9rem;
+        /* Clears the sticky header plus the step bar when a chip jumps to a
+           section. Measured at ~135px with the 44px chips; 10rem leaves room for
+           the horizontal scrollbar the bar shows on platforms without overlay
+           scrollbars, which would otherwise hide the heading behind it. */
+        scroll-margin-top: 10rem;
       }
     </style>
   </head>
@@ -148,7 +158,7 @@
 
         <section id="mark-a-session" class="wa-stack wa-gap-m guide-step">
           <h2 class="wa-heading-xl">Run a marking session</h2>
-          <p>A marking session is one sitting that takes a stack of cards from unmarked to marked. Work one card at a time, not one deck at a time. Mark the Pool cards first, because they carry the most marks.</p>
+          <p>A marking session is one sitting that takes a stack of cards from unmarked to marked. Work one card at a time, not one deck at a time. Mark the Pool cards first, because they carry the most marks. Make your first card a cheap one, a basic land or a bulk common that still carries several marks, so a miscount costs you a sleeve and not a Mana Crypt.</p>
           <p>PRISM builds an undone list of every card that still needs a mark, with the number of copies for each one. Take that list to the table and work from it.</p>
           <wa-callout variant="danger">
             <wa-icon slot="icon" name="triangle-exclamation"></wa-icon>
@@ -169,6 +179,10 @@
             <li>Put the inner sleeve back inside the outer sleeve.</li>
             <li>Check the card off in PRISM.</li>
           </ol>
+          <wa-callout variant="danger">
+            <wa-icon slot="icon" name="circle-check"></wa-icon>
+            <strong>Stop after the first card and check it against PRISM.</strong> Find that card in the list and confirm every mark you painted matches the color and slot PRISM shows for it. Step 1 tests the pen. This tests your reading of the slots, and it is the last point where a miscount costs one inner sleeve instead of two hundred.
+          </wa-callout>
           <p>Set a line length you can repeat and keep to it. Marks that vary in length are harder to read at a glance than marks that vary only in color and place.</p>
           <div class="wa-grid wa-gap-m" style="--min-column-size: 240px;">
             <img src="assets/Spririt-Guide.svg" alt="The Spirit Guide over a sleeve, with a mark drawn through one slot of its comb" style="max-inline-size: 100%; block-size: auto;" />

--- a/guide.html
+++ b/guide.html
@@ -24,20 +24,6 @@
       .wa-cloak,
       wa-page:not(:defined) { animation: prism-uncloak 0s linear 5s forwards; }
     </style>
-    <script>
-      // <wa-button href> only navigates once WA upgrades the element, so every CTA on
-      // this page is dead until then. Delegated from document so it also covers the
-      // header button layout.js injects later. No-op once WA is defined.
-      document.addEventListener('click', function (event) {
-        if (window.customElements && customElements.get('wa-button')) return;
-        var btn = event.target.closest && event.target.closest('wa-button[href]');
-        if (!btn || btn.hasAttribute('disabled')) return;
-        var href = btn.getAttribute('href');
-        if (!href) return;
-        if (btn.getAttribute('target') === '_blank') window.open(href, '_blank', 'noopener');
-        else window.location.href = href;
-      });
-    </script>
     <!-- iOS Home Screen icon (layout.js injects these as a fallback) -->
     <link rel="apple-touch-icon" href="./assets/apple-touch-icon.png" />
     <link rel="manifest" href="./assets/site.webmanifest" />

--- a/guide.html
+++ b/guide.html
@@ -26,15 +26,16 @@
     <link rel="preconnect" href="https://fonts.bunny.net" />
     <link rel="preconnect" href="https://fonts.bunny.net" crossorigin />
     <link rel="preconnect" href="https://cdn.jsdelivr.net" />
+    <link rel="preconnect" href="https://use.typekit.net" />
+    <link rel="preconnect" href="https://use.typekit.net" crossorigin />
     <!-- Web Awesome, fonts, and app CSS as static tags so the browser preload scanner
          starts them immediately; layout.js injectHeadResources skips tags already present -->
-   <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/themes/default.css">
-         <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/native.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/themes/default.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/native.css" />
     <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/utilities.css" />
     <script type="module" src="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/webawesome.loader.js"></script>
-    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Inter:ital,wght@0,100..900;1,100..900&display=swap" />
     <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Geist+Mono:wght@100..900&display=swap" />
-    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Crimson+Pro:ital,wght@0,200..900;1,200..900&display=swap" />
+    <link rel="stylesheet" href="https://use.typekit.net/gbw6ibc.css" />
     <link rel="stylesheet" href="css/custom.css" />
     <style>
       /* Guide step bar (sticky subheader) */

--- a/index.html
+++ b/index.html
@@ -175,10 +175,13 @@
         </section>
 
         <!-- Features -->
-        <section id="features" class="wa-stack wa-gap-xl">
+        <!-- Same 900px measure as How It Works. At 280px minimum the four cards
+             laid out 3 + 1, orphaning the last one beside a half-empty row; 380px
+             forces a 2x2 block and gives each card a ~49ch reading measure. -->
+        <section id="features" class="wa-stack wa-gap-xl" style="max-width: 900px; margin: 0 auto;">
           <h2 class="wa-heading-2xl" style="text-align: center;">Features</h2>
 
-          <div class="wa-grid wa-gap-l" style="--min-column-size: 280px;">
+          <div class="wa-grid wa-gap-l" style="--min-column-size: 380px;">
             <wa-card>
               <div slot="header" class="wa-cluster wa-gap-s wa-align-items-center">
                 <wa-icon name="code-branch" style="font-size: 1.25em; color: var(--wa-color-brand-fill);"></wa-icon>

--- a/index.html
+++ b/index.html
@@ -69,8 +69,12 @@
           <div class="wa-heading-m" style="text-align: center; letter-spacing: 0.05em;">One card. Every deck.&#8482;</div>
           <img src="./assets/Prism-Logo-Invert.svg" alt="PRISM logo" style="width:275px;" class="theme-logo-dark">
           <img src="./assets/Prism-Logo-Main.svg" alt="PRISM logo" style="width:275px;" class="theme-logo-light">
-          <div class="wa-heading-l" style="text-align: center;">Personal Reference Index &amp; Sleeve Marking</div>
-          <p class="wa-caption-l" style="text-align: center; max-width: 600px;">
+          <div class="wa-caption-m" style="text-align: center; letter-spacing: 0.05em; color: var(--wa-color-neutral-text-subtle);">Personal Reference Index &amp; Sleeve Marking</div>
+          <!-- Display step per DESIGN.md §8: 64px desktop down to 36px mobile. -->
+          <h1 class="wa-heading-3xl" style="text-align: center; max-width: 22ch; margin: 0; font-size: clamp(2.25rem, 6vw, 4rem); text-wrap: balance;">
+            Stop buying the same card ten times.
+          </h1>
+          <p style="text-align: center; max-width: 600px;">
             Own one copy of each card. Mark its sleeve with a stripe for every deck the card belongs to. Fan, pull, play.
           </p>
           <div class="wa-flank wa-gap-s" style="margin-top: var(--wa-space-l);">
@@ -121,37 +125,57 @@
           </div>
         </section>
 
-        <wa-divider style="--spacing: var(--wa-space-2xl);"></wa-divider>
+        <!-- What You Get Back. Figures are the README "Real World Impact" table,
+             computed from average EDHREC decklists for top commanders. Real math,
+             not illustrative: do not round or dramatize them. Tinted ground rather
+             than a divider so the section reads as a peak in the scroll; surface-2
+             is used because it is the one sunken token remapped for dark mode. -->
+        <section id="payoff" style="background: var(--wa-color-surface-2); padding: var(--wa-space-3xl) var(--wa-space-l); margin-block: var(--wa-space-2xl);">
+          <div class="wa-stack wa-gap-l" style="max-width: 720px; margin: 0 auto;">
+            <h2 class="wa-heading-2xl" style="text-align: center;">What You Get Back</h2>
+            <p style="text-align: center; max-width: 60ch; margin-inline: auto;">
+              Every deck you add overlaps the decks you already own. Those overlaps are copies you stop needing, and copies you can sell.
+            </p>
+
+            <table class="impact-table">
+              <caption>Duplicate copies a marked collection frees up, by collection size.</caption>
+              <thead>
+                <tr>
+                  <th scope="col">Collection</th>
+                  <th scope="col">Duplicates freed</th>
+                  <th scope="col" style="text-align: right;">Resale value</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th scope="row" class="impact-collection">5 decks</th>
+                  <td>166 cards</td>
+                  <td class="impact-value">~$919</td>
+                </tr>
+                <tr>
+                  <th scope="row" class="impact-collection">10 decks</th>
+                  <td>358 cards</td>
+                  <td class="impact-value">~$1,637</td>
+                </tr>
+                <tr>
+                  <th scope="row" class="impact-collection">48 decks</th>
+                  <td>2,295 cards</td>
+                  <td class="impact-value">~$9,680</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <p class="wa-caption-m" style="text-align: center; color: var(--wa-color-neutral-text-subtle);">
+              Based on average EDHREC decklists for top commanders. Your collection will differ.
+            </p>
+          </div>
+        </section>
 
         <!-- Features -->
         <section id="features" class="wa-stack wa-gap-xl">
           <h2 class="wa-heading-2xl" style="text-align: center;">Features</h2>
 
           <div class="wa-grid wa-gap-l" style="--min-column-size: 280px;">
-            <wa-card>
-              <div slot="header" class="wa-cluster wa-gap-s wa-align-items-center">
-                <wa-icon name="file-import" style="font-size: 1.25em; color: var(--wa-color-brand-fill);"></wa-icon>
-                <h3 class="wa-body-l">Import Decks</h3>
-              </div>
-              <p>Paste a deck URL, or type a list in standard MTGO format. PRISM parses the list, and organizes the cards.</p>
-            </wa-card>
-
-            <wa-card>
-              <div slot="header" class="wa-cluster wa-gap-s wa-align-items-center">
-                <wa-icon name="paintbrush" style="font-size: 1.25em; color: var(--wa-color-brand-fill);"></wa-icon>
-                <h3 class="wa-body-l">Smart Marking</h3>
-              </div>
-              <p>Each deck gets one color and one fixed slot. Fan your cards, find the stripes, and pull the deck.</p>
-            </wa-card>
-
-            <wa-card>
-              <div slot="header" class="wa-cluster wa-gap-s wa-align-items-center">
-                <wa-icon name="object-group" style="font-size: 1.25em; color: var(--wa-color-brand-fill);"></wa-icon>
-                <h3 class="wa-body-l">Overlap View</h3>
-              </div>
-              <p>See how much each pair of decks shares. Find the decks with no overlap, which is useful when someone borrows a deck. Or use the overlaps to fit more decks into fewer cards.</p>
-            </wa-card>
-            
             <wa-card>
               <div slot="header" class="wa-cluster wa-gap-s wa-align-items-center">
                 <wa-icon name="code-branch" style="font-size: 1.25em; color: var(--wa-color-brand-fill);"></wa-icon>
@@ -185,13 +209,6 @@
               <p>PRISM saves your work in your browser. Return at any time to update or export it. Login to sync across multiple devices.</p>
             </wa-card>
 
-            <wa-card>
-              <div slot="header" class="wa-cluster wa-gap-s wa-align-items-center">
-                <wa-icon name="layer-group" style="font-size: 1.25em; color: var(--wa-color-brand-fill);"></wa-icon>
-                <h3 class="wa-body-l">Up to 48 Decks</h3>
-              </div>
-              <p>A single PRISM holds up to 48 decks, or 96 with dot splits. Each deck gets its own slot. For a larger collection, create more than one PRISM.</p>
-            </wa-card>
           </div>
         </section>
 

--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@
             <wa-card>
               <div slot="header" class="wa-cluster wa-gap-s wa-align-items-center">
                 <wa-icon name="file-import" style="font-size: 1.25em; color: var(--wa-color-brand-fill);"></wa-icon>
-                <span class="wa-body-l">Import Decks</span>
+                <h3 class="wa-body-l">Import Decks</h3>
               </div>
               <p>Paste a deck URL, or type a list in standard MTGO format. PRISM parses the list, and organizes the cards.</p>
             </wa-card>
@@ -116,7 +116,7 @@
             <wa-card>
               <div slot="header" class="wa-cluster wa-gap-s wa-align-items-center">
                 <wa-icon name="paintbrush" style="font-size: 1.25em; color: var(--wa-color-brand-fill);"></wa-icon>
-                <span class="wa-body-l">Smart Marking</span>
+                <h3 class="wa-body-l">Smart Marking</h3>
               </div>
               <p>Each deck gets one color and one fixed slot. Fan your cards, find the stripes, and pull the deck.</p>
             </wa-card>
@@ -124,7 +124,7 @@
             <wa-card>
               <div slot="header" class="wa-cluster wa-gap-s wa-align-items-center">
                 <wa-icon name="object-group" style="font-size: 1.25em; color: var(--wa-color-brand-fill);"></wa-icon>
-                <span class="wa-body-l">Overlap View</span>
+                <h3 class="wa-body-l">Overlap View</h3>
               </div>
               <p>See how much each pair of decks shares. Find the decks with no overlap, which is useful when someone borrows a deck. Or use the overlaps to fit more decks into fewer cards.</p>
             </wa-card>
@@ -132,7 +132,7 @@
             <wa-card>
               <div slot="header" class="wa-cluster wa-gap-s wa-align-items-center">
                 <wa-icon name="code-branch" style="font-size: 1.25em; color: var(--wa-color-brand-fill);"></wa-icon>
-                <span class="wa-body-l">Deck Variants</span>
+                <h3 class="wa-body-l">Deck Variants</h3>
               </div>
               <p>Run one commander shell with several themes. Mark the copies every variant uses once, then mark each variant on its own. PRISM tracks the shell and its variants as one group.</p>
             </wa-card>
@@ -141,7 +141,7 @@
             <wa-card>
               <div slot="header" class="wa-cluster wa-gap-s wa-align-items-center">
                 <wa-icon name="arrows-rotate" style="font-size: 1.25em; color: var(--wa-color-brand-fill);"></wa-icon>
-                <span class="wa-body-l">Track Changes</span>
+                <h3 class="wa-body-l">Track Changes</h3>
               </div>
               <p>Add a new deck later and PRISM shows what changed. You mark only the new cards. You do not re-mark hundreds of sleeves.</p>
             </wa-card>
@@ -149,7 +149,7 @@
             <wa-card>
               <div slot="header" class="wa-cluster wa-gap-s wa-align-items-center">
                 <wa-icon name="download" style="font-size: 1.25em; color: var(--wa-color-brand-fill);"></wa-icon>
-                <span class="wa-body-l">Export Anywhere</span>
+                <h3 class="wa-body-l">Export Anywhere</h3>
               </div>
               <p>Use the web app here, or download your marking guide as CSV, JSON, or a printable reference.</p>
             </wa-card>
@@ -157,7 +157,7 @@
             <wa-card>
               <div slot="header" class="wa-cluster wa-gap-s wa-align-items-center">
                 <wa-icon name="floppy-disk" style="font-size: 1.25em; color: var(--wa-color-brand-fill);"></wa-icon>
-                <span class="wa-body-l">Auto-Save</span>
+                <h3 class="wa-body-l">Auto-Save</h3>
               </div>
               <p>PRISM saves your work in your browser. Return at any time to update or export it. Login to sync across multiple devices.</p>
             </wa-card>
@@ -165,7 +165,7 @@
             <wa-card>
               <div slot="header" class="wa-cluster wa-gap-s wa-align-items-center">
                 <wa-icon name="layer-group" style="font-size: 1.25em; color: var(--wa-color-brand-fill);"></wa-icon>
-                <span class="wa-body-l">Up to 48 Decks</span>
+                <h3 class="wa-body-l">Up to 48 Decks</h3>
               </div>
               <p>A single PRISM holds up to 48 decks, or 96 with dot splits. Each deck gets its own slot. For a larger collection, create more than one PRISM.</p>
             </wa-card>

--- a/index.html
+++ b/index.html
@@ -26,6 +26,8 @@
     <link rel="preconnect" href="https://fonts.bunny.net" />
     <link rel="preconnect" href="https://fonts.bunny.net" crossorigin />
     <link rel="preconnect" href="https://cdn.jsdelivr.net" />
+    <link rel="preconnect" href="https://use.typekit.net" />
+    <link rel="preconnect" href="https://use.typekit.net" crossorigin />
     <!-- Web Awesome, fonts, and app CSS as static tags so the browser preload scanner
          starts them immediately; layout.js injectHeadResources skips tags already present -->
     <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/themes/default.css" />

--- a/index.html
+++ b/index.html
@@ -24,20 +24,6 @@
       .wa-cloak,
       wa-page:not(:defined) { animation: prism-uncloak 0s linear 5s forwards; }
     </style>
-    <script>
-      // <wa-button href> only navigates once WA upgrades the element, so every CTA on
-      // this page is dead until then. Delegated from document so it also covers the
-      // header button layout.js injects later. No-op once WA is defined.
-      document.addEventListener('click', function (event) {
-        if (window.customElements && customElements.get('wa-button')) return;
-        var btn = event.target.closest && event.target.closest('wa-button[href]');
-        if (!btn || btn.hasAttribute('disabled')) return;
-        var href = btn.getAttribute('href');
-        if (!href) return;
-        if (btn.getAttribute('target') === '_blank') window.open(href, '_blank', 'noopener');
-        else window.location.href = href;
-      });
-    </script>
     <!-- iOS Home Screen icon (layout.js injects these as a fallback) -->
     <link rel="apple-touch-icon" href="./assets/apple-touch-icon.png" />
     <link rel="manifest" href="./assets/site.webmanifest" />

--- a/index.html
+++ b/index.html
@@ -15,6 +15,29 @@
     <meta name="description" content="Share MTG Commander cards across multiple decks without buying duplicates. PRISM helps you mark sleeves so one card can live in many decks." />
     <style>.wa-cloak { visibility: hidden; }</style>
     <style>wa-page:not(:defined) { visibility: hidden; }</style>
+    <!-- CDN resilience. Both rules above hide the page until Web Awesome loads, and
+         nothing removes them if it never does, so a blocked or stalled kit leaves a
+         blank white document. Reveal at 5s regardless: unstyled but readable beats
+         invisible. WA removes the class itself on a normal load, well before this. -->
+    <style>
+      @keyframes prism-uncloak { to { visibility: visible; } }
+      .wa-cloak,
+      wa-page:not(:defined) { animation: prism-uncloak 0s linear 5s forwards; }
+    </style>
+    <script>
+      // <wa-button href> only navigates once WA upgrades the element, so every CTA on
+      // this page is dead until then. Delegated from document so it also covers the
+      // header button layout.js injects later. No-op once WA is defined.
+      document.addEventListener('click', function (event) {
+        if (window.customElements && customElements.get('wa-button')) return;
+        var btn = event.target.closest && event.target.closest('wa-button[href]');
+        if (!btn || btn.hasAttribute('disabled')) return;
+        var href = btn.getAttribute('href');
+        if (!href) return;
+        if (btn.getAttribute('target') === '_blank') window.open(href, '_blank', 'noopener');
+        else window.location.href = href;
+      });
+    </script>
     <!-- iOS Home Screen icon (layout.js injects these as a fallback) -->
     <link rel="apple-touch-icon" href="./assets/apple-touch-icon.png" />
     <link rel="manifest" href="./assets/site.webmanifest" />

--- a/index.html
+++ b/index.html
@@ -114,14 +114,14 @@
           </div>
         </section>
 
-        <!-- What You Get Back. Figures are the README "Real World Impact" table,
+        <!-- Duplicates You Free Up. Figures are the README "Real World Impact" table,
              computed from average EDHREC decklists for top commanders. Real math,
              not illustrative: do not round or dramatize them. Tinted ground rather
              than a divider so the section reads as a peak in the scroll; surface-2
              is used because it is the one sunken token remapped for dark mode. -->
         <section id="payoff" style="background: var(--wa-color-surface-2); padding: var(--wa-space-3xl) var(--wa-space-l); margin-block: var(--wa-space-2xl);">
           <div class="wa-stack wa-gap-l" style="max-width: 720px; margin: 0 auto;">
-            <h2 class="wa-heading-2xl" style="text-align: center;">What You Get Back</h2>
+            <h2 class="wa-heading-2xl" style="text-align: center;">Duplicates You Free Up</h2>
             <p style="text-align: center; max-width: 60ch; margin-inline: auto;">
               Every deck you add overlaps the decks you already own. Those overlaps are copies you stop needing, and copies you can sell.
             </p>
@@ -157,6 +157,18 @@
             <p class="wa-caption-s" style="text-align: center; color: var(--wa-color-neutral-text-subtle);">
               Based on average EDHREC decklists for top commanders. Your collection will differ.
             </p>
+
+            <!-- Affiliate CTA. Placed after the figures because the table is what
+                 makes the argument; disclosure wording matches tools.html. -->
+            <div class="wa-stack wa-gap-xs wa-align-items-center">
+              <wa-button href="https://cardconduit.com/defcat" target="_blank" rel="noopener" appearance="outlined">
+                <wa-icon slot="start" name="box-open"></wa-icon>
+                Sell Your Duplicates with Card Conduit
+              </wa-button>
+              <p class="wa-caption-s" style="text-align: center; color: var(--wa-color-neutral-text-subtle); margin: 0;">
+                Support your local game store, or use the affiliate link above to help cover hosting costs.
+              </p>
+            </div>
           </div>
         </section>
 
@@ -234,7 +246,7 @@
 
           <wa-details>
             <span slot="summary" class="wa-body-m" style="font-weight: 500;">What about all my extra cards now?</span>
-            <p>Sell them. After you mark your sleeves, you need only one copy of each card. Your duplicates become trade fodder or cash. Many players cover the cost of their marking supplies this way.</p>
+            <p>Sell them. After you mark your sleeves, you need only one copy of each card. Your duplicates become trade fodder or cash. Many players cover the cost of their marking supplies this way. Support your local game store, or ship the pile to <a href="https://cardconduit.com/defcat" target="_blank" rel="noopener">Card Conduit</a> instead of listing singles one at a time. That is an affiliate link, and it helps cover hosting costs.</p>
           </wa-details>
 
          

--- a/index.html
+++ b/index.html
@@ -85,10 +85,10 @@
               <p>A copy that two or more decks use is Pool. PRISM finds every one of them, so one Sol Ring is all you need.</p>
             </div>
             <div class="wa-stack wa-gap-s wa-align-items-center" style="text-align: center;">
-              <!-- Full width, not 75%: this is a diagram of the jig's slot comb
+              <!-- Full width, not 75%: this is a diagram of the Spirit Guide's slot comb
                    with a mark passing through it, unreadable at icon scale (#163 F1). -->
               <div class="wa-frame" style="block-size: 11rem; inline-size: 100%;">
-                <img src="./assets/Spririt-Guide.svg" alt="The Spirit Guide jig over a sleeve, with a mark drawn through one slot of its comb" style="object-fit: contain;" />
+                <img src="./assets/Spririt-Guide.svg" alt="The Spirit Guide over a sleeve, with a mark drawn through one slot of its comb" style="object-fit: contain;" />
               </div>
 
               <h3 class="wa-heading-xl">Mark Your Sleeves</h3>
@@ -212,8 +212,8 @@
           </wa-details>
 
           <wa-details>
-            <span slot="summary" class="wa-caption-m">Can I reorder the stripe positions?</span>
-            <p>Yes. On each deck card, select Move to open the slot picker. To reorder several decks at once, use the dropdown list on the Export tab. Group your decks by color identity, or put your most-played decks in the positions that are easiest to see.</p>
+            <span slot="summary" class="wa-caption-m">Can I reorder the slots?</span>
+            <p>Yes. On each deck card, select Move to open the slot picker. To reorder several decks at once, use the dropdown list on the Export tab. Group your decks by color identity, or put your most-played decks in the slots that are easiest to see.</p>
           </wa-details>
 
           <wa-details>

--- a/index.html
+++ b/index.html
@@ -71,14 +71,14 @@
           <div class="wa-grid wa-gap-xl" style="--min-column-size: 250px;">
             <div class="wa-stack wa-gap-s wa-align-items-center" style="text-align: center;">
               <div class="wa-frame" style="block-size: 11rem; inline-size: 100%;">
-                <img src="./assets/Deck-List.svg" alt="icon-of-deck-list" style="object-fit: contain;" />
+                <img src="./assets/Deck-List.svg" alt="Three decklists shown as columns of stacked placeholder rows, side by side" style="object-fit: contain;" />
               </div>
               <h3 class="wa-heading-xl">Import Your Decks</h3>
               <p>Paste a deck URL from Moxfield or Archidekt. You can also type a list by hand. PRISM gives each deck one color and one slot. A single PRISM holds up to 48 decks, or 96 with dot splits.</p>
             </div>
             <div class="wa-stack wa-gap-s wa-align-items-center" style="text-align: center;">
               <div class="wa-frame" style="block-size: 11rem; inline-size: 100%;">
-                <img src="./assets/Web-App.svg" alt="icon-of-web-app" style="object-fit: contain;" />
+                <img src="./assets/Web-App.svg" alt="A results table mockup with a card checklist on the left and a grid of colored deck-color squares on the right, showing which decks share each card" style="object-fit: contain;" />
               </div>
 
               <h3 class="wa-heading-xl">Find Your Pool Copies</h3>

--- a/index.html
+++ b/index.html
@@ -66,10 +66,13 @@
       <main>
         <!-- Hero Section -->
         <section class="wa-stack wa-gap-m wa-align-items-center" style="padding-block: var(--wa-space-3xl);">
-          <div class="wa-heading-m" style="text-align: center; letter-spacing: 0.05em;">One card. Every deck.&#8482;</div>
+          <!-- Eyebrow role per DESIGN.md §3: halyard-micro 14px/500, 0.05em tracking.
+               This string is named there as the eyebrow, so it takes the body face,
+               not the heading serif it was rendering in. -->
+          <div class="wa-body-s" style="text-align: center; letter-spacing: 0.05em; font-weight: 500;">One card. Every deck.&#8482;</div>
           <img src="./assets/Prism-Logo-Invert.svg" alt="PRISM logo" style="width:275px;" class="theme-logo-dark">
           <img src="./assets/Prism-Logo-Main.svg" alt="PRISM logo" style="width:275px;" class="theme-logo-light">
-          <div class="wa-caption-m" style="text-align: center; letter-spacing: 0.05em; color: var(--wa-color-neutral-text-subtle);">Personal Reference Index &amp; Sleeve Marking</div>
+          <div class="wa-caption-s" style="text-align: center; letter-spacing: 0.05em; color: var(--wa-color-neutral-text-subtle);">Personal Reference Index &amp; Sleeve Marking</div>
           <!-- Display step per DESIGN.md §8: 64px desktop down to 36px mobile. -->
           <h1 class="wa-heading-3xl" style="text-align: center; max-width: 22ch; margin: 0; font-size: clamp(2.25rem, 6vw, 4rem); text-wrap: balance;">
             Stop buying the same card ten times.
@@ -165,7 +168,7 @@
               </tbody>
             </table>
 
-            <p class="wa-caption-m" style="text-align: center; color: var(--wa-color-neutral-text-subtle);">
+            <p class="wa-caption-s" style="text-align: center; color: var(--wa-color-neutral-text-subtle);">
               Based on average EDHREC decklists for top commanders. Your collection will differ.
             </p>
           </div>
@@ -179,7 +182,7 @@
             <wa-card>
               <div slot="header" class="wa-cluster wa-gap-s wa-align-items-center">
                 <wa-icon name="code-branch" style="font-size: 1.25em; color: var(--wa-color-brand-fill);"></wa-icon>
-                <h3 class="wa-body-l">Deck Variants</h3>
+                <h3 class="wa-heading-l">Deck Variants</h3>
               </div>
               <p>Run one commander shell with several themes. Mark the copies every variant uses once, then mark each variant on its own. PRISM tracks the shell and its variants as one group.</p>
             </wa-card>
@@ -188,7 +191,7 @@
             <wa-card>
               <div slot="header" class="wa-cluster wa-gap-s wa-align-items-center">
                 <wa-icon name="arrows-rotate" style="font-size: 1.25em; color: var(--wa-color-brand-fill);"></wa-icon>
-                <h3 class="wa-body-l">Track Changes</h3>
+                <h3 class="wa-heading-l">Track Changes</h3>
               </div>
               <p>Add a new deck later and PRISM shows what changed. You mark only the new cards. You do not re-mark hundreds of sleeves.</p>
             </wa-card>
@@ -196,7 +199,7 @@
             <wa-card>
               <div slot="header" class="wa-cluster wa-gap-s wa-align-items-center">
                 <wa-icon name="download" style="font-size: 1.25em; color: var(--wa-color-brand-fill);"></wa-icon>
-                <h3 class="wa-body-l">Export Anywhere</h3>
+                <h3 class="wa-heading-l">Export Anywhere</h3>
               </div>
               <p>Use the web app here, or download your marking guide as CSV, JSON, or a printable reference.</p>
             </wa-card>
@@ -204,7 +207,7 @@
             <wa-card>
               <div slot="header" class="wa-cluster wa-gap-s wa-align-items-center">
                 <wa-icon name="floppy-disk" style="font-size: 1.25em; color: var(--wa-color-brand-fill);"></wa-icon>
-                <h3 class="wa-body-l">Auto-Save</h3>
+                <h3 class="wa-heading-l">Auto-Save</h3>
               </div>
               <p>PRISM saves your work in your browser. Return at any time to update or export it. Login to sync across multiple devices.</p>
             </wa-card>
@@ -236,28 +239,28 @@
 
           
           <wa-details>
-            <span slot="summary" class="wa-caption-m">What markers should I use?</span>
+            <span slot="summary" class="wa-body-m" style="font-weight: 500;">What markers should I use?</span>
             <p>Use fine-tip acrylic paint pens. They work on most sleeves. PRISM defaults to colors that match standard paint pen sets. The <a href="tools.html">Tools page</a> lists specific products.</p>
           </wa-details>
 
           <wa-details>
-            <span slot="summary" class="wa-caption-m">What about all my extra cards now?</span>
+            <span slot="summary" class="wa-body-m" style="font-weight: 500;">What about all my extra cards now?</span>
             <p>Sell them. After you mark your sleeves, you need only one copy of each card. Your duplicates become trade fodder or cash. Many players cover the cost of their marking supplies this way.</p>
           </wa-details>
 
          
           <wa-details>
-            <span slot="summary" class="wa-caption-m">Where is my data stored?</span>
+            <span slot="summary" class="wa-body-m" style="font-weight: 500;">Where is my data stored?</span>
             <p>PRISM is local-first. Your decks and marks stay in your browser and work without an account. If you create an account, PRISM also syncs your data to our database so you can use it across devices. We use aggregate analytics that do not identify you. The <a href="privacy.html">Privacy Policy</a> has the details. You can export your data as JSON at any time.</p>
           </wa-details>
 
           <wa-details>
-            <span slot="summary" class="wa-caption-m">Can I reorder the slots?</span>
+            <span slot="summary" class="wa-body-m" style="font-weight: 500;">Can I reorder the slots?</span>
             <p>Yes. On each deck card, select Move to open the slot picker. To reorder several decks at once, use the dropdown list on the Export tab. Group your decks by color identity, or put your most-played decks in the slots that are easiest to see.</p>
           </wa-details>
 
           <wa-details>
-            <span slot="summary" class="wa-caption-m">Is this tournament legal?</span>
+            <span slot="summary" class="wa-body-m" style="font-weight: 500;">Is this tournament legal?</span>
             <p>Yes. <a href="https://blogs.magicjudges.org/rules/mtr3-12/" target="_blank" rel="noopener">MTR 3.12</a> defines a card as marked if the marking lets a player identify it without seeing its face. Sleeve edge marks add no noticeable thickness and do not change the card's profile in the deck. If you must look from a specific angle to see the mark, the card is not marked under the rule.</p>
           </wa-details>
         </section>

--- a/js/features/deck-form.js
+++ b/js/features/deck-form.js
@@ -43,6 +43,8 @@ export function initColorSwatches() {
     swatch.className = "color-swatch";
     swatch.style.backgroundColor = color;
     swatch.title = getColorName(color);
+    swatch.setAttribute("aria-label", getColorName(color));
+    swatch.setAttribute("aria-pressed", "false");
     swatch.dataset.color = color;
 
     swatch.addEventListener("click", () => {
@@ -68,6 +70,7 @@ export function updateColorSwatchSelection() {
     .forEach((swatch) => {
       const isSelected = swatch.dataset.color.toUpperCase() === selectedColor;
       swatch.classList.toggle("selected", isSelected);
+      swatch.setAttribute("aria-pressed", String(isSelected));
     });
 }
 

--- a/js/features/deck-list.js
+++ b/js/features/deck-list.js
@@ -21,8 +21,9 @@ import {
   createPrism,
   isDotVariant,
   updateSplitGroupInPrism,
+  applyCommanderFallback,
 } from "../modules/processor.js";
-import { savePrism, setCurrentPrism, recordUnmarkedCards } from "../modules/storage.js";
+import { savePrism, setCurrentPrism, recordUnmarkedCards, getPrism } from "../modules/storage.js";
 import { trackEvent } from "../modules/supabase-client.js";
 import { canonicalizeCards } from "../modules/scryfall.js";
 import { hideEditImportMessages } from "./deck-import.js";
@@ -274,6 +275,28 @@ export function handleClearRemoved(cardName, deckId) {
   showSuccess(`Cleared "${cardName}" from removed list.`);
 }
 
+/**
+ * Open the confirm dialog for clearing every stale mark. Each row is paint
+ * still on a sleeve, and the list cannot be rebuilt once dropped, so the bulk
+ * path is gated the same way deck deletion is.
+ */
+export function handleClearAllRemovedClick() {
+  if (!state.currentPrism || !state.currentPrism.removedCards?.length) return;
+
+  const count = state.currentPrism.removedCards.length;
+  const { clearAllRemovedDialog, clearAllRemovedCount } = state.elements;
+  if (!clearAllRemovedDialog) {
+    // No dialog on this page — fall back to acting directly rather than
+    // leaving the button dead.
+    handleClearAllRemoved();
+    return;
+  }
+  if (clearAllRemovedCount) {
+    clearAllRemovedCount.textContent = `${count} ${count === 1 ? 'mark' : 'marks'}`;
+  }
+  clearAllRemovedDialog.setAttribute('open', '');
+}
+
 export function handleClearAllRemoved() {
   if (!state.currentPrism || !state.currentPrism.removedCards?.length) return;
 
@@ -282,9 +305,10 @@ export function handleClearAllRemoved() {
   state.currentPrism.updatedAt = new Date().toISOString();
   savePrism(state.currentPrism);
 
+  state.elements.clearAllRemovedDialog?.removeAttribute('open');
   updateRemovedFilterBadge();
   renderResults();
-  showSuccess(`Cleared all ${count} card(s) from removed list.`);
+  showSuccess(`Cleared ${count} stale ${count === 1 ? 'mark' : 'marks'}.`);
 }
 
 // ============================================================================
@@ -652,6 +676,38 @@ export function handleNewPrism() {
   renderAll();
 }
 
+/**
+ * Switch the active PRISM. The current one is saved first so nothing in
+ * progress is lost, then the target is loaded from storage.
+ * @param {string} prismId
+ */
+export function handleSwitchPrism(prismId) {
+  if (!prismId || prismId === state.currentPrism?.id) return;
+
+  const target = getPrism(prismId);
+  if (!target) {
+    showError('That PRISM could not be loaded.');
+    return;
+  }
+
+  savePrism(state.currentPrism);
+  setCurrentPrism(prismId);
+  state.currentPrism = target;
+
+  // Legacy scalar-commander decks are normalized once at page load; a PRISM
+  // switched to at runtime never passed through that, so do it here too.
+  let normalized = false;
+  for (const deck of state.currentPrism.decks || []) {
+    if (applyCommanderFallback(deck, deck.commander)) normalized = true;
+  }
+  if (normalized) savePrism(state.currentPrism);
+
+  resetDeckForm();
+  initColorSwatches();
+  renderAll();
+  showSuccess(`Switched to "${target.name}".`);
+}
+
 export function handleStripeReorder(deckId, direction) {
   // Dot variants own no slot (stripePosition null) — exclude them so the
   // neighbour-swap logic only ever targets decks with a real position.
@@ -819,7 +875,7 @@ export function renderDeckCard(deck, showActions = true, processedCards = null) 
           <div class="deck-color-indicator" style="background-color: ${deck.color};" title="${getColorName(deck.color)}"></div>
           <div class="wa-stack wa-gap-2xs">
             <div class="wa-cluster wa-gap-s wa-align-items-center">
-              <span class="${isInGroup ? "wa-heading-s" : "wa-heading-m"}">${escapeHtml(deck.name)}</span>
+              <${isInGroup ? "h4" : "h3"} class="${isInGroup ? "wa-heading-s" : "wa-heading-m"}" style="margin: 0;">${escapeHtml(deck.name)}</${isInGroup ? "h4" : "h3"}>
               ${slotTagHtml}
               <wa-tag size="small" variant="neutral">Bracket ${deck.bracket}</wa-tag>
             </div>
@@ -936,7 +992,7 @@ export function renderDecksList() {
               <div class="deck-color-indicator" style="background-color: ${group.sideAColor};" title="${getColorName(group.sideAColor)}"></div>
               <div class="wa-stack wa-gap-2xs">
                 <div class="wa-cluster wa-gap-s wa-align-items-center">
-                  <span class="wa-heading-m">${escapeHtml(group.name)}</span>
+                  <h3 class="wa-heading-m" style="margin: 0;">${escapeHtml(group.name)}</h3>
                   <wa-tag size="small" variant="neutral">${formatSlotLabel(group.sideAPosition, "a")}</wa-tag>
                   <wa-tag size="small" variant="brand" appearance="outlined">
                     <wa-icon name="code-branch" style="font-size: 0.8em;"></wa-icon>

--- a/js/features/events.js
+++ b/js/features/events.js
@@ -18,7 +18,7 @@ import {
   editCommanderRefs,
 } from './deck-form.js';
 import { handleFileUpload, handleJsonImport, handleMoxfieldImport, handleEditFileUpload, handleEditUrlImport } from './deck-import.js';
-import { handleDeleteConfirm, handleEditConfirm, handleNewPrism, handleSplitConfirm, handleEditGroupConfirm } from './deck-list.js';
+import { handleDeleteConfirm, handleEditConfirm, handleNewPrism, handleSplitConfirm, handleEditGroupConfirm, handleClearAllRemoved } from './deck-list.js';
 import { renderResults } from './results.js';
 import { openScryMode } from './scry-mode.js';
 import { renderOverlapMatrix } from './analysis.js';
@@ -201,6 +201,11 @@ export function setupEventListeners() {
   // New PRISM dialog
   if (state.elements.btnNewPrism) {
     state.elements.btnNewPrism.addEventListener('click', () => {
+      // Name the PRISM being left behind so the recovery route is concrete.
+      if (state.elements.newPrismCurrentName) {
+        const name = state.currentPrism?.name?.trim();
+        state.elements.newPrismCurrentName.textContent = name || 'Your current PRISM';
+      }
       state.elements.newPrismDialog.setAttribute('open', '');
     });
   }
@@ -211,6 +216,16 @@ export function setupEventListeners() {
   }
   if (state.elements.btnConfirmNew) {
     state.elements.btnConfirmNew.addEventListener('click', handleNewPrism);
+  }
+
+  // Clear-all stale marks confirmation
+  if (state.elements.btnCancelClearAllRemoved) {
+    state.elements.btnCancelClearAllRemoved.addEventListener('click', () => {
+      state.elements.clearAllRemovedDialog.removeAttribute('open');
+    });
+  }
+  if (state.elements.btnConfirmClearAllRemoved) {
+    state.elements.btnConfirmClearAllRemoved.addEventListener('click', handleClearAllRemoved);
   }
 
   // Edit dialog

--- a/js/features/init.js
+++ b/js/features/init.js
@@ -5,11 +5,11 @@
 import { state } from '../core/state.js';
 import { getLogicalDeckCount, debugLog } from '../core/utils.js';
 import { createPrism, getUsedPositions, MAX_STRIPE_SLOTS, applyCommanderFallback } from '../modules/processor.js';
-import { getCurrentPrism, savePrism, setCurrentPrism, getPreferences, onSyncStatusChange, forceSyncCurrentPrism } from '../modules/storage.js';
+import { getCurrentPrism, savePrism, setCurrentPrism, getPreferences, onSyncStatusChange, forceSyncCurrentPrism, getAllPrisms } from '../modules/storage.js';
 import { initAuth, setupAuthListeners, getCurrentUser } from '../modules/auth.js';
 import { logToSupabase } from '../modules/supabase-client.js';
 import { initColorSwatches } from './deck-form.js';
-import { renderDecksList } from './deck-list.js';
+import { renderDecksList, handleSwitchPrism } from './deck-list.js';
 import { setupStripeReorderDialog } from './stripe-reorder-dialog.js';
 import { setupScryMode } from './scry-mode.js';
 import { renderResults, updateRemovedFilterBadge } from './results.js';
@@ -98,6 +98,17 @@ function getElements() {
     btnNewPrism: document.getElementById('btn-new-prism'),
     btnCancelNew: document.getElementById('btn-cancel-new'),
     btnConfirmNew: document.getElementById('btn-confirm-new'),
+    newPrismCurrentName: document.getElementById('new-prism-current-name'),
+
+    // PRISM switcher (injected into the ... overflow menu)
+    prismOverflow: document.getElementById('prism-overflow'),
+    prismSwitchDivider: document.getElementById('prism-switch-divider'),
+
+    // Clear-all stale marks confirmation
+    clearAllRemovedDialog: document.getElementById('clear-all-removed-dialog'),
+    clearAllRemovedCount: document.getElementById('clear-all-removed-count'),
+    btnCancelClearAllRemoved: document.getElementById('btn-cancel-clear-all-removed'),
+    btnConfirmClearAllRemoved: document.getElementById('btn-confirm-clear-all-removed'),
 
     // Edit dialog
     editDialog: document.getElementById('edit-dialog'),
@@ -237,10 +248,67 @@ export function renderAll() {
   updateRemovedFilterBadge();
 }
 
+/**
+ * Populate the ... overflow menu with one entry per stored PRISM.
+ *
+ * This is the only route back to a previous PRISM for a logged-out user —
+ * profile.html lists PRISMs inside its logged-in block only — so without it
+ * creating a new PRISM strands every deck and every mark record.
+ */
+function renderPrismSwitcher() {
+  const { prismOverflow, prismSwitchDivider } = state.elements;
+  if (!prismOverflow || !prismSwitchDivider) return;
+
+  // Drop previously injected entries; everything from the divider down is static.
+  prismOverflow
+    .querySelectorAll('[data-prism-switch]')
+    .forEach((el) => el.remove());
+
+  const prisms = getAllPrisms();
+  const currentId = state.currentPrism?.id;
+
+  // A lone PRISM needs no switcher; the divider would then float above
+  // "New PRISM" with nothing over it, so hide it too.
+  const showSwitcher = prisms.length > 1;
+  prismSwitchDivider.hidden = !showSwitcher;
+  if (!showSwitcher) return;
+
+  const label = document.createElement('span');
+  label.dataset.prismSwitch = '';
+  label.className = 'wa-caption-s';
+  label.style.cssText =
+    'display:block;padding:var(--wa-space-s) var(--wa-space-m) var(--wa-space-2xs);color:var(--wa-color-neutral-text-subtle);';
+  label.textContent = 'Switch PRISM';
+  prismOverflow.insertBefore(label, prismSwitchDivider);
+
+  for (const prism of prisms) {
+    const isCurrent = prism.id === currentId;
+    const item = document.createElement('wa-dropdown-item');
+    item.dataset.prismSwitch = '';
+    item.dataset.prismId = prism.id;
+    if (isCurrent) item.setAttribute('checked', '');
+
+    const count = getLogicalDeckCount(prism);
+    const icon = document.createElement('wa-icon');
+    icon.setAttribute('slot', 'icon');
+    icon.setAttribute('name', isCurrent ? 'circle-check' : 'gem');
+    item.appendChild(icon);
+    item.appendChild(
+      document.createTextNode(
+        `${prism.name || 'Untitled PRISM'} (${count} ${count === 1 ? 'deck' : 'decks'})`,
+      ),
+    );
+
+    item.addEventListener('click', () => handleSwitchPrism(prism.id));
+    prismOverflow.insertBefore(item, prismSwitchDivider);
+  }
+}
+
 function renderPrismHeader() {
   if (state.elements.prismName) {
     state.elements.prismName.value = state.currentPrism.name;
   }
+  renderPrismSwitcher();
   if (state.elements.deckCountTag) {
     const logicalCount = getLogicalDeckCount(state.currentPrism);
     state.elements.deckCountTag.textContent = `${logicalCount} ${logicalCount === 1 ? 'deck' : 'decks'}`;

--- a/js/features/results.js
+++ b/js/features/results.js
@@ -460,7 +460,6 @@ export function renderResults() {
       `;
     }
 
-    const rowClass = card.logicalDeckCount > 1 ? 'shared-row' : '';
     const nameClass = card.isBasicLand ? 'basic-land' : '';
     const basicTag = card.isBasicLand && !card.isPassRow ? ' <span class="basic-tag">(Basic)</span>' : '';
     const batches = card.batches || [];
@@ -473,7 +472,7 @@ export function renderResults() {
       const isMarked = markedSetForRows.has(cardKey);
       const stripes = stripesCell(card.stripes);
       return `
-        <tr class="${rowClass} ${isMarked ? 'marked-row' : ''}" data-card-key="${escapeHtml(cardKey)}">
+        <tr class="${isMarked ? 'marked-row' : ''}" data-card-key="${escapeHtml(cardKey)}">
           <td style="text-align: center;">
             <label class="mark-checkbox-hit"><input type="checkbox" class="mark-checkbox" aria-label="Mark ${escapeHtml(card.name)} done" ${isMarked ? "checked" : ""}></label>
           </td>
@@ -491,7 +490,7 @@ export function renderResults() {
     const allDone = doneCount === batches.length;
     const isExpanded = expandedCards.has(card.name);
     const parentRow = `
-      <tr class="${rowClass} ${allDone ? 'marked-row' : ''} batch-parent">
+      <tr class="${allDone ? 'marked-row' : ''} batch-parent">
         <td style="text-align: center;">
           <input type="checkbox" class="batch-parent-check" disabled
             aria-label="${escapeHtml(card.name)} roll-up: ${doneCount} of ${batches.length} batches done"

--- a/js/features/results.js
+++ b/js/features/results.js
@@ -384,7 +384,7 @@ export function renderResults() {
   // NOT live inside the stripes <td>: on a phone the table scrolls horizontally
   // and that column sits past the right edge, so text placed there would be
   // unreadable without scrolling and would inflate the row height besides.
-  const stripesCell = (stripes) => {
+  const stripesCell = (stripes, band = '') => {
     const marks = markDescriptors(stripes);
     const strip = `<div class="stripe-indicators">${stripeHtml(stripes)}</div>`;
     if (marks.length === 0) return { cell: `<td>${strip}</td>`, detailRow: '' };
@@ -406,7 +406,7 @@ export function renderResults() {
       cell: `<td>
         <button type="button" class="stripe-cell-toggle" aria-expanded="false" aria-controls="${id}" aria-label="${escapeHtml(summary)}">${strip}</button>
       </td>`,
-      detailRow: `<tr class="stripe-detail-row" id="${id}" hidden>
+      detailRow: `<tr class="stripe-detail-row${band}" id="${id}" hidden>
         <td colspan="${detailColspan}"><ul class="stripe-detail">${items}</ul></td>
       </tr>`,
     };
@@ -417,7 +417,13 @@ export function renderResults() {
   // common singleton path gains no text at all.
   const copiesCell = (q) => `<td class="copies-cell">${q > 1 ? q : ''}</td>`;
 
-  state.elements.resultsTbody.innerHTML = displayCards.map(card => {
+  // Zebra banding is applied per card, not per <tr>: a multi-batch card's
+  // sub-rows and a row's stripe-detail row all share their card's band, so an
+  // expanded card still reads as one block. It cannot be done with
+  // :nth-child() — the detail rows interleave, and cards with no marks emit
+  // none, so row parity is not even uniform.
+  state.elements.resultsTbody.innerHTML = displayCards.map((card, cardIndex) => {
+    const band = cardIndex % 2 === 1 ? ' alt-row' : '';
     // Handle removed cards differently
     if (card.isRemoved) {
       const removedKey = `${card.name}|${card.removedDeckId}`;
@@ -430,7 +436,7 @@ export function renderResults() {
         ? ` — clear ${clearCopies} ${clearCopies === 1 ? 'copy' : 'copies'}`
         : '';
       return `
-        <tr class="removed-row" data-removed-key="${escapeHtml(removedKey)}">
+        <tr class="removed-row${band}" data-removed-key="${escapeHtml(removedKey)}">
           <td>${escapeHtml(card.name)}</td>
           <td>
             <div class="wa-cluster wa-gap-xs wa-align-items-center">
@@ -470,9 +476,9 @@ export function renderResults() {
       // `<name>|<deckName>` key.
       const cardKey = card.isPassRow ? `${card.displayName}|${card.deckName}` : card.name;
       const isMarked = markedSetForRows.has(cardKey);
-      const stripes = stripesCell(card.stripes);
+      const stripes = stripesCell(card.stripes, band);
       return `
-        <tr class="${isMarked ? 'marked-row' : ''}" data-card-key="${escapeHtml(cardKey)}">
+        <tr class="${isMarked ? 'marked-row' : ''}${band}" data-card-key="${escapeHtml(cardKey)}">
           <td style="text-align: center;">
             <label class="mark-checkbox-hit"><input type="checkbox" class="mark-checkbox" aria-label="Mark ${escapeHtml(card.name)} done" ${isMarked ? "checked" : ""}></label>
           </td>
@@ -490,7 +496,7 @@ export function renderResults() {
     const allDone = doneCount === batches.length;
     const isExpanded = expandedCards.has(card.name);
     const parentRow = `
-      <tr class="${allDone ? 'marked-row' : ''} batch-parent">
+      <tr class="${allDone ? 'marked-row' : ''} batch-parent${band}">
         <td style="text-align: center;">
           <input type="checkbox" class="batch-parent-check" disabled
             aria-label="${escapeHtml(card.name)} roll-up: ${doneCount} of ${batches.length} batches done"
@@ -511,9 +517,9 @@ export function renderResults() {
       const marked = markedSetForRows.has(b.key);
       // Two batches can share a copy count, so the class disambiguates the label.
       const batchClass = b.isDedicated ? 'dedicated' : (b.isPool ? 'pool' : 'core');
-      const stripes = stripesCell(b.stripes);
+      const stripes = stripesCell(b.stripes, band);
       return `
-        <tr class="batch-subrow ${marked ? 'marked-row' : ''}" data-card-key="${escapeHtml(b.key)}">
+        <tr class="batch-subrow ${marked ? 'marked-row' : ''}${band}" data-card-key="${escapeHtml(b.key)}">
           <td style="text-align: center;">
             <label class="mark-checkbox-hit"><input type="checkbox" class="mark-checkbox" aria-label="Mark ${b.copyCount} ${batchClass} ${escapeHtml(card.name)} copies done" ${marked ? "checked" : ""}></label>
           </td>

--- a/js/features/results.js
+++ b/js/features/results.js
@@ -7,7 +7,7 @@ import { escapeHtml, stripeNumberLabel, countVisibleMarks, STRIPE_SPARSE_MAX, is
 import { getStripeNumbersMode } from '../modules/storage.js';
 import { processCards, formatSlotLabel } from '../modules/processor.js';
 import { prefetchCards } from '../modules/scryfall.js';
-import { handleMarkToggle, handleClearRemoved, handleClearAllRemoved } from './deck-list.js';
+import { handleMarkToggle, handleClearRemoved, handleClearAllRemovedClick } from './deck-list.js';
 import { renderOverlapMatrix } from './analysis.js';
 
 // ============================================================================
@@ -491,10 +491,11 @@ export function renderResults() {
     });
   });
 
-  // Add event listener for "Clear All" removed button
+  // Add event listener for "Clear All" removed button (opens a confirm dialog —
+  // the rows it drops are paint still on sleeves and cannot be rebuilt)
   const clearAllBtn = document.getElementById('clear-all-removed-btn');
   if (clearAllBtn) {
-    clearAllBtn.addEventListener('click', handleClearAllRemoved);
+    clearAllBtn.addEventListener('click', handleClearAllRemovedClick);
   }
 
   const colspan = 4;
@@ -621,7 +622,7 @@ function renderResultsHeader() {
         </th>
         <th>Remove Mark From</th>
         <th style="width: 80px; text-align: center;">
-          <button id="clear-all-removed-btn" class="btn-clear-all-removed" title="Clear all stale marks">Clear All</button>
+          <wa-button id="clear-all-removed-btn" appearance="outlined" variant="danger" size="small">Clear All</wa-button>
         </th>
       </tr>
     `;

--- a/js/features/results.js
+++ b/js/features/results.js
@@ -354,6 +354,64 @@ export function renderResults() {
     return html;
   };
 
+  // The stripes strip answers "which pen, which slot" — but deck identity lived
+  // only in a `title`, which touch devices never fire and screen readers do not
+  // reliably announce. The strip is therefore wrapped in one focusable control
+  // (one tab stop per row, not one per mark) carrying the full list as its
+  // accessible name, and activating it reveals the same list as text.
+  const markDescriptors = (stripes) =>
+    (stripes || [])
+      .filter((s) => s.markType !== 'membership')
+      .slice()
+      .sort((a, b) => a.position - b.position)
+      .map((s) => ({
+        position: s.position,
+        deckName: s.deckName,
+        color: s.color,
+        isDot: s.markType === 'dot',
+      }));
+
+  const describeMark = (m) =>
+    `${m.isDot ? 'Dot, ' : ''}${formatSlotLabel(m.position)}, ${m.deckName}`;
+
+  let detailRowSeq = 0;
+  // Done / Card Name / Copies / Stripes. The Copies column is unconditional
+  // (#149) and the stale-marks view uses its own row markup, so this is stable.
+  const detailColspan = 4;
+
+  // Returns the <td> plus, when there is anything to decode, a full-width
+  // sibling <tr> holding the legend for that row. The detail deliberately does
+  // NOT live inside the stripes <td>: on a phone the table scrolls horizontally
+  // and that column sits past the right edge, so text placed there would be
+  // unreadable without scrolling and would inflate the row height besides.
+  const stripesCell = (stripes) => {
+    const marks = markDescriptors(stripes);
+    const strip = `<div class="stripe-indicators">${stripeHtml(stripes)}</div>`;
+    if (marks.length === 0) return { cell: `<td>${strip}</td>`, detailRow: '' };
+
+    const id = `stripe-detail-${++detailRowSeq}`;
+    const summary = `${marks.length} ${marks.length === 1 ? 'mark' : 'marks'}: ${marks
+      .map(describeMark)
+      .join('; ')}`;
+    const items = marks
+      .map(
+        (m) => `<li>
+          <span class="stripe-detail-swatch${m.isDot ? ' stripe-detail-swatch-dot' : ''}" style="background-color: ${m.color};"></span>
+          <span>${escapeHtml(describeMark(m))}</span>
+        </li>`,
+      )
+      .join('');
+
+    return {
+      cell: `<td>
+        <button type="button" class="stripe-cell-toggle" aria-expanded="false" aria-controls="${id}" aria-label="${escapeHtml(summary)}">${strip}</button>
+      </td>`,
+      detailRow: `<tr class="stripe-detail-row" id="${id}" hidden>
+        <td colspan="${detailColspan}"><ul class="stripe-detail">${items}</ul></td>
+      </tr>`,
+    };
+  };
+
   const markedSetForRows = new Set(state.currentPrism.markedCards || []);
   // Copies cell renders only when the quantity exceeds one (#149) — the
   // common singleton path gains no text at all.
@@ -413,14 +471,16 @@ export function renderResults() {
       // `<name>|<deckName>` key.
       const cardKey = card.isPassRow ? `${card.displayName}|${card.deckName}` : card.name;
       const isMarked = markedSetForRows.has(cardKey);
+      const stripes = stripesCell(card.stripes);
       return `
         <tr class="${rowClass} ${isMarked ? 'marked-row' : ''}" data-card-key="${escapeHtml(cardKey)}">
           <td style="text-align: center;">
-            <input type="checkbox" class="mark-checkbox" aria-label="Mark ${escapeHtml(card.name)} done" ${isMarked ? 'checked' : ''}>
+            <label class="mark-checkbox-hit"><input type="checkbox" class="mark-checkbox" aria-label="Mark ${escapeHtml(card.name)} done" ${isMarked ? "checked" : ""}></label>
           </td>
           <td class="${nameClass} card-name-cell" data-card-name="${escapeHtml(card.isPassRow ? card.displayName : card.name)}">${escapeHtml(card.name)}${basicTag}</td>${copiesCell(card.totalQuantity)}
-          <td><div class="stripe-indicators">${stripeHtml(card.stripes)}</div></td>
+          ${stripes.cell}
         </tr>
+        ${stripes.detailRow}
       `;
     }
 
@@ -452,14 +512,16 @@ export function renderResults() {
       const marked = markedSetForRows.has(b.key);
       // Two batches can share a copy count, so the class disambiguates the label.
       const batchClass = b.isDedicated ? 'dedicated' : (b.isPool ? 'pool' : 'core');
+      const stripes = stripesCell(b.stripes);
       return `
         <tr class="batch-subrow ${marked ? 'marked-row' : ''}" data-card-key="${escapeHtml(b.key)}">
           <td style="text-align: center;">
-            <input type="checkbox" class="mark-checkbox" aria-label="Mark ${b.copyCount} ${batchClass} ${escapeHtml(card.name)} copies done" ${marked ? 'checked' : ''}>
+            <label class="mark-checkbox-hit"><input type="checkbox" class="mark-checkbox" aria-label="Mark ${b.copyCount} ${batchClass} ${escapeHtml(card.name)} copies done" ${marked ? "checked" : ""}></label>
           </td>
           <td class="batch-subrow-label" data-card-name="${escapeHtml(card.name)}">${b.copyCount} ${b.copyCount === 1 ? 'copy' : 'copies'} — ${batchClass}</td>${copiesCell(b.copyCount)}
-          <td><div class="stripe-indicators">${stripeHtml(b.stripes)}</div></td>
+          ${stripes.cell}
         </tr>
+        ${stripes.detailRow}
       `;
     }).join('');
   }).join('');
@@ -475,6 +537,18 @@ export function renderResults() {
   });
   state.elements.resultsTbody.querySelectorAll('.batch-parent-check[data-indeterminate="1"]').forEach(cb => {
     cb.indeterminate = true;
+  });
+
+  // Reveal the deck name and slot behind each mark. Kept local to the row so a
+  // marking session never loses its place in the table to a popover.
+  state.elements.resultsTbody.querySelectorAll('.stripe-cell-toggle').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const detail = document.getElementById(btn.getAttribute('aria-controls'));
+      if (!detail) return;
+      const open = btn.getAttribute('aria-expanded') === 'true';
+      btn.setAttribute('aria-expanded', open ? 'false' : 'true');
+      detail.hidden = open;
+    });
   });
 
   // Add event listeners for checkboxes

--- a/js/features/stripe-reorder-dialog.js
+++ b/js/features/stripe-reorder-dialog.js
@@ -104,8 +104,27 @@ function renderSlot(position, activeDeck, slotMap) {
   const slot = document.createElement('div');
   slot.dataset.position = String(position);
   slot.title = info
-    ? `${info.name} — ${formatSlotLabel(position)}`
-    : `Empty — ${formatSlotLabel(position)}`;
+    ? `${info.name}, ${formatSlotLabel(position)}`
+    : `Empty, ${formatSlotLabel(position)}`;
+
+  // A title attribute is invisible to touch and unreliable for screen readers,
+  // and 48 bare divs are unreachable by keyboard. The picker is a single-choice
+  // widget, so model it as a radiogroup with a roving tabindex (see
+  // wireSlotKeyboard) rather than 48 tab stops.
+  const slotLabel = formatSlotLabel(position);
+  slot.setAttribute('role', 'radio');
+  slot.setAttribute('aria-checked', isActive ? 'true' : 'false');
+  slot.tabIndex = -1;
+  if (isDisabled) {
+    slot.setAttribute('aria-disabled', 'true');
+    slot.setAttribute('aria-label', `${slotLabel}, unavailable`);
+  } else if (isActive) {
+    slot.setAttribute('aria-label', `${slotLabel}, current position of ${activeDeck.name}`);
+  } else if (info) {
+    slot.setAttribute('aria-label', `${slotLabel}, taken by ${info.name}, activate to swap`);
+  } else {
+    slot.setAttribute('aria-label', `${slotLabel}, empty, activate to move here`);
+  }
 
   const classes = ['stripe-reorder-slot'];
   if (isDisabled) {
@@ -131,6 +150,101 @@ function renderSlot(position, activeDeck, slotMap) {
   }
 
   return slot;
+}
+
+// ============================================================================
+// Keyboard navigation across the two sleeve edges
+// ============================================================================
+
+/**
+ * Give the 48 slots one tab stop and arrow-key movement.
+ *
+ * Up/Down walk the current edge, Left/Right cross to the other edge at the same
+ * depth, Home/End jump to the ends of the edge, Enter/Space activate. Disabled
+ * slots are skipped rather than focused, so a keyboard user never lands on a
+ * dead target.
+ */
+function wireSlotKeyboard(sleeve, activeDeck, slotMap) {
+  const edges = [...sleeve.querySelectorAll('.stripe-reorder-edge')];
+  if (edges.length === 0) return;
+
+  const slotsOf = (edge) => [...edge.querySelectorAll('.stripe-reorder-slot')];
+  const isFocusable = (el) => el.getAttribute('aria-disabled') !== 'true';
+  const allSlots = edges.flatMap(slotsOf);
+
+  // Roving tabindex: the checked slot owns the tab stop, else the first
+  // focusable one, so Tab reaches the picker in a single press.
+  const initial =
+    allSlots.find((s) => s.getAttribute('aria-checked') === 'true') ||
+    allSlots.find(isFocusable);
+  if (initial) initial.tabIndex = 0;
+
+  const focus = (el) => {
+    if (!el) return;
+    for (const s of allSlots) s.tabIndex = -1;
+    el.tabIndex = 0;
+    el.focus();
+  };
+
+  const step = (edgeSlots, from, dir) => {
+    for (let i = from + dir; i >= 0 && i < edgeSlots.length; i += dir) {
+      if (isFocusable(edgeSlots[i])) return edgeSlots[i];
+    }
+    return null;
+  };
+
+  sleeve.addEventListener('keydown', (e) => {
+    const slot = e.target.closest?.('.stripe-reorder-slot');
+    if (!slot || !sleeve.contains(slot)) return;
+
+    const edge = slot.closest('.stripe-reorder-edge');
+    const edgeIndex = edges.indexOf(edge);
+    const edgeSlots = slotsOf(edge);
+    const index = edgeSlots.indexOf(slot);
+    let target = null;
+
+    switch (e.key) {
+      case 'ArrowDown':
+      case 'ArrowUp':
+        target = step(edgeSlots, index, e.key === 'ArrowDown' ? 1 : -1);
+        break;
+      case 'ArrowRight':
+      case 'ArrowLeft': {
+        const otherEdge = edges[edgeIndex === 0 ? 1 : 0];
+        if (!otherEdge) break;
+        const others = slotsOf(otherEdge);
+        // Cross at the same depth, then fan outwards for the nearest live slot.
+        const at = others[Math.min(index, others.length - 1)];
+        if (at && isFocusable(at)) { target = at; break; }
+        const start = Math.min(index, others.length - 1);
+        for (let d = 1; d < others.length; d++) {
+          const down = others[start + d];
+          const up = others[start - d];
+          if (down && isFocusable(down)) { target = down; break; }
+          if (up && isFocusable(up)) { target = up; break; }
+        }
+        break;
+      }
+      case 'Home':
+        target = edgeSlots.find(isFocusable) || null;
+        break;
+      case 'End':
+        target = [...edgeSlots].reverse().find(isFocusable) || null;
+        break;
+      case 'Enter':
+      case ' ':
+        e.preventDefault();
+        if (isFocusable(slot)) slot.click();
+        return;
+      default:
+        return;
+    }
+
+    if (target) {
+      e.preventDefault();
+      focus(target);
+    }
+  });
 }
 
 // ============================================================================
@@ -240,6 +354,8 @@ function renderSleeveVisualization(activeDeck, slotMap) {
   // Sleeve card
   const sleeve = document.createElement('div');
   sleeve.className = 'stripe-reorder-sleeve';
+  sleeve.setAttribute('role', 'radiogroup');
+  sleeve.setAttribute('aria-label', `Choose a slot for ${activeDeck.name}`);
 
   // Left edge
   const leftEdge = document.createElement('div');
@@ -254,7 +370,7 @@ function renderSleeveVisualization(activeDeck, slotMap) {
   cardBody.innerHTML = `
     <div class="stripe-reorder-card-hint">
       <wa-icon name="hand-pointer" style="font-size: 1.5rem; display: block; margin-bottom: var(--wa-space-2xs);"></wa-icon>
-      <span>Click a slot</span>
+      <span>Choose a slot</span>
     </div>
   `;
 
@@ -268,6 +384,7 @@ function renderSleeveVisualization(activeDeck, slotMap) {
   sleeve.appendChild(leftEdge);
   sleeve.appendChild(cardBody);
   sleeve.appendChild(rightEdge);
+  wireSlotKeyboard(sleeve, activeDeck, slotMap);
   wrapper.appendChild(sleeve);
 
   // Edge labels

--- a/js/features/stripe-reorder-dialog.js
+++ b/js/features/stripe-reorder-dialog.js
@@ -119,7 +119,7 @@ function renderSlot(position, activeDeck, slotMap) {
     slot.setAttribute('aria-disabled', 'true');
     slot.setAttribute('aria-label', `${slotLabel}, unavailable`);
   } else if (isActive) {
-    slot.setAttribute('aria-label', `${slotLabel}, current position of ${activeDeck.name}`);
+    slot.setAttribute('aria-label', `${slotLabel}, current slot of ${activeDeck.name}`);
   } else if (info) {
     slot.setAttribute('aria-label', `${slotLabel}, taken by ${info.name}, activate to swap`);
   } else {

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -538,7 +538,7 @@ function renderArtist(root, id) {
           <h1 class="wa-heading-xl">${escapeHtml(artist.name)}</h1>
           ${artist.isPartner ? '<wa-tag variant="brand"><wa-icon slot="start" name="handshake-angle"></wa-icon>PRISM Partner</wa-tag>' : ''}
         </div>
-        <p style="color: var(--wa-color-neutral-text-normal); margin: var(--wa-space-xs) 0 0; max-width: 64ch;">${escapeHtml(artist.bio)}</p>
+        <p style="color: var(--wa-color-neutral-text); margin: var(--wa-space-xs) 0 0; max-width: 64ch;">${escapeHtml(artist.bio)}</p>
         ${artist.links.length ? `<div class="wa-cluster wa-gap-m" style="margin-top: var(--wa-space-s); font-size: var(--wa-font-size-s);">${artist.links.map(l => `<a href="${escapeHtml(safeUrl(l.href))}" target="_blank" rel="noopener"><wa-icon name="${escapeHtml(l.icon || 'globe')}"${l.family ? ` family="${escapeHtml(l.family)}"` : ''}></wa-icon> ${escapeHtml(l.label)}</a>`).join('')}</div>` : ''}
         ${artist.isPartner ? `
         <div class="gallery-stats">

--- a/js/layout.js
+++ b/js/layout.js
@@ -167,6 +167,32 @@ function injectHeadResources() {
     --wa-color-danger-80: #ffb0aa;
     --wa-color-danger-90: #ffd7d3;
     --wa-color-danger-95: #ffeae7;
+
+    /* Semantic tokens (DESIGN.md §2.5). WA 3.11 renamed/dropped its own
+       versions of these (neutral-text -> text-normal, etc.), so PRISM now
+       defines them itself rather than relying on the CDN theme to. */
+    --wa-color-surface-1: var(--wa-color-surface-default);
+    --wa-color-surface-2: var(--wa-color-neutral-95);
+    --wa-color-surface-3: var(--wa-color-neutral-90);
+    --wa-color-neutral-stroke: var(--wa-color-neutral-80);
+    --wa-color-neutral-text: var(--wa-color-neutral-20);
+    --wa-color-neutral-text-subtle: var(--wa-color-neutral-40);
+    --wa-color-brand-text: var(--wa-color-brand-30);
+    --wa-color-brand-fill: var(--wa-color-brand-40);
+    --wa-color-brand-fill-subtle: var(--wa-color-brand-90);
+    --wa-color-brand-stroke: var(--wa-color-brand-50);
+    --wa-color-brand-stroke-subtle: var(--wa-color-brand-70);
+    --wa-color-success-text: var(--wa-color-success-40);
+    --wa-color-success-fill: var(--wa-color-success-50);
+    --wa-color-warning-text: var(--wa-color-warning-40);
+    --wa-color-warning-surface: var(--wa-color-warning-90);
+    --wa-color-warning-surface-subtle: var(--wa-color-warning-95);
+    --wa-color-warning-stroke-subtle: var(--wa-color-warning-70);
+    --wa-color-danger-text: var(--wa-color-danger-40);
+    --wa-color-danger-surface: var(--wa-color-danger-90);
+    --wa-color-danger-surface-subtle: var(--wa-color-danger-95);
+    --wa-color-danger-border: var(--wa-color-danger-70);
+
     --wa-font-family-body: "halyard-micro",sans-serif;
     --wa-font-family-heading: "adobe-aldine", serif;
     --wa-font-family-code: "Geist Mono", monospace;
@@ -178,6 +204,28 @@ function injectHeadResources() {
     --wa-border-radius-scale: 0.5;
     --wa-border-width-scale: 1;
     --wa-space-scale: 1.125;
+      }
+
+      /* Dark-mode remap for the ramp-derived semantic tokens above (DESIGN.md
+         §2.5: "surfaces to neutral-10/20/30, neutral-text to neutral-95,
+         brand-text to brand-80, state text to the 80 step, state surfaces to
+         the 20 step"). Tokens built from WA's own native tokens (surface-1,
+         via surface-default) don't need a remap here — WA already themes those. */
+      .wa-dark {
+    --wa-color-surface-2: var(--wa-color-neutral-20);
+    --wa-color-surface-3: var(--wa-color-neutral-30);
+    --wa-color-neutral-stroke: var(--wa-color-neutral-30);
+    --wa-color-neutral-text: var(--wa-color-neutral-95);
+    --wa-color-neutral-text-subtle: var(--wa-color-neutral-80);
+    --wa-color-brand-text: var(--wa-color-brand-80);
+    --wa-color-brand-stroke: var(--wa-color-brand-70);
+    --wa-color-success-text: var(--wa-color-success-80);
+    --wa-color-warning-text: var(--wa-color-warning-80);
+    --wa-color-warning-surface: var(--wa-color-warning-20);
+    --wa-color-warning-surface-subtle: var(--wa-color-warning-10);
+    --wa-color-danger-text: var(--wa-color-danger-80);
+    --wa-color-danger-surface: var(--wa-color-danger-20);
+    --wa-color-danger-surface-subtle: var(--wa-color-danger-10);
       }
     `;
     head.appendChild(style);

--- a/js/layout.js
+++ b/js/layout.js
@@ -52,6 +52,7 @@ export function initLayout(options = {}) {
   const { activePage = '' } = options;
 
   initGlobalErrorReporting();
+  initButtonHrefFallback();
   injectHeadResources();
   injectNav(activePage);
   injectHeader(options.headerCta);
@@ -59,6 +60,32 @@ export function initLayout(options = {}) {
   injectAuthDialog();
   injectSettingsDrawer();
   initAuthModule();
+}
+
+/**
+ * `<wa-button href>` only navigates once Web Awesome upgrades the element, so
+ * until the kit arrives every link-button on the page is dead. On a slow or
+ * blocked CDN that includes each page's primary CTA.
+ *
+ * Delegated from `document` rather than bound per element, so it also covers
+ * the header CTA and nav buttons injected below, and anything a page adds
+ * later. It bails as soon as `wa-button` is defined: `customElements.define`
+ * upgrades every matching element already in the document synchronously, so a
+ * resolved constructor means WA owns the click and nothing should navigate twice.
+ */
+function initButtonHrefFallback() {
+  if (document.__prismHrefFallback) return;
+  document.__prismHrefFallback = true;
+
+  document.addEventListener('click', (event) => {
+    if (window.customElements && customElements.get('wa-button')) return;
+    const btn = event.target.closest?.('wa-button[href]');
+    if (!btn || btn.hasAttribute('disabled')) return;
+    const href = btn.getAttribute('href');
+    if (!href) return;
+    if (btn.getAttribute('target') === '_blank') window.open(href, '_blank', 'noopener');
+    else window.location.href = href;
+  });
 }
 
 // ============================================================
@@ -364,14 +391,9 @@ function injectNav(activePage) {
   // Insert nav as first child of wa-page (before header and main)
   waPage.insertBefore(nav, waPage.firstChild);
 
-  // Fallback: <wa-button href> only navigates after WA upgrades the element.
-  // Add a click listener so navigation works even before WA loads.
-  const profileNavBtn = nav.querySelector('wa-button[href="profile.html"]');
-  if (profileNavBtn) {
-    profileNavBtn.addEventListener('click', () => {
-      window.location.href = 'profile.html';
-    });
-  }
+  // The profile button used to carry its own pre-upgrade click fallback here.
+  // initButtonHrefFallback() now covers every <wa-button href> on the page,
+  // including this one and the header CTA, so the per-element listener is gone.
 }
 
 // ============================================================

--- a/js/layout.js
+++ b/js/layout.js
@@ -640,7 +640,7 @@ function injectSettingsDrawer() {
           <p class="wa-caption-s" style="color: var(--wa-color-neutral-text-subtle); margin: 0;">Slot numbers stay the same — stripes move so Slot 1 starts at the chosen corner.</p>
           <wa-slider
             id="stripe-position-numbers-mode"
-            label="Position Numbers"
+            label="Slot Numbers"
             name="position-numbers"
             min="1"
             max="3"

--- a/js/layout.js
+++ b/js/layout.js
@@ -40,7 +40,8 @@ const NAV_LINKS = [
  * Initialize shared layout components.
  * @param {Object} options
  * @param {string} options.activePage - Which nav link to highlight ('home'|'guide'|'tools'|'build'|'profile'|'privacy'|'terms')
- * @param {Object} [options.headerCta] - Header CTA button config
+ * @param {Object|null} [options.headerCta] - Header CTA button config. Pass
+ *   null to render no CTA; omit for the default "Build PRISM" link.
  * @param {string} [options.headerCta.id] - Button id (e.g. 'btn-new-prism')
  * @param {string} [options.headerCta.label] - Button label text
  * @param {string} [options.headerCta.href] - Link destination (omit for button-only)
@@ -204,6 +205,14 @@ function injectHeadResources() {
     --wa-color-neutral-stroke: var(--wa-color-neutral-80);
     --wa-color-neutral-text: var(--wa-color-neutral-20);
     --wa-color-neutral-text-subtle: var(--wa-color-neutral-40);
+    /* WA's own token, used by every wa-caption-* utility and several components.
+       PRISM never defined it, so caption color came from the CDN theme alone and
+       a WA update could recolor it sitewide. Aliased to the PRISM subtle role so
+       both stay in step. This also fixes dark mode: WA drops text-quiet to
+       neutral-60, which DESIGN.md §2.6 forbids on dark (never darker than step
+       80). The .wa-dark remap below resolves through this alias automatically,
+       and PRISM's block is unlayered so it outranks @layer wa-theme either way. */
+    --wa-color-text-quiet: var(--wa-color-neutral-text-subtle);
     --wa-color-brand-text: var(--wa-color-brand-30);
     --wa-color-brand-fill: var(--wa-color-brand-40);
     --wa-color-brand-fill-subtle: var(--wa-color-brand-90);
@@ -411,6 +420,12 @@ function injectHeader(ctaConfig) {
   header.slot = 'header';
   header.className = 'wa-split';
 
+  // Pass `headerCta: null` to ship a header with no CTA at all. build.html does
+  // this: its only header action used to be "New PRISM", and a mis-click in the
+  // primary-action slot swapped the whole PRISM out. That action now lives in
+  // the ... overflow menu next to the PRISM switcher.
+  const suppressCta = ctaConfig === null;
+
   // Default CTA: link to build.html with brand variant
   const cta = ctaConfig || { href: 'build.html', label: 'Build PRISM', icon: 'wand-magic-sparkles' };
   const ctaId = cta.id ? ` id="${cta.id}"` : '';
@@ -438,10 +453,10 @@ function injectHeader(ctaConfig) {
             <wa-icon name="gear"></wa-icon>
           </wa-button>
           <wa-tooltip for="btn-settings">Settings</wa-tooltip>
-          <wa-button${ctaId}${ctaHref} variant="${ctaVariant}"${ctaAppearanceAttr} size="small">
+          ${suppressCta ? '' : `<wa-button${ctaId}${ctaHref} variant="${ctaVariant}"${ctaAppearanceAttr} size="small">
             <wa-icon slot="start" name="${ctaIcon}"></wa-icon>
             ${ctaLabel}
-          </wa-button>
+          </wa-button>`}
         </div>`;
 
   // Insert after nav (if exists) or as first child

--- a/js/layout.js
+++ b/js/layout.js
@@ -353,7 +353,7 @@ function injectHeader(ctaConfig) {
 
   header.innerHTML = `
         <div class="wa-cluster wa-gap-m wa-align-items-center">
-          <wa-button data-toggle-nav appearance="plain" variant="neutral" size="small">
+          <wa-button data-toggle-nav appearance="plain" variant="neutral" size="small" aria-label="Menu">
             <wa-icon name="bars"></wa-icon>
           </wa-button>
           <a href="index.html" class="wa-cluster wa-gap-xs wa-align-items-center" style="text-decoration: none; color: inherit;">
@@ -407,10 +407,10 @@ function injectFooter() {
                 <span style="color: var(--wa-color-neutral-text-subtle);">Made for Commander players, by Commander players</span>
               </div>
               <div class="wa-cluster wa-gap-m" style="color: var(--wa-color-neutral-text-subtle);">
-                <a href="https://github.com/codwats/prism" target="_blank" rel="noopener" title="PRISM on GitHub">
+                <a href="https://github.com/codwats/prism" target="_blank" rel="noopener" title="PRISM on GitHub" aria-label="PRISM on GitHub">
                   <wa-icon name="github" family="brands"></wa-icon>
                 </a>
-                <a href="https://discord.gg/Jp84QUPSe" target="_blank" rel="noopener" title="Join the PRISM Discord">
+                <a href="https://discord.gg/Jp84QUPSe" target="_blank" rel="noopener" title="Join the PRISM Discord" aria-label="Join the PRISM Discord">
                   <wa-icon name="discord" family="brands"></wa-icon>
                 </a>
               </div>

--- a/js/modules/processor.js
+++ b/js/modules/processor.js
@@ -1078,7 +1078,7 @@ export function splitDeck(prism, deckId, splitCount, splitStyle = 'stripes') {
 				? null
 				: getNextVariantPosition({ ...prism, splitGroups: [...(prism.splitGroups || []), group] });
 			if (!isDots && firstPosition === null) {
-				throw new Error('No available stripe positions. All 48 slots are occupied.');
+				throw new Error('All 48 slots are occupied.');
 			}
 			const firstChild = {
 				...d,
@@ -1101,7 +1101,7 @@ export function splitDeck(prism, deckId, splitCount, splitStyle = 'stripes') {
 				if (!isDots) {
 					childPosition = getNextVariantPosition(tempPrism);
 					if (childPosition === null) {
-						throw new Error('No available stripe positions. All 48 slots are occupied.');
+						throw new Error('All 48 slots are occupied.');
 					}
 				}
 				const childColor = getNextColor(tempPrism);
@@ -1157,7 +1157,7 @@ export function addSplitToGroup(prism, groupId) {
 	if (!isDots) {
 		childPosition = getNextVariantPosition(prism);
 		if (childPosition === null) {
-			throw new Error('No available stripe positions. All 48 slots are occupied.');
+			throw new Error('All 48 slots are occupied.');
 		}
 	}
 	const childColor = getNextColor(prism);

--- a/mpc-stripes.html
+++ b/mpc-stripes.html
@@ -8,6 +8,15 @@
     <title>MPC Stripe Compositor - PRISM</title>
     <style>.wa-cloak { visibility: hidden; }</style>
     <style>wa-page:not(:defined) { visibility: hidden; }</style>
+    <!-- CDN resilience. Both rules above hide the page until Web Awesome loads, and
+         nothing removes them if it never does, so a blocked or stalled kit leaves a
+         blank white document. Reveal at 5s regardless: unstyled but readable beats
+         invisible. WA removes the class itself on a normal load, well before this. -->
+    <style>
+      @keyframes prism-uncloak { to { visibility: visible; } }
+      .wa-cloak,
+      wa-page:not(:defined) { animation: prism-uncloak 0s linear 5s forwards; }
+    </style>
     <!-- iOS Home Screen icon (layout.js injects these as a fallback) -->
     <link rel="apple-touch-icon" href="./assets/apple-touch-icon.png" />
     <link rel="manifest" href="./assets/site.webmanifest" />

--- a/mpc-stripes.html
+++ b/mpc-stripes.html
@@ -19,15 +19,16 @@
     <link rel="preconnect" href="https://fonts.bunny.net" />
     <link rel="preconnect" href="https://fonts.bunny.net" crossorigin />
     <link rel="preconnect" href="https://cdn.jsdelivr.net" />
+    <link rel="preconnect" href="https://use.typekit.net" />
+    <link rel="preconnect" href="https://use.typekit.net" crossorigin />
     <!-- Web Awesome, fonts, and app CSS as static tags so the browser preload scanner
          starts them immediately; layout.js injectHeadResources skips tags already present -->
-         <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/themes/default.css">
-               <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/native.css" />
-          <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/utilities.css" />
-          <script type="module" src="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/webawesome.loader.js"></script>
-    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Inter:ital,wght@0,100..900;1,100..900&display=swap" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/themes/default.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/native.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/utilities.css" />
+    <script type="module" src="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/webawesome.loader.js"></script>
     <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Geist+Mono:wght@100..900&display=swap" />
-    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Crimson+Pro:ital,wght@0,200..900;1,200..900&display=swap" />
+    <link rel="stylesheet" href="https://use.typekit.net/gbw6ibc.css" />
     <link rel="stylesheet" href="css/custom.css" />
   </head>
   <body>

--- a/privacy.html
+++ b/privacy.html
@@ -26,15 +26,16 @@
     <link rel="preconnect" href="https://fonts.bunny.net" />
     <link rel="preconnect" href="https://fonts.bunny.net" crossorigin />
     <link rel="preconnect" href="https://cdn.jsdelivr.net" />
+    <link rel="preconnect" href="https://use.typekit.net" />
+    <link rel="preconnect" href="https://use.typekit.net" crossorigin />
     <!-- Web Awesome, fonts, and app CSS as static tags so the browser preload scanner
          starts them immediately; layout.js injectHeadResources skips tags already present -->
-         <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/themes/default.css">
-               <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/native.css" />
-          <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/utilities.css" />
-          <script type="module" src="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/webawesome.loader.js"></script>
-    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Inter:ital,wght@0,100..900;1,100..900&display=swap" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/themes/default.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/native.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/utilities.css" />
+    <script type="module" src="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/webawesome.loader.js"></script>
     <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Geist+Mono:wght@100..900&display=swap" />
-    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Crimson+Pro:ital,wght@0,200..900;1,200..900&display=swap" />
+    <link rel="stylesheet" href="https://use.typekit.net/gbw6ibc.css" />
     <link rel="stylesheet" href="css/custom.css" />
   </head>
   <body>

--- a/privacy.html
+++ b/privacy.html
@@ -15,6 +15,15 @@
     <meta name="description" content="Privacy Policy for PRISM - MTG Deck Sleeve Marking Tool" />
     <style>.wa-cloak { visibility: hidden; }</style>
     <style>wa-page:not(:defined) { visibility: hidden; }</style>
+    <!-- CDN resilience. Both rules above hide the page until Web Awesome loads, and
+         nothing removes them if it never does, so a blocked or stalled kit leaves a
+         blank white document. Reveal at 5s regardless: unstyled but readable beats
+         invisible. WA removes the class itself on a normal load, well before this. -->
+    <style>
+      @keyframes prism-uncloak { to { visibility: visible; } }
+      .wa-cloak,
+      wa-page:not(:defined) { animation: prism-uncloak 0s linear 5s forwards; }
+    </style>
     <!-- iOS Home Screen icon (layout.js injects these as a fallback) -->
     <link rel="apple-touch-icon" href="./assets/apple-touch-icon.png" />
     <link rel="manifest" href="./assets/site.webmanifest" />

--- a/profile.html
+++ b/profile.html
@@ -26,16 +26,16 @@
     <link rel="preconnect" href="https://fonts.bunny.net" />
     <link rel="preconnect" href="https://fonts.bunny.net" crossorigin />
     <link rel="preconnect" href="https://cdn.jsdelivr.net" />
+    <link rel="preconnect" href="https://use.typekit.net" />
+    <link rel="preconnect" href="https://use.typekit.net" crossorigin />
     <!-- Web Awesome, fonts, and app CSS as static tags so the browser preload scanner
          starts them immediately; layout.js injectHeadResources skips tags already present -->
-         <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/themes/default.css">
-               <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/native.css" />
-          <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/utilities.css" />
-          <script type="module" src="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/webawesome.loader.js"></script>
-    <script type="module" src="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.10.0/webawesome.loader.js"></script>
-    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Inter:ital,wght@0,100..900;1,100..900&display=swap" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/themes/default.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/native.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/utilities.css" />
+    <script type="module" src="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/webawesome.loader.js"></script>
     <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Geist+Mono:wght@100..900&display=swap" />
-    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Crimson+Pro:ital,wght@0,200..900;1,200..900&display=swap" />
+    <link rel="stylesheet" href="https://use.typekit.net/gbw6ibc.css" />
     <link rel="stylesheet" href="css/custom.css" />
   </head>
   <body>

--- a/profile.html
+++ b/profile.html
@@ -15,6 +15,15 @@
     <meta name="description" content="Manage your PRISM account, view your PRISMs, and update your settings." />
     <style>.wa-cloak { visibility: hidden; }</style>
     <style>wa-page:not(:defined) { visibility: hidden; }</style>
+    <!-- CDN resilience. Both rules above hide the page until Web Awesome loads, and
+         nothing removes them if it never does, so a blocked or stalled kit leaves a
+         blank white document. Reveal at 5s regardless: unstyled but readable beats
+         invisible. WA removes the class itself on a normal load, well before this. -->
+    <style>
+      @keyframes prism-uncloak { to { visibility: visible; } }
+      .wa-cloak,
+      wa-page:not(:defined) { animation: prism-uncloak 0s linear 5s forwards; }
+    </style>
     <!-- iOS Home Screen icon (layout.js injects these as a fallback) -->
     <link rel="apple-touch-icon" href="./assets/apple-touch-icon.png" />
     <link rel="manifest" href="./assets/site.webmanifest" />

--- a/terms.html
+++ b/terms.html
@@ -15,6 +15,15 @@
     <meta name="description" content="Terms of Service for PRISM - MTG Deck Sleeve Marking Tool" />
     <style>.wa-cloak { visibility: hidden; }</style>
     <style>wa-page:not(:defined) { visibility: hidden; }</style>
+    <!-- CDN resilience. Both rules above hide the page until Web Awesome loads, and
+         nothing removes them if it never does, so a blocked or stalled kit leaves a
+         blank white document. Reveal at 5s regardless: unstyled but readable beats
+         invisible. WA removes the class itself on a normal load, well before this. -->
+    <style>
+      @keyframes prism-uncloak { to { visibility: visible; } }
+      .wa-cloak,
+      wa-page:not(:defined) { animation: prism-uncloak 0s linear 5s forwards; }
+    </style>
     <!-- iOS Home Screen icon (layout.js injects these as a fallback) -->
     <link rel="apple-touch-icon" href="./assets/apple-touch-icon.png" />
     <link rel="manifest" href="./assets/site.webmanifest" />

--- a/terms.html
+++ b/terms.html
@@ -26,15 +26,16 @@
     <link rel="preconnect" href="https://fonts.bunny.net" />
     <link rel="preconnect" href="https://fonts.bunny.net" crossorigin />
     <link rel="preconnect" href="https://cdn.jsdelivr.net" />
+    <link rel="preconnect" href="https://use.typekit.net" />
+    <link rel="preconnect" href="https://use.typekit.net" crossorigin />
     <!-- Web Awesome, fonts, and app CSS as static tags so the browser preload scanner
          starts them immediately; layout.js injectHeadResources skips tags already present -->
-         <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/themes/default.css">
-               <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/native.css" />
-          <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/utilities.css" />
-          <script type="module" src="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/webawesome.loader.js"></script>
-    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Inter:ital,wght@0,100..900;1,100..900&display=swap" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/themes/default.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/native.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/utilities.css" />
+    <script type="module" src="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/webawesome.loader.js"></script>
     <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Geist+Mono:wght@100..900&display=swap" />
-    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Crimson+Pro:ital,wght@0,200..900;1,200..900&display=swap" />
+    <link rel="stylesheet" href="https://use.typekit.net/gbw6ibc.css" />
     <link rel="stylesheet" href="css/custom.css" />
   </head>
   <body>

--- a/terms.html
+++ b/terms.html
@@ -132,7 +132,7 @@
         <section class="wa-stack wa-gap-m">
           <h2 class="wa-heading-m">11. Contact</h2>
           <p>For questions about these Terms, contact us at:</p>
-          <p><a href="mailto:prismmtg@gmail.com">legal@prismmtg.com</a></p>
+          <p><a href="mailto:prismmtg@gmail.com">prismmtg@gmail.com</a></p>
         </section>
       </main>
     </wa-page>

--- a/tests/processor.variant-position.test.js
+++ b/tests/processor.variant-position.test.js
@@ -32,7 +32,7 @@ test('getNextVariantPosition returns null when all 48 slots are occupied', () =>
 test('splitDeck throws when all 48 slots are occupied instead of assigning a bad position', () => {
 	const prism = fullPrism();
 	const deckId = prism.decks[0].id;
-	assert.throws(() => splitDeck(prism, deckId, 2), /No available stripe positions/);
+	assert.throws(() => splitDeck(prism, deckId, 2), /All 48 slots are occupied/);
 });
 
 // All 48 slots occupied, but one slot belongs to a stripe split group with a
@@ -76,6 +76,6 @@ test('addSplitToGroup throws and does not mutate prism when all 48 slots are occ
 	const prism = fullPrismWithGroup();
 	const groupId = prism.splitGroups[0].id;
 	const before = structuredClone(prism);
-	assert.throws(() => addSplitToGroup(prism, groupId), /No available stripe positions/);
+	assert.throws(() => addSplitToGroup(prism, groupId), /All 48 slots are occupied/);
 	assert.deepEqual(prism, before);
 });

--- a/tools.html
+++ b/tools.html
@@ -44,7 +44,7 @@
         <!-- Page Header -->
         <div class="wa-flank" style="--flank-size: 8rem;">
   <div class="wa-frame wa-border-radius-m">
-    <img src="assets/spiritguide.avif" alt="3dprinted-cardguide" />
+    <img src="assets/spiritguide.avif" alt="A white 3D-printed Spirit Guide jig, embossed with the PRISM wordmark, held in front of a fanned stack of Magic: The Gathering cards" />
   </div>
   <div class="wa-flank:end" style="--content-percentage: 45%">
     <div class="wa-stack wa-gap-xs">

--- a/tools.html
+++ b/tools.html
@@ -15,6 +15,29 @@
     <meta name="description" content="Recommended paint pens, sleeves, and the 3D printable Spirit Guide alignment tool for the PRISM sleeve marking system." />
     <style>.wa-cloak { visibility: hidden; }</style>
     <style>wa-page:not(:defined) { visibility: hidden; }</style>
+    <!-- CDN resilience. Both rules above hide the page until Web Awesome loads, and
+         nothing removes them if it never does, so a blocked or stalled kit leaves a
+         blank white document. Reveal at 5s regardless: unstyled but readable beats
+         invisible. WA removes the class itself on a normal load, well before this. -->
+    <style>
+      @keyframes prism-uncloak { to { visibility: visible; } }
+      .wa-cloak,
+      wa-page:not(:defined) { animation: prism-uncloak 0s linear 5s forwards; }
+    </style>
+    <script>
+      // <wa-button href> only navigates once WA upgrades the element, so every CTA on
+      // this page is dead until then. Delegated from document so it also covers the
+      // header button layout.js injects later. No-op once WA is defined.
+      document.addEventListener('click', function (event) {
+        if (window.customElements && customElements.get('wa-button')) return;
+        var btn = event.target.closest && event.target.closest('wa-button[href]');
+        if (!btn || btn.hasAttribute('disabled')) return;
+        var href = btn.getAttribute('href');
+        if (!href) return;
+        if (btn.getAttribute('target') === '_blank') window.open(href, '_blank', 'noopener');
+        else window.location.href = href;
+      });
+    </script>
     <!-- iOS Home Screen icon (layout.js injects these as a fallback) -->
     <link rel="apple-touch-icon" href="./assets/apple-touch-icon.png" />
     <link rel="manifest" href="./assets/site.webmanifest" />

--- a/tools.html
+++ b/tools.html
@@ -65,18 +65,16 @@
     <wa-page mobile-breakpoint="768">
       <main style="max-width: 900px; margin: 0 auto;">
         <!-- Page Header -->
-        <div class="wa-flank" style="--flank-size: 8rem;">
-  <div class="wa-frame wa-border-radius-m">
-    <img src="assets/spiritguide.avif" alt="A white 3D-printed Spirit Guide, embossed with the PRISM wordmark, held in front of a fanned stack of Magic: The Gathering cards" />
-  </div>
-  <div class="wa-flank:end" style="--content-percentage: 45%">
-    <div class="wa-stack wa-gap-xs">
-      <h1 class="wa-heading-2xl">Tools and Supplies</h1>
-
-    </div>
-
-  </div>
-</div>
+        <!-- wa-flank sizes its first child from --flank-size and gives the rest to
+             the content, so the heading needs no wrapper. The previous markup put
+             the ":end" modifier and --content-percentage on the child instead of the
+             container, where neither applies, and wrapped the h1 in an empty stack. -->
+        <div class="wa-flank wa-gap-l wa-align-items-center" style="--flank-size: 8rem;">
+          <div class="wa-frame wa-border-radius-m">
+            <img src="assets/spiritguide.avif" alt="A white 3D-printed Spirit Guide, embossed with the PRISM wordmark, held in front of a fanned stack of Magic: The Gathering cards" />
+          </div>
+          <h1 class="wa-heading-2xl">Tools and Supplies</h1>
+        </div>
 
 
 
@@ -96,7 +94,7 @@
           <div class="wa-grid wa-gap-m" style="--min-column-size: 280px;">
             <wa-card>
               <div class="wa-stack wa-gap-s">
-                <wa-tag variant="success">Recommended</wa-tag>
+                <wa-tag variant="success" style="align-self: start;">Recommended</wa-tag>
                 <h3 class="wa-heading-m">
                   <a href="https://amzn.to/4t5Ue1i" target="_blank" rel="noopener" style="color: inherit; text-decoration: none;">
                     Uni Posca Paint Pens
@@ -114,7 +112,7 @@
 
             <wa-card>
               <div class="wa-stack wa-gap-s">
-                <wa-tag variant="neutral">Alternative</wa-tag>
+                <wa-tag variant="neutral" style="align-self: start;">Alternative</wa-tag>
                 <h3 class="wa-heading-m">
                   <a href="https://amzn.to/3Q1aO3G" target="_blank" rel="noopener" style="color: inherit; text-decoration: none;">
                     Oil-Based Paint Pens
@@ -132,7 +130,7 @@
 
             <wa-card>
               <div class="wa-stack wa-gap-s">
-                <wa-tag variant="warning">Budget</wa-tag>
+                <wa-tag variant="warning" style="align-self: start;">Budget</wa-tag>
                 <h3 class="wa-heading-m">
                   <a href="https://amzn.to/41r7Ckq" target="_blank" rel="noopener" style="color: inherit; text-decoration: none;">
                     Acrylic Paint Pen Sets
@@ -150,7 +148,7 @@
 
             <wa-card>
               <div class="wa-stack wa-gap-s">
-                <wa-tag variant="brand">Precision</wa-tag>
+                <wa-tag variant="brand" style="align-self: start;">Precision</wa-tag>
                 <h3 class="wa-heading-m">
                   <a href="https://amzn.to/47SXzYU" target="_blank" rel="noopener" style="color: inherit; text-decoration: none;">
                     Pentel Matte Hop Gel Pens
@@ -172,8 +170,10 @@
             <strong>Whichever pen you pick, let the marks dry for 2 to 3 minutes before you sleeve the card.</strong> Touch-dry is not sleeve-ready. Wet paint transfers to the outer sleeve and to the card face. See <a href="guide.html#mark-a-session">Run a marking session</a>.
           </wa-callout>
 
-          <wa-callout variant="warning">
-            <wa-icon slot="icon" name="triangle-exclamation"></wa-icon>
+          <!-- Neutral, not warning: this is a preference, and stacking two amber
+               callouts flattened the dry-time warning above into the same tone. -->
+          <wa-callout variant="neutral">
+            <wa-icon slot="icon" name="circle-info"></wa-icon>
             <strong>Avoid brush-tip pens that are too flexible</strong> if possible. They make it hard to keep your lines consistent, even with the Spirit Guide.
           </wa-callout>
         </section>

--- a/tools.html
+++ b/tools.html
@@ -26,15 +26,16 @@
     <link rel="preconnect" href="https://fonts.bunny.net" />
     <link rel="preconnect" href="https://fonts.bunny.net" crossorigin />
     <link rel="preconnect" href="https://cdn.jsdelivr.net" />
+    <link rel="preconnect" href="https://use.typekit.net" />
+    <link rel="preconnect" href="https://use.typekit.net" crossorigin />
     <!-- Web Awesome, fonts, and app CSS as static tags so the browser preload scanner
          starts them immediately; layout.js injectHeadResources skips tags already present -->
-         <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/themes/default.css">
-               <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/native.css" />
-          <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/utilities.css" />
-          <script type="module" src="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/webawesome.loader.js"></script>
-    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Inter:ital,wght@0,100..900;1,100..900&display=swap" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/themes/default.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/native.css" />
+    <link rel="stylesheet" href="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/styles/utilities.css" />
+    <script type="module" src="https://ka-p.webawesome.com/kit/da021fed1e5141f2/webawesome@3.11.0/webawesome.loader.js"></script>
     <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Geist+Mono:wght@100..900&display=swap" />
-    <link rel="stylesheet" href="https://fonts.bunny.net/css2?family=Crimson+Pro:ital,wght@0,200..900;1,200..900&display=swap" />
+    <link rel="stylesheet" href="https://use.typekit.net/gbw6ibc.css" />
     <link rel="stylesheet" href="css/custom.css" />
   </head>
   <body>

--- a/tools.html
+++ b/tools.html
@@ -24,20 +24,6 @@
       .wa-cloak,
       wa-page:not(:defined) { animation: prism-uncloak 0s linear 5s forwards; }
     </style>
-    <script>
-      // <wa-button href> only navigates once WA upgrades the element, so every CTA on
-      // this page is dead until then. Delegated from document so it also covers the
-      // header button layout.js injects later. No-op once WA is defined.
-      document.addEventListener('click', function (event) {
-        if (window.customElements && customElements.get('wa-button')) return;
-        var btn = event.target.closest && event.target.closest('wa-button[href]');
-        if (!btn || btn.hasAttribute('disabled')) return;
-        var href = btn.getAttribute('href');
-        if (!href) return;
-        if (btn.getAttribute('target') === '_blank') window.open(href, '_blank', 'noopener');
-        else window.location.href = href;
-      });
-    </script>
     <!-- iOS Home Screen icon (layout.js injects these as a fallback) -->
     <link rel="apple-touch-icon" href="./assets/apple-touch-icon.png" />
     <link rel="manifest" href="./assets/site.webmanifest" />
@@ -75,8 +61,6 @@
           </div>
           <h1 class="wa-heading-2xl">Tools and Supplies</h1>
         </div>
-
-
 
         <!-- Paint Pens -->
         <section class="wa-stack wa-gap-l" style="padding-block: var(--wa-space-xl);">

--- a/tools.html
+++ b/tools.html
@@ -12,7 +12,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tools & Supplies - PRISM</title>
-    <meta name="description" content="Recommended paint pens, sleeves, and 3D printable marking jigs for the PRISM sleeve marking system." />
+    <meta name="description" content="Recommended paint pens, sleeves, and the 3D printable Spirit Guide alignment tool for the PRISM sleeve marking system." />
     <style>.wa-cloak { visibility: hidden; }</style>
     <style>wa-page:not(:defined) { visibility: hidden; }</style>
     <!-- iOS Home Screen icon (layout.js injects these as a fallback) -->
@@ -44,7 +44,7 @@
         <!-- Page Header -->
         <div class="wa-flank" style="--flank-size: 8rem;">
   <div class="wa-frame wa-border-radius-m">
-    <img src="assets/spiritguide.avif" alt="A white 3D-printed Spirit Guide jig, embossed with the PRISM wordmark, held in front of a fanned stack of Magic: The Gathering cards" />
+    <img src="assets/spiritguide.avif" alt="A white 3D-printed Spirit Guide, embossed with the PRISM wordmark, held in front of a fanned stack of Magic: The Gathering cards" />
   </div>
   <div class="wa-flank:end" style="--content-percentage: 45%">
     <div class="wa-stack wa-gap-xs">
@@ -83,7 +83,7 @@
                 <ul style="padding-left: var(--wa-space-m); font-size: var(--wa-font-size-s);">
                   <li>PC-1M (extra fine) recommended</li>
                   <li>Wide color range</li>
-                  <li>Dries in seconds</li>
+                  <li>Touch-dry in about a minute</li>
                   <li>Does not smear once dry</li>
                 </ul>
               </div>
@@ -145,6 +145,11 @@
           </div>
 
           <wa-callout variant="warning">
+            <wa-icon slot="icon" name="hourglass"></wa-icon>
+            <strong>Whichever pen you pick, let the marks dry for 2 to 3 minutes before you sleeve the card.</strong> Touch-dry is not sleeve-ready. Wet paint transfers to the outer sleeve and to the card face. See <a href="guide.html#mark-a-session">Run a marking session</a>.
+          </wa-callout>
+
+          <wa-callout variant="warning">
             <wa-icon slot="icon" name="triangle-exclamation"></wa-icon>
             <strong>Avoid brush-tip pens that are too flexible</strong> if possible. They make it hard to keep your lines consistent, even with the Spirit Guide.
           </wa-callout>
@@ -158,7 +163,7 @@
             <wa-icon name="layer-group" style="margin-right: var(--wa-space-s);"></wa-icon>
             Sleeve Recommendations
           </h2>
-          <p>Most Perfect Fit inner sleeves work well. We recommend:</p>
+          <p>Most Perfect Fit inners work well. We recommend:</p>
 
           <ul style="padding-left: var(--wa-space-xl); line-height: 2;">
             <li>
@@ -197,7 +202,7 @@
             <wa-icon name="handshake-angle" style="margin-right: var(--wa-space-s);"></wa-icon>
             PRISM Spirit Guide
           </h2>
-          <p>The Spirit Guide is a marking jig that holds your sleeve in place with guides for each slot. It makes marking faster, more consistent, and lets you work one-handed with its magnetic hold.</p>
+          <p>The Spirit Guide is an alignment tool that holds your sleeve in place with guides for each slot. It makes marking faster, more consistent, and lets you work one-handed with its magnetic hold.</p>
 
           <wa-card appearance="filled" style="background: var(--wa-color-surface-2);">
             <div class="wa-stack wa-gap-m">


### PR DESCRIPTION
## Summary

Started as an `/impeccable audit` of `index.html`, `tools.html`, and `guide.html`. It grew twice: first when the punch list surfaced a sitewide colour-token failure, then again when a second `/impeccable critique` of `build.html` found a data-loss path in the app itself. **The title undersells the scope — this now touches the app, not just the static pages.** Reviewers who only expect font and colour changes should read sections 3 and 4.

27 commits. Grouped by what they actually change:

---

### 1. Sitewide infrastructure

- **Broken colour token system (the big one).** The WA 3.10→3.11 upgrade renamed or dropped ~22 semantic colour tokens this codebase depends on (`neutral-text`, `neutral-text-subtle`, `brand-fill`, `surface-2`/`-3`, every state `-text`/`-surface`/`-surface-subtle`). Verified by diffing every `var(--wa-color-*)` reference against the actual CDN stylesheet: none existed in 3.11, so all of them silently resolved to nothing — inherited colour for text, transparent for backgrounds. `js/layout.js` now defines them itself, plus a `.wa-dark` remap. `neutral-text-subtle` corrected to ramp step 40 (was 50, which DESIGN.md's own contrast rule already prohibited for anything but large text). `--wa-color-text-quiet` likewise defined rather than borrowed.
- **Font-loading drift** (all 9 pages). 7 of 9 still shipped the pre-v2.1 Inter/Crimson Pro stack instead of the Typekit stylesheet `layout.js`'s tokens reference. Because the fallback loaded the correct fonts by exact href match, every affected page double-loaded, with the right fonts arriving late via JS instead of at byte 0. Added the missing `use.typekit.net` preconnect everywhere. `profile.html` also had a duplicate `webawesome.loader.js` pinned to 3.10.0 — removed.
- **CDN resilience** (all 9 pages). Every page sets `class="wa-cloak"` and hides `wa-page:not(:defined)`, and nothing in the codebase removes either — Web Awesome's loader does. A slow, blocked, or down `ka-p.webawesome.com` therefore left a permanently blank white document, `build.html` included. A zero-duration keyframe with a 5s delay now reveals the page regardless: unstyled but readable beats invisible. Kept inline per page on purpose, since it is the fallback that has to survive JS failing entirely.

### 2. Static pages (`index.html`, `guide.html`, `tools.html`)

- **`index.html` leads with the payoff, not the mechanism.** PRODUCT.md requires the money saved stay legible; the only dollar figure on the page was inside a collapsed FAQ behind a question that presupposed the visitor had already adopted the system, while eight feature cards spent ~250 words on mechanism. The hero now carries a real `<h1>` with the payoff — which also gives the page the `<h1>` it never had (the outline ran h2, h3×3, h2, h3×8, with the product name marked up as divs).
- **Serif/sans hierarchy restored.** Feature card titles were `<h3 class="wa-body-l">`; WA's `text.css` sets `[class*='wa-body']` to the body family, so titles rendered halyard-micro 400 — identical in family and weight to the paragraph beneath. DESIGN.md §3 calls a sans heading over serif body an inversion of the system's signature.
- **Guide calibration step.** The marking procedure ran test-pen → unsleeve → paint → paint the rest, with nothing between the first card and the next two hundred. Step 1 tested the pen; nothing tested the user's *reading* of the slot system, so a miscounted corner was discoverable only after it had been repeated across the whole Pool, on sleeves that cannot be un-painted. Added a verification beat: mark one card, confirm it against PRISM, then do the rest.
- **Copy defects.** `tools.html` claimed Posca pens "dry in seconds" while `guide.html` says wait 2–3 minutes before resleeving — a user trusting the first would resleeve wet and transfer paint to the card face. Also a ghost filter name, banned terms, and a mismatched contact email on `terms.html`.
- **Layout and a11y.** Features grid laid out 3+1 at 1440px, orphaning the fourth card; scroll affordance on the guide's step bar; accessible names on the icon-only nav toggle and footer links; real heading elements on the Features cards; real alt text on three images.

### 3. `build.html` — the app (new since the original description)

From a second `/impeccable critique`, scored 24/40. All P0 and P1 findings are closed.

- **P0: "New PRISM" stranded a logged-out user's entire PRISM.** `NAV_LINKS` has no PRISMs entry and `profile.html` lists them only inside its logged-in block, so creating a new PRISM left every deck and mark record unreachable — while the dialog said the old one "can be accessed later", which was false. The `⋯` overflow menu now lists every stored PRISM, "New PRISM" moved out of the header's primary-action slot into that same menu, and the dialog names the outgoing PRISM and states the real recovery route. **This is the change most worth reviewing carefully:** the data at stake is the index to paint already applied to physical sleeves.
- **Bulk stale-mark wipe was unconfirmed**, and its button rendered through five WA 2.x token names that no longer resolve in 3.11, so every declaration was being dropped. Now a `wa-button` behind a confirm dialog.
- **Accessibility spine.** No `<h1>` or `<h2>` anywhere — the outline started at an `<h3>` stat label. Both decklist textareas were `required` with no `label`, so WA rendered the asterisk into an empty label slot and the field had no accessible name (this is the bare `*` noted earlier in the repo). The slot picker was 48 bare `<div>`s with click listeners: keyboard-unreachable and screen-reader-silent, now a radiogroup with roving tabindex and arrow/Home/End/Enter support.
- **Usable at the table.** Deck identity in the Stripes column lived only in a `title`, which touch never fires — on the one surface DESIGN.md §8 commits to. The strip is now one focusable control carrying every mark in its accessible name, and activating it reveals the list as a full-width row. Mark checkbox given a 44px hit area keyed off `pointer: coarse`, and the stripe block no longer shrinks to 14px on narrow screens.
- **Marked rows were failing WCAG AA.** `opacity: 0.45` computed body text to ~2.6:1 in what becomes the majority state of the table, and dimmed the stripe swatches so the colour just painted was harder to compare against the pen. Now quiet and struck through at **5.80:1** light / **10.29:1** dark, with swatches and checkbox at full strength. Strikethrough also moved off the checkbox cell onto the card name, per DESIGN.md.
- **Vocabulary.** "Position" → "slot" in user-facing strings per `CONTEXT.md`; identifiers deliberately unchanged.

### 4. Documentation

- `DESIGN.md` + `.impeccable/design.json` document the corrected token contract.
- `CLAUDE.md` updated for the colour context; `CONTEXT.md` label correction.
- `TO-DO.md` added, carrying everything both critiques left open — 24 items for `build.html` (all P2 and below, plus four design questions) and the static-page remainder.
- `.impeccable/critique/` snapshots committed.

---

## Test plan

- [x] Detector (`detect.mjs`) after every change — no new findings. Two pre-existing advisories remain, both `font-size` on `<wa-icon>`, which is WA's glyph-sizing idiom, not typography.
- [x] Headless Chromium against a local server, light and dark, 390/768/1440. Confirmed: text hierarchy, sunken surfaces, callout surfaces, guide step-bar hint, and no horizontal overflow at any width.
- [x] `build.html` P0 walked end to end: create a new PRISM from a populated one, recover the original from the switcher, survive a reload with both PRISMs intact.
- [x] Stale-mark wipe: dialog open leaves rows intact, Cancel leaves them intact, Confirm clears and closes.
- [x] Slot picker driven by real dispatched key events — arrows across both edges, one tab stop maintained, Enter moved a deck from Slot 1 to Slot 25.
- [x] Contrast computed in-page against the real painted background (compositing alpha) on the warning-tinted Pool row, the worst case available.
- [x] Accessibility tree queried directly for the decklist textareas: name `"Decklist *"`, `required=true`.
- [x] `doctor.mjs` clean, no PRODUCT.md/DESIGN.md drift.
- [ ] **Manual pass in a real browser recommended before merge.** Everything above is headless Chromium plus CSS-spec reasoning. Worth exercising by hand: the PRISM switcher while logged in (sync interaction was not tested against a live Supabase session), and the slot picker on a real touch device.

## Known gaps

Deliberately not in scope, tracked in `TO-DO.md`: the `Position Numbers` preference is inert (renders numbers regardless of its value), Pool/Core ships in four casings, caption line-height is 1.2 against a documented 1.5, and nine WA deprecation warnings (`size="large"` → `"l"`) fire on every load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
